### PR TITLE
feat: extension UX polish and auto-create App+Process from CLI

### DIFF
--- a/backend/login/models.py
+++ b/backend/login/models.py
@@ -29,6 +29,8 @@ class LoginSession(Base):
     login_url: Mapped[str] = mapped_column(String(2000))
     status: Mapped[str] = mapped_column(String(20), default="idle")  # idle | recording | completed | failed
     notes: Mapped[str] = mapped_column(Text, default="")
+    project_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    process_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
     created_at: Mapped[datetime] = mapped_column(default=_utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=_utcnow, onupdate=_utcnow)
     started_at: Mapped[datetime | None] = mapped_column(nullable=True)

--- a/backend/login/router.py
+++ b/backend/login/router.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.database import get_db
+from backend.elicitation.models import Process, Project
 from backend.login.models import LoginDraft, LoginSession
 from backend.login.schemas import LoginSessionCreate, LoginSessionOut, LoginSessionUpdate
 from backend.shared.models import ClickEvent, HarFile, UrlEvent
@@ -23,6 +25,25 @@ router = APIRouter(tags=["login-sessions"])
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+async def _find_or_create_project(db: AsyncSession, app_name: str, url: str) -> str:
+    """Find an existing project by name or URL hostname, or create one."""
+    hostname = urlparse(url).hostname or ""
+    result = await db.execute(
+        select(Project).where(func.lower(Project.name) == app_name.lower())
+    )
+    project = result.scalar_one_or_none()
+    if not project and hostname:
+        result = await db.execute(
+            select(Project).where(Project.base_url.contains(hostname))
+        )
+        project = result.scalar_one_or_none()
+    if not project:
+        project = Project(name=app_name, base_url=url)
+        db.add(project)
+        await db.flush()
+    return project.id
+
 
 async def _get_session(session_id: str, db: AsyncSession) -> LoginSession:
     result = await db.execute(select(LoginSession).where(LoginSession.id == session_id))
@@ -41,16 +62,23 @@ async def create_login_session(
     data: LoginSessionCreate,
     db: AsyncSession = Depends(get_db),
 ) -> LoginSession:
-    """Create a new login-recording session."""
+    """Create a new login-recording session and ensure an App + Process exist."""
+    project_id = await _find_or_create_project(db, data.app_name, data.login_url)
+    process = Process(project_id=project_id, name="Login", base_url=data.login_url)
+    db.add(process)
+    await db.flush()
+
     session = LoginSession(
         app_name=data.app_name,
         login_url=data.login_url,
         notes=data.notes,
+        project_id=project_id,
+        process_id=process.id,
     )
     db.add(session)
     await db.commit()
     await db.refresh(session)
-    logger.info("Created login session %s for %s", session.id, session.app_name)
+    logger.info("Created login session %s for %s (project=%s)", session.id, session.app_name, project_id)
     return session
 
 

--- a/backend/login/schemas.py
+++ b/backend/login/schemas.py
@@ -26,6 +26,8 @@ class LoginSessionOut(BaseModel):
     login_url: str
     status: str
     notes: str
+    project_id: str | None
+    process_id: str | None
     created_at: datetime
     updated_at: datetime
     started_at: datetime | None

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,8 @@ from typing import AsyncGenerator
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from sqlalchemy import text
+
 from backend.config import settings
 from backend.database import Base, engine
 
@@ -67,6 +69,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     logger.info("Database tables ensured at: %s", settings.db_url)
+
+    # Migrate existing tables — add new columns (SQLite no-op if they already exist)
+    async with engine.begin() as conn:
+        for col_def in [
+            "ALTER TABLE login_sessions ADD COLUMN project_id VARCHAR(36)",
+            "ALTER TABLE login_sessions ADD COLUMN process_id VARCHAR(36)",
+            "ALTER TABLE workflow_sessions ADD COLUMN project_id VARCHAR(36)",
+            "ALTER TABLE workflow_sessions ADD COLUMN process_id VARCHAR(36)",
+        ]:
+            try:
+                await conn.execute(text(col_def))
+            except Exception:
+                pass  # column already exists
 
     yield
 

--- a/backend/workflow/models.py
+++ b/backend/workflow/models.py
@@ -29,6 +29,8 @@ class WorkflowSession(Base):
     start_url: Mapped[str] = mapped_column(String(2000), default="")
     description: Mapped[str] = mapped_column(Text, default="")
     status: Mapped[str] = mapped_column(String(20), default="idle")  # idle | recording | completed | failed
