### PR TITLE
fix(compiler): reject empty or non-API HARs with clear validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/noui-record-workflow` skill now documents the CDP default under *How
   Execution Works*; `/noui-generalize` reframed around hand-edit cases on top
   of the default (SPA DOM scraping, HITL login).
+- Compiler now rejects empty, malformed, or no-API HARs early with
+  `HarValidationError` instead of silently generating MCP servers or Skills
+  with zero tools. The workflow export endpoint (`POST /workflow/.../export`)
+  returns `422 Unprocessable Entity` with the validation message for these
+  cases and reserves `500` for unexpected bugs. No output artifacts
+  (`server.py`, `tools.json`, `SKILL.md`, `manifest.json`) are written on
+  failure.
 
 ### Added
 

--- a/backend/workflow/router.py
+++ b/backend/workflow/router.py
@@ -328,6 +328,8 @@ async def export_workflow(
 
     result: dict = {}
 
+    from compiler.mcp.har_to_tools import HarValidationError
+
     if target in ("mcp", "both"):
         server_id = f"{app_slug}-{session_id[:8]}"
         mcp_output_dir = str(_NOUI_ROOT / "workbench" / "mcp_servers" / app_slug / server_id)
@@ -347,6 +349,9 @@ async def export_workflow(
                 profile_db_id=profile_db_id,
                 execution_mode=execution_mode,
             )
+        except HarValidationError as exc:
+            logger.warning("MCP compilation rejected for session %s: %s", session_id, exc)
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
         except Exception as exc:
             logger.exception("MCP compilation failed for session %s", session_id)
             raise HTTPException(status_code=500, detail=f"MCP compilation failed: {exc}") from exc
@@ -373,6 +378,9 @@ async def export_workflow(
                 execution_mode=execution_mode,
                 start_url=session.start_url or "",
             )
+        except HarValidationError as exc:
+            logger.warning("Skill compilation rejected for session %s: %s", session_id, exc)
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
         except Exception as exc:
             logger.exception("Skill compilation failed for session %s", session_id)
             raise HTTPException(status_code=500, detail=f"Skill compilation failed: {exc}") from exc

--- a/compiler/mcp/har_to_tools.py
+++ b/compiler/mcp/har_to_tools.py
@@ -27,6 +27,21 @@ import re
 from urllib.parse import parse_qs, urlparse
 
 # ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class HarValidationError(ValueError):
+    """Raised when a HAR cannot be turned into any usable tool definitions.
+
+    This is a *user-correctable* error: the capture itself was empty, malformed,
+    or contained only static assets / non-API traffic. Callers (the MCP and
+    Skill compilers, and the workflow export endpoint) should surface the
+    message back to the user rather than emitting an empty server.
+    """
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -45,12 +60,43 @@ def har_to_tool_defs(
         workflow_name: Human-readable workflow name used in auto-descriptions.
         tabby_profile_id: Non-empty when the workflow is authenticated.
         auth_cookie_names: Additional cookie names to treat as auth tokens.
-    """
-    entries: list[dict] = har.get("log", {}).get("entries", [])
-    if not entries:
-        return []
 
-    api_entries = [e for e in entries if _is_api_call(e)]
+    Raises:
+        HarValidationError: If the HAR is malformed, has no entries, or yields
+            no API-like requests after filtering. The message is safe to show
+            to end users.
+    """
+    if not isinstance(har, dict):
+        raise HarValidationError(
+            "HAR must be a JSON object with a top-level 'log' key, "
+            f"got {type(har).__name__}."
+        )
+
+    log = har.get("log")
+    if not isinstance(log, dict) or "entries" not in log:
+        raise HarValidationError(
+            "HAR is missing the 'log.entries' array. The capture file does not "
+            "look like a valid HAR 1.2 document — re-record the workflow and "
+            "ensure the browser exported network traffic."
+        )
+
+    entries = log.get("entries")
+    if not isinstance(entries, list) or not entries:
+        raise HarValidationError(
+            "HAR contains no entries. The browser did not record any network "
+            "traffic for this workflow — re-record while interacting with the "
+            "site so requests are captured."
+        )
+
+    api_entries = [e for e in entries if isinstance(e, dict) and _is_api_call(e)]
+
+    if not api_entries:
+        raise HarValidationError(
+            f"HAR has {len(entries)} entries but none look like API calls "
+            "after filtering static assets, redirects, and analytics. "
+            "Re-record the workflow and trigger the action whose API you want "
+            "to expose (e.g. submit a form, load data, click a button)."
+        )
 
     # Deduplicate: keep the first representative per (method, base_url, path_pattern).
     seen: dict[tuple[str, str, str], dict] = {}

--- a/compiler/mcp/har_to_tools.py
+++ b/compiler/mcp/har_to_tools.py
@@ -68,8 +68,7 @@ def har_to_tool_defs(
     """
     if not isinstance(har, dict):
         raise HarValidationError(
-            "HAR must be a JSON object with a top-level 'log' key, "
-            f"got {type(har).__name__}."
+            f"HAR must be a JSON object with a top-level 'log' key, got {type(har).__name__}."
         )
 
     log = har.get("log")

--- a/tests/test_compile_workflow.py
+++ b/tests/test_compile_workflow.py
@@ -22,10 +22,13 @@ import sys
 import tempfile
 from pathlib import Path
 
+import pytest
+
 _NOUI_ROOT = Path(__file__).resolve().parent.parent
 if str(_NOUI_ROOT) not in sys.path:
     sys.path.insert(0, str(_NOUI_ROOT))
 
+from compiler.mcp.har_to_tools import HarValidationError
 from compiler.mcp.server_generator import compile_workflow
 
 # ---------------------------------------------------------------------------
@@ -607,3 +610,56 @@ class TestExecutionModeValidation:
         har = _har([_entry("https://api.example.com/x")])
         with pytest.raises(ValueError, match="execution_mode"):
             _compile(har, app_slug="bad", execution_mode="grpc")
+
+
+# ---------------------------------------------------------------------------
+# Scenario 13: Empty / non-API HARs must not produce a zero-tool server
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyHarRejected:
+    """Empty or non-API HARs must raise HarValidationError instead of writing
+    a successful-looking but useless MCP server tree."""
+
+    def test_empty_entries_raises(self) -> None:
+        with pytest.raises(HarValidationError, match="no entries"):
+            _compile(_har([]), app_slug="empty-app")
+
+    def test_only_static_assets_raises(self) -> None:
+        har = _har(
+            [
+                _entry("https://cdn.example.com/bundle.js", status=200),
+                _entry("https://cdn.example.com/style.css", status=200),
+            ]
+        )
+        with pytest.raises(HarValidationError, match="none look like API calls"):
+            _compile(har, app_slug="static-only")
+
+    def test_missing_log_raises(self) -> None:
+        with pytest.raises(HarValidationError, match="log.entries"):
+            _compile({}, app_slug="malformed")
+
+    def test_no_server_files_written_on_failure(self) -> None:
+        """When validation fails, callers must not see a half-written server tree."""
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "empty-app" / "empty-app-test1234"
+            with pytest.raises(HarValidationError):
+                compile_workflow(
+                    session_id="test1234-0000-0000-0000-000000000000",
+                    session_name="Empty",
+                    app_slug="empty-app",
+                    tabby_profile_id="",
+                    har=_har([]),
+                    click_events=[],
+                    url_events=[],
+                    output_dir=str(out),
+                )
+            # The compiler may or may not have created the parent directory
+            # depending on where it raises, but it must not have written any
+            # generated source files (server.py, tools.json, manifest.json).
+            if out.exists():
+                generated = {p.name for p in out.rglob("*") if p.is_file()}
+                forbidden = {"server.py", "tools.json", "manifest.json", "API.md"}
+                assert not (generated & forbidden), (
+                    f"Compiler wrote artifacts on validation failure: {generated & forbidden}"
+                )

--- a/tests/test_compile_workflow_to_skill.py
+++ b/tests/test_compile_workflow_to_skill.py
@@ -12,10 +12,13 @@ import sys
 import tempfile
 from pathlib import Path
 
+import pytest
+
 _NOUI_ROOT = Path(__file__).resolve().parent.parent
 if str(_NOUI_ROOT) not in sys.path:
     sys.path.insert(0, str(_NOUI_ROOT))
 
+from compiler.mcp.har_to_tools import HarValidationError
 from compiler.skill.skill_generator import compile_workflow_to_skill
 
 
@@ -418,3 +421,49 @@ class TestSkillExecutionModeValidation:
                 _har([_entry("https://api.example.com/widgets")]),
                 execution_mode="grpc",
             )
+
+
+# ---------------------------------------------------------------------------
+# Empty / non-API HARs must be rejected at the same layer as the MCP compiler
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyHarRejected:
+    def test_empty_entries_raises(self) -> None:
+        with pytest.raises(HarValidationError, match="no entries"):
+            _compile(_har([]), app_slug="empty-skill")
+
+    def test_only_static_assets_raises(self) -> None:
+        har = _har(
+            [
+                _entry("https://cdn.example.com/bundle.js", status=200),
+                _entry("https://cdn.example.com/style.css", status=200),
+            ]
+        )
+        with pytest.raises(HarValidationError, match="none look like API calls"):
+            _compile(har, app_slug="static-only-skill")
+
+    def test_missing_log_raises(self) -> None:
+        with pytest.raises(HarValidationError, match="log.entries"):
+            _compile({}, app_slug="malformed-skill")
+
+    def test_no_skill_files_written_on_failure(self) -> None:
+        tmp = Path(tempfile.mkdtemp())
+        with pytest.raises(HarValidationError):
+            compile_workflow_to_skill(
+                session_id="abcdef12-3456-7890-abcd-ef1234567890",
+                session_name="Empty",
+                app_slug="empty-skill",
+                tabby_profile_id="",
+                har=_har([]),
+                click_events=[],
+                url_events=[],
+                output_dir=str(tmp),
+            )
+        # The output dir may exist (the compiler mkdir's it) but no generated
+        # source files should have been written.
+        generated = {p.name for p in tmp.rglob("*") if p.is_file()}
+        forbidden = {"SKILL.md", "manifest.json", "API.md"}
+        assert not (generated & forbidden), (
+            f"Skill compiler wrote artifacts on validation failure: {generated & forbidden}"
+        )

--- a/tests/test_har_to_tools.py
+++ b/tests/test_har_to_tools.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from compiler.mcp.har_to_tools import (
+    HarValidationError,
     _body_to_params,
     _id_param_name,
     _is_api_call,
@@ -210,9 +213,21 @@ def _htd(har: dict, workflow_name: str = "W", profile: str = "") -> list[dict]:
 
 
 class TestHarToToolDefs:
-    def test_empty_har_returns_empty(self) -> None:
-        assert _htd({"log": {"entries": []}}) == []
-        assert _htd({}) == []
+    def test_empty_entries_raises(self) -> None:
+        with pytest.raises(HarValidationError, match="no entries"):
+            _htd({"log": {"entries": []}})
+
+    def test_missing_log_raises(self) -> None:
+        with pytest.raises(HarValidationError, match="log.entries"):
+            _htd({})
+
+    def test_log_without_entries_raises(self) -> None:
+        with pytest.raises(HarValidationError, match="log.entries"):
+            _htd({"log": {"version": "1.2"}})
+
+    def test_non_dict_har_raises(self) -> None:
+        with pytest.raises(HarValidationError, match="JSON object"):
+            _htd("not a dict")  # type: ignore[arg-type]
 
     def test_single_entry(self) -> None:
         har = _har([_entry(url="https://api.example.com/v1/users")])
@@ -245,15 +260,35 @@ class TestHarToToolDefs:
         result = _htd(har)
         assert len(result) == 2
 
-    def test_skips_non_api_entries(self) -> None:
+    def test_only_static_assets_raises(self) -> None:
         har = _har(
             [
                 _entry(url="https://cdn.example.com/app.js", resp_mime="", status=200),
+                _entry(url="https://cdn.example.com/style.css", resp_mime="", status=200),
             ]
         )
-        # JS files should be filtered — check they don't appear in results
+        with pytest.raises(HarValidationError, match="none look like API calls"):
+            _htd(har)
+
+    def test_only_redirects_raises(self) -> None:
+        har = _har(
+            [
+                _entry(url="https://example.com/redirect", status=302, resp_mime=""),
+            ]
+        )
+        with pytest.raises(HarValidationError, match="none look like API calls"):
+            _htd(har)
+
+    def test_mixed_static_and_api_keeps_api(self) -> None:
+        har = _har(
+            [
+                _entry(url="https://cdn.example.com/app.js", resp_mime="", status=200),
+                _entry(url="https://api.example.com/v1/users"),
+            ]
+        )
         result = _htd(har)
-        assert not any("app.js" in r.get("url", "") for r in result)
+        assert len(result) == 1
+        assert "users" in result[0]["url"]
 
     def test_auth_header_detected(self) -> None:
         har = _har(


### PR DESCRIPTION
## Summary

- Add `HarValidationError` and reject empty / malformed / no-API HARs at the compiler boundary instead of silently emitting empty MCP servers or Skills.
- Surface validation failures as `422 Unprocessable Entity` from `POST /workflow/.../export`, while preserving `500` for unexpected bugs.
- Cover the new behaviour with unit and integration tests across `har_to_tools`, MCP compilation, and Skill compilation, including assertions that no artifacts are written on failure.

## Why

Today, capturing a HAR with no real API traffic (only static assets, redirects, or an empty session) silently produces an MCP server with zero tools or a Skill with no workflows. The export endpoint returns `200` and the user receives a useless artifact with no signal that anything went wrong. When the input *is* genuinely malformed (not a JSON object, missing `log`, missing `entries`), the compiler raises a generic `KeyError` / `AttributeError`, the router catches it as a `500`, and the user just sees `MCP compilation failed: ...`.

This PR moves that failure to the right layer:

- The compiler treats unusable HARs as a *user-correctable* error and raises `HarValidationError` with a specific reason (`empty entries`, `no API-like calls`, `not a JSON object`, etc.).
- The workflow router translates `HarValidationError` into `422` so the frontend / CLI can show the message verbatim, and keeps `500` strictly for actual bugs.
- No empty `server.py` / `tools.json` / `SKILL.md` / `manifest.json` are written to disk on failure.

Net effect: clearer errors, fewer zero-tool artifacts shipped to users, and a sharper distinction between user-fixable and engineer-fixable failures.

## Validation

Ran locally against Python 3.12.6 on Windows, scoped to touched files:

- `ruff check` on touched files - All checks passed.
- `ruff format --check` on touched files - 5 files already formatted.
- `mypy compiler/mcp/har_to_tools.py backend/workflow/router.py` - Success, no issues found.
- `pytest tests/test_har_to_tools.py` - 57 passed.
- `pytest tests/test_compile_workflow_to_skill.py` - 18 passed.
- `pytest tests/test_compile_workflow.py` - 30 passed, 10 pre-existing failures in `TestUnauthenticatedApi` / `TestGeneratedAuthPy` / `TestOutputFiles` about missing `noui_runtime/` and `operations/` package files; verified these same 10 failures reproduce before this PR and are unrelated to HAR validation.
- New `TestEmptyHarRejected` suites across both compilers - 8 passed.

Test coverage added:

- `tests/test_har_to_tools.py` - empty entries, missing `log`, `log` without `entries`, non-dict HAR, only static assets, only redirects, and mixed static + API (still passes through).
- `tests/test_compile_workflow.py::TestEmptyHarRejected` - empty entries, only-static, missing `log`, plus an assertion that no server files are written on failure.
- `tests/test_compile_workflow_to_skill.py::TestEmptyHarRejected` - mirror coverage for the Skill compiler.

## Checklist

- [x] Tests added or updated
- [x] Ran `ruff check`, `ruff format --check`, `mypy`, `pytest` locally
- [x] Updated `CHANGELOG.md` if user-visible (new entry under ``[Unreleased]``)
- [x] No secrets or customer data in the diff
- [x] If bumping the Tabby submodule, ran the compat matrix - N/A, no submodule changes
