### PR TITLE
fix: MCP and Tabby session reliability improvements

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -158,6 +158,7 @@ def _pid_running(pid: int) -> bool:
 
 def _cdp_is_reachable(host: str = "localhost", port: int = 9222, timeout: float = 2.0) -> bool:
     import socket
+
     try:
         with socket.create_connection((host, port), timeout=timeout):
             return True
@@ -168,8 +169,20 @@ def _cdp_is_reachable(host: str = "localhost", port: int = 9222, timeout: float 
 def _mark_session_terminated(session_id: str) -> None:
     sql = f"UPDATE sessions SET state='TERMINATED' WHERE id='{session_id}'"
     subprocess.run(
-        ["docker", "compose", "exec", "-T", "postgres", "psql",
-         "-U", "browser_hitl", "-d", "browser_hitl", "-c", sql],
+        [
+            "docker",
+            "compose",
+            "exec",
+            "-T",
+            "postgres",
+            "psql",
+            "-U",
+            "browser_hitl",
+            "-d",
+            "browser_hitl",
+            "-c",
+            sql,
+        ],
         cwd=str(TABBY_DIR),
         capture_output=True,
     )
@@ -1087,7 +1100,11 @@ def cmd_workflow_export_mcp(args: argparse.Namespace) -> int:
         if not slug:
             print()
             print(_yellow("  ⚠  This server requires auth but no profile was linked."))
-            print(_yellow(f"     Re-export with: noui workflow export-mcp {session_id} --profile-slug <slug>"))
+            print(
+                _yellow(
+                    f"     Re-export with: noui workflow export-mcp {session_id} --profile-slug <slug>"
+                )
+            )
             print(_yellow("     Available profiles: noui tabby session status"))
     else:
         print("  Auth       : none (public API)")
@@ -1968,10 +1985,14 @@ def cmd_mcp_status(args: argparse.Namespace) -> int:
 
     # Check CDP accessibility for servers that use the browser-via-CDP pattern
     ops_dir = manifest_path.parent / "operations"
-    uses_cdp = any(
-        "CDP_LIST_URL" in op_file.read_text(encoding="utf-8", errors="ignore")
-        for op_file in ops_dir.glob("*.py")
-    ) if ops_dir.exists() else False
+    uses_cdp = (
+        any(
+            "CDP_LIST_URL" in op_file.read_text(encoding="utf-8", errors="ignore")
+            for op_file in ops_dir.glob("*.py")
+        )
+        if ops_dir.exists()
+        else False
+    )
     if uses_cdp:
         if _cdp_is_reachable():
             print(f"  CDP       : {_green('reachable (localhost:9222)')}")
@@ -3348,7 +3369,7 @@ def cmd_session_ensure(args: argparse.Namespace) -> int:
         # Worker has died but DB still shows HEALTHY — clear the stale state
         _mark_session_terminated(healthy[0]["id"])
         _clear_pid(TABBY_WORKER_PID_FILE)
-        print(_yellow(f"  Stale HEALTHY session detected (worker not running) — restarting …"))
+        print(_yellow("  Stale HEALTHY session detected (worker not running) — restarting …"))
 
     print(f"No HEALTHY session for '{_cyan(profile_id)}' — starting one …")
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -156,6 +156,25 @@ def _pid_running(pid: int) -> bool:
         return False
 
 
+def _cdp_is_reachable(host: str = "localhost", port: int = 9222, timeout: float = 2.0) -> bool:
+    import socket
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _mark_session_terminated(session_id: str) -> None:
+    sql = f"UPDATE sessions SET state='TERMINATED' WHERE id='{session_id}'"
+    subprocess.run(
+        ["docker", "compose", "exec", "-T", "postgres", "psql",
+         "-U", "browser_hitl", "-d", "browser_hitl", "-c", sql],
+        cwd=str(TABBY_DIR),
+        capture_output=True,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Backend HTTP helpers
 # ---------------------------------------------------------------------------
@@ -1063,8 +1082,13 @@ def cmd_workflow_export_mcp(args: argparse.Namespace) -> int:
     auth_info = result.get("auth", {})
     if auth_info.get("requires_auth"):
         strategy = auth_info.get("strategy") or "tabby_credentials"
-        slug = auth_info.get("profile_slug") or auth_info.get("tabby_profile_id") or "?"
-        print(f"  Auth       : {strategy} (profile: {slug})")
+        slug = auth_info.get("profile_slug") or auth_info.get("tabby_profile_id") or ""
+        print(f"  Auth       : {strategy} (profile: {slug or '?'})")
+        if not slug:
+            print()
+            print(_yellow("  ⚠  This server requires auth but no profile was linked."))
+            print(_yellow(f"     Re-export with: noui workflow export-mcp {session_id} --profile-slug <slug>"))
+            print(_yellow("     Available profiles: noui tabby session status"))
     else:
         print("  Auth       : none (public API)")
     print()
@@ -1095,6 +1119,7 @@ def _run_mcp_verify(server_id: str) -> int:
         return 0
 
     try:
+        sys.path.insert(0, str(NOUI_DIR))
         from compiler.mcp.auth_verifier import verify_before_install
     except ImportError as exc:
         print(_red(f"  Cannot import auth_verifier: {exc}"))
@@ -1940,6 +1965,20 @@ def cmd_mcp_status(args: argparse.Namespace) -> int:
         print(f"  Status    : {_green(f'running (PID {pid})')}")
     else:
         print(f"  Status    : {_red('stopped')}")
+
+    # Check CDP accessibility for servers that use the browser-via-CDP pattern
+    ops_dir = manifest_path.parent / "operations"
+    uses_cdp = any(
+        "CDP_LIST_URL" in op_file.read_text(encoding="utf-8", errors="ignore")
+        for op_file in ops_dir.glob("*.py")
+    ) if ops_dir.exists() else False
+    if uses_cdp:
+        if _cdp_is_reachable():
+            print(f"  CDP       : {_green('reachable (localhost:9222)')}")
+        else:
+            print(f"  CDP       : {_red('not reachable (localhost:9222)')}")
+            print(_yellow("             Run: noui tabby session ensure"))
+
     return 0
 
 
@@ -2397,6 +2436,7 @@ def cmd_mcp_diagnose_auth(args: argparse.Namespace) -> int:
     # Run verification
     print(_bold("Running verification …"))
     try:
+        sys.path.insert(0, str(NOUI_DIR))
         from compiler.mcp.auth_verifier import verify_before_install
 
         result = asyncio.run(verify_before_install(server_dir))
@@ -3301,8 +3341,14 @@ def cmd_session_ensure(args: argparse.Namespace) -> int:
     sessions = _get_sessions(admin_token)
     healthy = [s for s in sessions if s.get("app_id") == app_id and s.get("state") == "HEALTHY"]
     if healthy:
-        print(_green(f"✓ Session for '{profile_id}' is already HEALTHY"))
-        return 0
+        pid = _read_pid(TABBY_WORKER_PID_FILE)
+        if pid and _pid_running(pid) and _cdp_is_reachable():
+            print(_green(f"✓ Session for '{profile_id}' is already HEALTHY"))
+            return 0
+        # Worker has died but DB still shows HEALTHY — clear the stale state
+        _mark_session_terminated(healthy[0]["id"])
+        _clear_pid(TABBY_WORKER_PID_FILE)
+        print(_yellow(f"  Stale HEALTHY session detected (worker not running) — restarting …"))
 
     print(f"No HEALTHY session for '{_cyan(profile_id)}' — starting one …")
 

--- a/compiler/mcp/server_generator.py
+++ b/compiler/mcp/server_generator.py
@@ -160,6 +160,12 @@ def compile_workflow(
 
     # ── 8. Write auth_plan.json (when auth is required) ───────────────────────
     if auth_plan:
+        # Ensure profile_slug in auth_plan always matches the manifest value so
+        # the two files stay in sync regardless of how generate_auth_plan resolves it.
+        if effective_slug:
+            auth_plan["profile_slug"] = effective_slug
+            if "tabby_export" in auth_plan:
+                auth_plan["tabby_export"]["runtime_identifier"] = effective_slug
         (out_path / "auth_plan.json").write_text(
             json.dumps(auth_plan, indent=2, ensure_ascii=False), encoding="utf-8"
         )

--- a/skills/noui-mcp/SKILL.md
+++ b/skills/noui-mcp/SKILL.md
@@ -68,6 +68,13 @@ mcp_servers/<app_slug>/<server_id>/.mcp-<server_id>.log
 .venv/bin/python cli/main.py mcp status <server_id>
 ```
 
+For servers that use CDP (Akamai-protected sites like Expedia), status also shows browser session health:
+
+```
+  CDP       : ✓ reachable (localhost:9222)   ← worker is running
+  CDP       : ✗ not reachable (localhost:9222) ← run: noui tabby session ensure
+```
+
 ---
 
 ## Step 4 — Stop a Server
@@ -149,7 +156,7 @@ Start
 | `.venv/bin/python cli/main.py mcp list` | List all generated servers with running status |
 | `.venv/bin/python cli/main.py mcp start <server_id>` | Start a server process in the background |
 | `.venv/bin/python cli/main.py mcp stop <server_id>` | Stop a running server process |
-| `.venv/bin/python cli/main.py mcp status <server_id>` | Show running state, tool count, and manifest path |
+| `.venv/bin/python cli/main.py mcp status <server_id>` | Show running state, tool count, manifest path, and CDP reachability (for browser-based servers) |
 | `.venv/bin/python cli/main.py mcp docs <server_id>` | Regenerate `API.md` from current `tools.json` |
 | `.venv/bin/python cli/main.py mcp docs <server_id> --check` | Exit non-zero if `API.md` is stale (for CI / agent validation) |
 | `.venv/bin/python cli/main.py mcp verify <server_id>` | Run AuthVerifier — reports PASS / REPAIR_APPLIED / NEEDS_SECRET / UNSUPPORTED |
@@ -170,3 +177,6 @@ Start
 | Auth errors at runtime (authenticated server) | Run `mcp diagnose-auth <server_id>` — shows missing env vars and repair steps |
 | `NEEDS_SECRET <VAR>` from verify | Set `<VAR>=<value>` in `noui/.env` and re-run `mcp verify <server_id>` |
 | Server is v1 (no `auth_plan.json`) | Re-export with `workflow export-mcp ... --profile-slug <slug> --verify` to upgrade to v2 |
+| Tool fails with "All connection attempts failed" | CDP-based server needs browser session — run `mcp status <server_id>` to check CDP, then `noui tabby session ensure` |
+| Tabby session shows HEALTHY but tools still fail | Worker crashed but DB state is stale — run `noui tabby session ensure` (auto-detects and restarts dead workers) |
+| Exported server has `profile_slug: null` | No `--profile-slug` was passed at export time — re-export: `workflow export-mcp <session_id> --profile-slug <slug>` |


### PR DESCRIPTION
## Summary

- **`mcp verify` / `diagnose-auth` broken** — fixed `ImportError: No module named 'compiler'` by adding `sys.path.insert(0, NOUI_DIR)` before both imports (mirrors the working pattern used by `mcp docs`)
- **Stale HEALTHY session** — `tabby session ensure` now checks worker PID liveness + CDP port (9222) before trusting DB state; auto-marks stale sessions as TERMINATED and restarts the worker
- **Silent missing profile on export** — `workflow export-mcp` now prints a loud warning with the re-export command when an authenticated server is exported without `--profile-slug`
- **Profile slug mismatch** — `compiler/mcp/server_generator.py` now normalizes `auth_plan.json` `profile_slug` to always match the manifest's `effective_slug` at export time
- **CDP health invisible** — `mcp status` now probes `localhost:9222` and shows a `CDP: reachable / not reachable` line for servers that use browser-via-CDP

## Files changed

| File | What changed |
|---|---|
| `cli/main.py` | sys.path fix (×2), stale session gate + helpers, export warning, CDP status line |
| `compiler/mcp/server_generator.py` | Normalize auth_plan profile_slug to match manifest |
| `skills/noui-mcp/SKILL.md` | Updated mcp status description + 3 new troubleshooting rows |

## Test plan

- [x] `noui mcp verify <server_id>` — no longer errors with `No module named 'compiler'`
- [x] `noui mcp diagnose-auth <server_id>` — prints full auth breakdown
- [x] Kill worker, run `noui tabby session ensure` — detects stale HEALTHY, prints warning, restarts worker
- [x] Export authenticated workflow without `--profile-slug` — warning printed with re-export command
- [x] Export with `--profile-slug <slug>` — `manifest.json` and `auth_plan.json` have matching `profile_slug`
- [x] `noui mcp status <server_id>` on a CDP server — shows `CDP: reachable` or `not reachable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)