+    project_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    process_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
     created_at: Mapped[datetime] = mapped_column(default=_utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=_utcnow, onupdate=_utcnow)
     started_at: Mapped[datetime | None] = mapped_column(nullable=True)

--- a/backend/workflow/router.py
+++ b/backend/workflow/router.py
@@ -7,12 +7,14 @@ import logging
 import re
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.database import get_db
+from backend.elicitation.models import Process, Project
 from backend.shared.models import ClickEvent, HarFile, UrlEvent
 from backend.workflow.models import WorkflowSession
 from backend.workflow.schemas import WorkflowSessionCreate, WorkflowSessionOut, WorkflowSessionUpdate
@@ -28,6 +30,20 @@ _NOUI_ROOT = Path(__file__).resolve().parent.parent.parent
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+async def _find_or_create_project(db: AsyncSession, name: str, url: str) -> str:
+    """Find an existing project by URL hostname, or create one."""
+    hostname = urlparse(url).hostname or name
+    result = await db.execute(
+        select(Project).where(Project.base_url.contains(hostname))
+    )
+    project = result.scalar_one_or_none()
+    if not project:
+        project = Project(name=hostname, base_url=url)
+        db.add(project)
+        await db.flush()
+    return project.id
+
 
 async def _get_session(session_id: str, db: AsyncSession) -> WorkflowSession:
     result = await db.execute(select(WorkflowSession).where(WorkflowSession.id == session_id))
@@ -46,16 +62,23 @@ async def create_workflow_session(
     data: WorkflowSessionCreate,
     db: AsyncSession = Depends(get_db),
 ) -> WorkflowSession:
-    """Create a new workflow-recording session."""
+    """Create a new workflow-recording session and ensure an App + Process exist."""
+    project_id = await _find_or_create_project(db, data.name, data.start_url)
+    process = Process(project_id=project_id, name=data.name, base_url=data.start_url)
+    db.add(process)
+    await db.flush()
+
     session = WorkflowSession(
         name=data.name,
         start_url=data.start_url,
         description=data.description,
+        project_id=project_id,
+        process_id=process.id,
     )
     db.add(session)
     await db.commit()
     await db.refresh(session)
-    logger.info("Created workflow session %s: %s", session.id, session.name)
+    logger.info("Created workflow session %s: %s (project=%s)", session.id, session.name, project_id)
     return session
 
 

--- a/backend/workflow/schemas.py
+++ b/backend/workflow/schemas.py
@@ -26,6 +26,8 @@ class WorkflowSessionOut(BaseModel):
     start_url: str
     description: str
     status: str
+    project_id: str | None
+    process_id: str | None
     created_at: datetime
     updated_at: datetime
     started_at: datetime | None

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Adopt.ai Workflow Onboarding Agent",
+  "name": "NoUI Workflow Recorder",
   "version": "0.3.2",
   "description": "Record enriched browser sessions for API specification elicitation",
   "permissions": [

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1046,14 +1046,14 @@ function App() {
         <img src="../icons/icon48.png" alt="logo" />
         <h1>
           ${view === "projects"
-            ? "Projects"
+            ? "Apps"
             : view === "projectDetail"
-              ? `Project: ${currentProject?.name || "..."}`
+              ? `App: ${currentProject?.name || "..."}`
               : view === "test"
-                ? "Plumbing Tests"
-                : view === "options"
-                  ? "Options"
-                  : `Process: ${currentProcess?.name || "..."}`}
+                  ? "Plumbing Tests"
+                  : view === "options"
+                    ? "Options"
+                    : `Process: ${currentProcess?.name || "..."}`}
         </h1>
         ${(view === "projectDetail" || view === "processDetail") &&
         html`<${ScreenshotControls}
@@ -1254,7 +1254,7 @@ function ProjectListView({ projects, onOpen, onOpenTest, showNew, onToggleNew, o
   return html`
     <div class="content">
       <div class="flex-between" style="margin-bottom:12px">
-        <span class="section-title">Your Projects</span>
+        <span class="section-title">Your Apps</span>
         <div class="flex gap-sm">
           <button class="btn btn-secondary btn-sm" onClick=${onImportProject}>Import</button>
           <button class="btn btn-secondary btn-sm" onClick=${onOpenTest}>Test</button>
@@ -1283,7 +1283,7 @@ function ProjectListView({ projects, onOpen, onOpenTest, showNew, onToggleNew, o
       `}
 
       ${projects.length === 0
-        ? html`<div class="empty-state">No projects yet. Create one to get started.</div>`
+        ? html`<div class="empty-state">No apps yet. Create one to get started.</div>`
         : projects.map(
             (p) => editingId === p.id
               ? html`
@@ -1374,7 +1374,7 @@ function ProjectDetailView({
   onDeleteChatSession,
   onRenameChatSession,
 }) {
-  const [tab, setTab] = useState("chat");
+  const [tab, setTab] = useState("processes");
   const [procName, setProcName] = useState("");
   const [procDesc, setProcDesc] = useState("");
   const [procBaseUrl, setProcBaseUrl] = useState("");
@@ -1454,61 +1454,11 @@ function ProjectDetailView({
 
   return html`
     <div class="tabs">
-      <button class="tab ${tab === "chat" ? "active" : ""}" onClick=${() => setTab("chat")}>Chat</button>
       <button class="tab ${tab === "processes" ? "active" : ""}" onClick=${() => setTab("processes")}>Processes</button>
       <button class="tab ${tab === "captures" ? "active" : ""}" onClick=${() => setTab("captures")}>Captures</button>
       <button class="tab ${tab === "assets" ? "active" : ""}" onClick=${() => setTab("assets")}>Assets</button>
-      <button class="tab ${tab === "questions" ? "active" : ""}" onClick=${() => setTab("questions")}>Questions</button>
       <button class="tab ${tab === "timeline" ? "active" : ""}" onClick=${() => setTab("timeline")}>Timeline</button>
     </div>
-
-    ${tab === "chat" && html`
-      <div style="flex:1;display:flex;flex-direction:column;overflow:hidden">
-        ${editingProject ? html`
-          <div style="padding:8px 16px;background:#fffbeb;border-bottom:1px solid #fde68a">
-            <div class="form-group">
-              <label>Name</label>
-              <input class="input" value=${editProjName} onInput=${(e) => setEditProjName(e.target.value)} />
-            </div>
-            <div class="form-group">
-              <label>Description</label>
-              <input class="input" value=${editProjDesc} onInput=${(e) => setEditProjDesc(e.target.value)} />
-            </div>
-            <div class="form-group">
-              <label>Base URL</label>
-              <input class="input" value=${editProjBaseUrl} onInput=${(e) => setEditProjBaseUrl(e.target.value)} />
-            </div>
-            <div class="flex gap-sm">
-              <button class="btn btn-primary btn-sm" onClick=${saveEditProject}>Save</button>
-              <button class="btn btn-secondary btn-sm" onClick=${() => setEditingProject(false)}>Cancel</button>
-            </div>
-          </div>
-        ` : html`
-          <div class="flex-between" style="padding:4px 16px;background:#eff6ff;border-bottom:1px solid #e5e7eb">
-            <span class="text-muted" style="font-size:11px">${project?.base_url || "No base URL"}</span>
-            <div class="flex gap-sm">
-              <button class="btn btn-secondary btn-sm" style="padding:2px 8px;font-size:11px" onClick=${startEditProject}>Edit</button>
-              <button class="btn btn-secondary btn-sm" style="padding:2px 8px;font-size:11px" onClick=${() => onExportProject(project.id)}>Export</button>
-            </div>
-          </div>
-        `}
-        <${ChatSessionBar}
-          sessions=${chatSessions}
-          activeSession=${activeChatSession}
-          onNew=${onNewChatSession}
-          onSwitch=${onSwitchChatSession}
-          onDelete=${onDeleteChatSession}
-          onRename=${onRenameChatSession}
-        />
-        <div class="content" style="flex:1;overflow-y:auto">
-          <${MessageList} messages=${messages} streamingContent=${streamingContent} />
-        </div>
-        <${MessageInput}
-          onSend=${onSendMessage}
-          disabled=${isStreaming}
-        />
-      </div>
-    `}
 
     ${tab === "processes" && html`
       <div class="content">
@@ -1608,15 +1558,6 @@ function ProjectDetailView({
       </div>
     `}
 
-    ${tab === "questions" && html`
-      <${QuestionsPanel}
-        questions=${questions}
-        onAdd=${onAddQuestion}
-        onUpdate=${onUpdateQuestion}
-        onDelete=${onDeleteQuestion}
-      />
-    `}
-
     ${tab === "timeline" && html`
       <${Timeline} events=${timelineEvents} onDownload=${onDownloadTimeline} onClear=${onClearTimeline} />
     `}
@@ -1666,7 +1607,7 @@ function ProcessDetailView({
   onDeleteChatSession,
   onRenameChatSession,
 }) {
-  const [tab, setTab] = useState("chat");
+  const [tab, setTab] = useState("captures");
   const [editingProcess, setEditingProcess] = useState(false);
   const [editName, setEditName] = useState("");
   const [editDesc, setEditDesc] = useState("");
@@ -1743,29 +1684,10 @@ function ProcessDetailView({
         </div>
       `}
       <div class="tabs">
-        <button class="tab ${tab === "chat" ? "active" : ""}" onClick=${() => setTab("chat")}>Chat</button>
         <button class="tab ${tab === "captures" ? "active" : ""}" onClick=${() => setTab("captures")}>Captures</button>
         <button class="tab ${tab === "assets" ? "active" : ""}" onClick=${() => setTab("assets")}>Assets</button>
-        <button class="tab ${tab === "questions" ? "active" : ""}" onClick=${() => setTab("questions")}>Questions</button>
         <button class="tab ${tab === "timeline" ? "active" : ""}" onClick=${() => setTab("timeline")}>Timeline</button>
       </div>
-      ${tab === "chat" && html`
-        <${ChatSessionBar}
-          sessions=${chatSessions}
-          activeSession=${activeChatSession}
-          onNew=${onNewChatSession}
-          onSwitch=${onSwitchChatSession}
-          onDelete=${onDeleteChatSession}
-          onRename=${onRenameChatSession}
-        />
-        <div class="content" style="flex:1;overflow-y:auto">
-          <${MessageList} messages=${messages} streamingContent=${streamingContent} />
-        </div>
-        <${MessageInput}
-          onSend=${onSendMessage}
-          disabled=${isStreaming}
-        />
-      `}
       ${tab === "captures" && html`
         <${CaptureSessionsList} sessions=${captureSessions} onDownloadHar=${onDownloadHar} onDelete=${onDeleteCaptureSession} />
       `}
@@ -1790,14 +1712,6 @@ function ProcessDetailView({
             onImageClick=${onImageClick}
           />
         </div>
-      `}
-      ${tab === "questions" && html`
-        <${QuestionsPanel}
-          questions=${questions}
-          onAdd=${onAddQuestion}
-          onUpdate=${onUpdateQuestion}
-          onDelete=${onDeleteQuestion}
-        />
       `}
       ${tab === "timeline" && html`
         <${Timeline} events=${timelineEvents} onDownload=${onDownloadTimeline} onClear=${onClearTimeline} />

--- a/skills/noui-record-login/SKILL.md
+++ b/skills/noui-record-login/SKILL.md
@@ -16,7 +16,6 @@ All commands run from the `noui/` directory using `.venv/bin/python cli/main.py`
 ## Critical Rules (Never Violate)
 
 - **ALWAYS** start the backend before asking the user to record
-- **ALWAYS** use **Login Recording Mode** in the extension — not the standard Workflow Recording button
 - **ALWAYS** run `login review` after export and before register — never skip it even for clean-looking recordings
 - **NEVER** run `login register` if the review output shows `Generator valid: No` or any generator errors
 - **NEVER** use the `tabby_profile_id` in a workflow export until `login validate` succeeds with a HEALTHY state
@@ -64,40 +63,17 @@ The CLI creates a session and prints the `session_id`. Note it — you need it f
 
 ## Step 3 — Record in Chrome
 
-> **Extension UX note:** The dedicated "Login Recording Mode" button is not currently wired into the extension popup. The popup exposes a project/process/capture UI (`Create Project → Start Capture → Stop`), but `startLoginRecording` in `api.js` is not called from `popup.js`. To activate the login recorder you must send messages directly to the extension service worker.
+The CLI automatically created an App and a **Login** process in the extension (Step 2). Use the standard capture flow:
 
-**Trigger login recording via the service worker console:**
+1. Click the **NoUI Workflow Recorder** extension icon in the Chrome toolbar
+2. You will see the App (e.g., "HubSpot") in the Apps list — click it
+3. Click the **Login** process inside the app
+4. Navigate to the login URL in the active Chrome tab if not already there
+5. Click **Start Capture** to begin recording
+6. Perform the complete login flow: enter credentials, submit, and wait for the authenticated page to fully settle
+7. Click **Stop** when done
 
-1. Open `chrome://extensions/`, find **NoUI Workflow Recorder**, and click the **service worker** link to open its DevTools console.
-2. Send the following messages (replace `<session_id>` with the value from Step 2):
-
-```js
-chrome.runtime.sendMessage({
-  type: "SET_LOGIN_RECORDING_STATE",
-  captureSessionId: "<session_id>",
-  projectId: null,
-  processId: null
-}, r => console.log("state set", r));
-
-chrome.runtime.sendMessage({ type: "INJECT_LOGIN_RECORDER" }, r => console.log("recorder injected", r));
-```
-
-3. Navigate to the login URL in the active Chrome tab.
-4. Perform the complete login flow: enter credentials, submit, and wait for the authenticated page to fully settle.
-5. Stop recording and mark the session complete:
-
-```js
-chrome.runtime.sendMessage({ type: "REMOVE_LOGIN_RECORDER" }, r => console.log("recorder removed", r));
-chrome.runtime.sendMessage({ type: "CLEAR_LOGIN_RECORDING_STATE" }, r => console.log("state cleared", r));
-```
-
-Then mark the session complete on the backend:
-
-```bash
-curl -s -X POST http://localhost:8002/login-sessions/<session_id>/complete | python -m json.tool
-```
-
-> If the session capture appears empty on export, check the service worker console for `LOGIN_CLICK_EVENT` / `LOGIN_INPUT_EVENT` messages during the recording — their absence means the recorder was not injected correctly. Retry from sub-step 2.
+> If the App or Login process is not visible, confirm the backend is running (`status`) and that Step 2 succeeded.
 
 ---
 
@@ -233,8 +209,8 @@ Start
   │
   Step 2: login record "<App>" "<url>" → note session_id
   │
-  Step 3: Chrome (inject login recorder via service worker console)
-    └─ no LOGIN_CLICK_EVENTs? → recorder not injected, retry Step 3
+  Step 3: Chrome (Apps → <AppName> → Login → Start Capture → login → Stop)
+    └─ no events on export? → ensure target tab was active, retry Step 3
   │
   Step 4: login export <session_id>
     └─ writes noui-<id8>-bundle.json
@@ -281,7 +257,7 @@ Start
 | Backend not running | `.venv/bin/python cli/main.py start` |
 | `Tabby API not reachable` | Confirm Tabby is running; check `TABBY_API_HOST` in `.env` |
 | Bundle has generator errors | Re-record with slower, explicit interactions; avoid rapid clicks |
-| Used Workflow Recording instead of Login Recording Mode | Discard session; start new `login record` from Step 2 |
+| App or Login process missing in extension | Confirm Step 2 ran successfully; check backend is running |
 | Low selector confidence in review | Re-record; interact with fields one at a time with visible focus |
 | Validate timeout (60s) | Check Tabby logs; verify the keepalive URL returns HTTP 200 when authenticated |
 | Keepalive URL is redirect-only | Find a URL that loads authenticated content, not a redirect chain |


### PR DESCRIPTION
## Summary

- **Extension renamed** to "NoUI Workflow Recorder" in `manifest.json`
- **Projects → Apps** rename throughout the popup UI (labels, empty state, header titles)
- **Removed Chat and Questions tabs** from App and Process views; default tabs updated (Processes / Captures)
- **Auto-create App + Process** when CLI runs `login record` or `workflow record` — entities appear immediately in the extension without manual setup
- **Updated `noui-record-login` skill** Step 3 to direct users through the standard App→Process→Start Capture flow

## Backend detail

`POST /login-sessions` and `POST /workflow-sessions` now find-or-create a `Project` (App) and `Process` before creating the session:

- **Login**: matches existing project by `app_name` (case-insensitive), falls back to URL hostname match, then creates if not found. Process is always named "Login".
- **Workflow**: matches existing project by URL hostname in `base_url`, creates if not found. Process is named after the workflow.

`LoginSession` and `WorkflowSession` models now carry `project_id` and `process_id`. `backend/main.py` runs `ALTER TABLE … ADD COLUMN` migrations on startup (no-op if columns already exist).

## Test plan

- [x] Restart backend: `cli/main.py start`
- [x] Run `cli/main.py login record "TestApp" "https://example.com/"` → response includes `project_id` and `process_id`
- [x] Open extension → "TestApp" app appears with a "Login" process
- [x] Run again with same app name → same project reused, new process created
- [x] Run `cli/main.py workflow record "Extract Data" "https://example.com/"` → reuses "TestApp" project (URL match), adds "Extract Data" process
- [x] Extension shows no Chat or Questions tabs; Apps list shows "Your Apps" header
- [x] Extension name in `chrome://extensions/` shows "NoUI Workflow Recorder"

🤖 Generated with [Claude Code](https://claude.com/claude-code)