### PR TITLE
fix(cli): give Tabby failures actionable error messages

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -547,6 +547,18 @@ def _tabby_http(
     except urllib.error.HTTPError as exc:
         body_text = exc.read().decode(errors="replace")
         raise RuntimeError(f"HTTP {exc.code} from {method} {path}: {body_text}") from exc
+    except urllib.error.URLError as exc:
+        # Connection refused, DNS failure, timeout, etc. The underlying OSError
+        # (or socket.timeout) is exposed via exc.reason; surface a clear,
+        # user-actionable message instead of letting the traceback escape.
+        reason = exc.reason
+        if isinstance(reason, TimeoutError):
+            detail = f"timed out after {timeout}s"
+        else:
+            detail = str(reason) or type(reason).__name__
+        raise RuntimeError(
+            f"Cannot reach Tabby at {url} ({detail}). Is Tabby running? Try `noui tabby status`."
+        ) from exc
 
 
 def _tabby_alive() -> bool:
@@ -1053,7 +1065,7 @@ def cmd_login_register(args: argparse.Namespace) -> int:
     print(_green(f"Registered profile '{profile_id}'"))
     print(f"  Application ID       : {_cyan(app_id)}")
     print(f"  ServiceProfile DB ID : {_cyan(profile_db_id)}")
-    print(f"  Tabby profile ID     : {_cyan(profile_db_id)}")
+    print(f"  Tabby profile ID     : {_cyan(profile_id)}")
     print("  Version state        : STAGING")
     print()
     print("  Next steps:")
@@ -1096,11 +1108,12 @@ def cmd_login_validate(args: argparse.Namespace) -> int:
         flush=True,
     )
     deadline = time.time() + 60
+    last_error: Exception | None = None
     while time.time() < deadline:
         time.sleep(3)
         print(".", end="", flush=True)
         try:
-            sessions = _get_sessions(admin_token)
+            sessions = _get_sessions(admin_token, raise_on_error=True)
             healthy = [
                 s for s in sessions if s.get("app_id") == app_id and s.get("state") == "HEALTHY"
             ]
@@ -1121,11 +1134,22 @@ def cmd_login_validate(args: argparse.Namespace) -> int:
                 print()
                 print(_red(f"Session entered failed state: {failed[0].get('state')}"))
                 return 1
-        except (RuntimeError, AssertionError):
-            pass
+        except (RuntimeError, AssertionError) as exc:
+            # Don't abort polling on a single failed call (Tabby may be briefly
+            # restarting). Remember the last error so we can surface it if we
+            # eventually time out instead of swallowing it silently.
+            last_error = exc
     else:
         print()
-        print(_red("No HEALTHY session found within 60s — run: noui tabby session ensure"))
+        if last_error is not None:
+            print(
+                _red(
+                    f"No HEALTHY session found within 60s. Last polling error: {last_error}. "
+                    f"Run: noui tabby session ensure"
+                )
+            )
+        else:
+            print(_red("No HEALTHY session found within 60s — run: noui tabby session ensure"))
         return 1
 
 
@@ -3754,13 +3778,23 @@ def _ensure_service_profile(
 # ---------------------------------------------------------------------------
 
 
-def _get_sessions(admin_token: str) -> list[dict[str, Any]]:
+def _get_sessions(admin_token: str, *, raise_on_error: bool = False) -> list[dict[str, Any]]:
+    """Fetch all browser sessions known to Tabby.
+
+    By default, transport / HTTP failures are swallowed and an empty list is
+    returned so that status-style callers can show "no sessions" without
+    aborting. Pass ``raise_on_error=True`` when the caller needs to distinguish
+    "Tabby is unreachable" from "Tabby returned zero sessions" (for example,
+    inside a polling loop that should surface persistent failures on timeout).
+    """
     try:
         resp = _tabby_http("GET", "/sessions?limit=200", token=admin_token)
         if isinstance(resp, dict):
             return resp.get("data", [])
         return list(resp)  # type: ignore[arg-type]
     except RuntimeError:
+        if raise_on_error:
+            raise
         return []
 
 

--- a/tests/test_cli_tabby.py
+++ b/tests/test_cli_tabby.py
@@ -1,0 +1,275 @@
+"""Unit tests for Tabby-related CLI helpers and commands.
+
+Covers behaviour added in the "improve Tabby CLI failure messages" PR:
+
+1. ``_tabby_http`` translates ``urllib.error.HTTPError`` and connection /
+   timeout failures into a single ``RuntimeError`` with an actionable message.
+2. ``_get_sessions`` swallows errors by default but propagates them when
+   ``raise_on_error=True`` (used by the login-validate polling loop).
+3. ``cmd_login_validate`` surfaces the last polling error on timeout instead
+   of dropping it silently.
+4. ``cmd_login_register`` prints the human-friendly profile slug as
+   ``Tabby profile ID`` rather than repeating the database UUID.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import socket
+import sys
+import urllib.error
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+if str(_NOUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(_NOUI_ROOT))
+
+from cli import main as cli_main
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for ``urllib.request.urlopen`` context-manager output."""
+
+    def __init__(self, payload: dict) -> None:
+        self._body = json.dumps(payload).encode()
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+@contextmanager
+def _patched_urlopen(side_effect):
+    """Patch ``urllib.request.urlopen`` for the duration of the test."""
+    with patch.object(cli_main.urllib.request, "urlopen", side_effect=side_effect) as p:
+        yield p
+
+
+def _make_http_error(code: int, body: str = "{}") -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="http://localhost:8080/whatever",
+        code=code,
+        msg="test",
+        hdrs=None,  # type: ignore[arg-type]
+        fp=io.BytesIO(body.encode()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. _tabby_http transport / HTTP error handling
+# ---------------------------------------------------------------------------
+
+
+class TestTabbyHttpErrors:
+    def test_happy_path_returns_parsed_json(self) -> None:
+        with _patched_urlopen(side_effect=lambda *_a, **_k: _FakeResponse({"ok": True})):
+            result = cli_main._tabby_http("GET", "/health/live")
+        assert result == {"ok": True}
+
+    def test_http_error_preserves_status_and_body(self) -> None:
+        # Regression: existing behaviour must keep working unchanged.
+        err = _make_http_error(401, '{"detail":"unauthorized"}')
+        with _patched_urlopen(side_effect=err), pytest.raises(RuntimeError) as exc_info:
+            cli_main._tabby_http("GET", "/admin/profiles", token="bad")
+        msg = str(exc_info.value)
+        assert "HTTP 401" in msg
+        assert "unauthorized" in msg
+        assert "/admin/profiles" in msg
+
+    def test_connection_refused_is_actionable(self) -> None:
+        # Simulate the Tabby API not running at all.
+        err = urllib.error.URLError(ConnectionRefusedError(111, "Connection refused"))
+        with _patched_urlopen(side_effect=err), pytest.raises(RuntimeError) as exc_info:
+            cli_main._tabby_http("GET", "/health/live")
+        msg = str(exc_info.value)
+        assert "Cannot reach Tabby" in msg
+        assert cli_main.TABBY_API_HOST in msg
+        assert "noui tabby status" in msg
+        # The underlying OS error should be visible to the user.
+        assert "Connection refused" in msg
+
+    def test_dns_failure_is_actionable(self) -> None:
+        # gaierror is the typical DNS-level failure surfaced as URLError.
+        err = urllib.error.URLError(socket.gaierror(8, "nodename nor servname provided"))
+        with _patched_urlopen(side_effect=err), pytest.raises(RuntimeError) as exc_info:
+            cli_main._tabby_http("GET", "/health/live")
+        msg = str(exc_info.value)
+        assert "Cannot reach Tabby" in msg
+        assert "nodename" in msg or "servname" in msg
+
+    def test_timeout_is_named_explicitly(self) -> None:
+        # urllib wraps socket-level timeouts in URLError(reason=TimeoutError(...)).
+        err = urllib.error.URLError(TimeoutError("timed out"))
+        with _patched_urlopen(side_effect=err), pytest.raises(RuntimeError) as exc_info:
+            cli_main._tabby_http("GET", "/health/live", timeout=7)
+        msg = str(exc_info.value)
+        assert "Cannot reach Tabby" in msg
+        assert "timed out after 7s" in msg
+
+
+# ---------------------------------------------------------------------------
+# 2. _get_sessions raise_on_error toggle
+# ---------------------------------------------------------------------------
+
+
+class TestGetSessions:
+    def test_default_swallows_errors(self) -> None:
+        with patch.object(cli_main, "_tabby_http", side_effect=RuntimeError("boom")):
+            assert cli_main._get_sessions("tok") == []
+
+    def test_raise_on_error_propagates(self) -> None:
+        with (
+            patch.object(cli_main, "_tabby_http", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            cli_main._get_sessions("tok", raise_on_error=True)
+
+    def test_returns_list_payload(self) -> None:
+        sessions = [{"id": "abc", "state": "HEALTHY"}]
+        with patch.object(cli_main, "_tabby_http", return_value={"data": sessions}):
+            assert cli_main._get_sessions("tok") == sessions
+
+
+# ---------------------------------------------------------------------------
+# 3. cmd_login_validate surfaces the last polling error on timeout
+# ---------------------------------------------------------------------------
+
+
+class TestLoginValidateErrorSurfacing:
+    def _bundle_path(self, tmp_path: Path) -> Path:
+        bundle = {
+            "_provisioned": {
+                "app_id": "app-uuid-1234",
+                "profile_db_id": "db-uuid-5678",
+                "profile_id": "my-app",
+            }
+        }
+        path = tmp_path / "bundle.json"
+        path.write_text(json.dumps(bundle))
+        return path
+
+    def _drive_polling_loop(self, monkeypatch: pytest.MonkeyPatch) -> list[float]:
+        """Patch time so the 60s polling loop completes in two iterations."""
+        ticks = iter([100.0, 100.5, 101.0, 200.0])  # last tick exits the loop
+        used: list[float] = []
+
+        def fake_time() -> float:
+            t = next(ticks)
+            used.append(t)
+            return t
+
+        monkeypatch.setattr(cli_main.time, "time", fake_time)
+        monkeypatch.setattr(cli_main.time, "sleep", lambda _s: None)
+        return used
+
+    def test_timeout_includes_last_polling_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        bundle = self._bundle_path(tmp_path)
+        monkeypatch.setattr(cli_main, "_tabby_alive", lambda: True)
+        monkeypatch.setattr(cli_main, "_get_admin_token", lambda: "tok")
+        monkeypatch.setattr(
+            cli_main,
+            "_get_sessions",
+            lambda _t, raise_on_error=False: (_ for _ in ()).throw(
+                RuntimeError("Cannot reach Tabby at http://localhost:8080 (Connection refused)")
+            ),
+        )
+        self._drive_polling_loop(monkeypatch)
+
+        rc = cli_main.cmd_login_validate(SimpleNamespace(bundle_file=str(bundle)))
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Last polling error" in out
+        assert "Connection refused" in out
+
+    def test_timeout_without_errors_keeps_classic_message(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        # If polling succeeds but never finds a HEALTHY session, the existing
+        # "noui tabby session ensure" hint must still be the message shown.
+        bundle = self._bundle_path(tmp_path)
+        monkeypatch.setattr(cli_main, "_tabby_alive", lambda: True)
+        monkeypatch.setattr(cli_main, "_get_admin_token", lambda: "tok")
+        monkeypatch.setattr(cli_main, "_get_sessions", lambda _t, raise_on_error=False: [])
+        self._drive_polling_loop(monkeypatch)
+
+        rc = cli_main.cmd_login_validate(SimpleNamespace(bundle_file=str(bundle)))
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Last polling error" not in out
+        assert "noui tabby session ensure" in out
+
+
+# ---------------------------------------------------------------------------
+# 4. cmd_login_register prints the slug, not the DB UUID, as profile ID
+# ---------------------------------------------------------------------------
+
+
+class TestLoginRegisterOutput:
+    def test_tabby_profile_id_is_the_slug(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        bundle = {
+            "validation": {"generator_valid": True},
+            "application_draft": {
+                "name": "MyApp",
+                "target_urls": ["https://example.com"],
+                "login_config": {"credential_ref": "k8s:secret/tabby-my-app"},
+            },
+            "service_profile_draft": {
+                "profile_id": "my-app",
+                "version": "0.0.0",
+            },
+        }
+        bundle_path = tmp_path / "bundle.json"
+        bundle_path.write_text(json.dumps(bundle))
+
+        monkeypatch.setattr(cli_main, "_tabby_alive", lambda: True)
+        monkeypatch.setattr(cli_main, "_get_admin_token", lambda: "tok")
+        monkeypatch.setattr(cli_main, "_load_cache", lambda: {})
+        monkeypatch.setattr(cli_main, "_save_cache", lambda _c: None)
+
+        def fake_http(method: str, path: str, body=None, token=None, timeout=15):  # noqa: ARG001
+            if path == "/apps":
+                return {"app_id": "app-uuid-1111"}
+            if path == "/admin/profiles":
+                return {"id": "db-uuid-2222"}
+            raise AssertionError(f"unexpected call: {method} {path}")
+
+        monkeypatch.setattr(cli_main, "_tabby_http", fake_http)
+
+        rc = cli_main.cmd_login_register(SimpleNamespace(bundle_file=str(bundle_path)))
+        assert rc == 0
+
+        out = capsys.readouterr().out
+        # The slug must appear next to "Tabby profile ID", and the DB UUID must
+        # NOT show up there (it still appears next to "ServiceProfile DB ID").
+        tabby_line = next(line for line in out.splitlines() if "Tabby profile ID" in line)
+        assert "my-app" in tabby_line
+        assert "db-uuid-2222" not in tabby_line
+        assert "ServiceProfile DB ID" in out


### PR DESCRIPTION
## Summary

Three small reliability / UX fixes in the Tabby flow of `cli/main.py`, all stemming from places where transport or shape errors get hidden from the operator:

- **`_tabby_http()` now surfaces transport failures as actionable errors.** Previously only `urllib.error.HTTPError` was caught — `URLError` (connection refused, DNS failure, socket timeout) escaped as a raw traceback. Now those become a `RuntimeError` like `Cannot reach Tabby at http://localhost:8080 (Connection refused). Is Tabby running? Try \`noui tabby status\`.`, with the timeout case named explicitly.
- **`noui login validate` no longer hides why polling failed.** `_get_sessions()` was unconditionally swallowing `RuntimeError` and returning `[]`, so the polling loop in `cmd_login_validate` would see a steady stream of "no sessions" and time out with a generic *"No HEALTHY session found within 60s"*, even when every poll was throwing a 500 or a connection refused. `_get_sessions()` now takes a `raise_on_error` toggle (default `False` to preserve current callers in `tabby session status` / `tabby session ensure`); the polling loop opts in, tracks the most recent error across the window, and prints it on timeout.
- **`noui login register` prints the profile slug as `Tabby profile ID`.** It was printing the database UUID twice — once correctly under `ServiceProfile DB ID`, and once mislabelled as `Tabby profile ID`. The slug (e.g. `my-app`) is the value users actually need to pass to `--profile` later, so showing the UUID was actively misleading.

## Why

These three are all the same shape of bug: a CLI step *succeeds* in the sense of "didn't throw" but leaves the operator without the information they need to fix the next failure. They are the kind of issue a new user runs into during their first 30 minutes with the project — Docker not up, Tabby not yet started, copy/pasting the wrong ID into the next command — so they tend to amplify support load disproportionately to their fix size.

The diffs are intentionally narrow:

- New `URLError` branch in `_tabby_http` (~12 lines) — every existing caller benefits automatically.
- `raise_on_error` toggle on `_get_sessions` (~3 lines) — opt-in, so `tabby session status` and `tabby session ensure` keep their soft-failure UX.
- `last_error` tracking in the `cmd_login_validate` polling loop and an `if last_error is not None` branch on the timeout message.
- Single field swap on the register output line.

No public behaviour change for the happy path; only the failure paths get clearer.

## Validation

Ran locally against Python 3.12.6 on Windows, scoped to touched files:

- `ruff check cli/main.py tests/test_cli_tabby.py` — All checks passed.
- `ruff format --check cli/main.py tests/test_cli_tabby.py` — 2 files already formatted.
- `mypy cli/main.py` — Success: no issues found.
- `pytest tests/test_cli_tabby.py` — 11 passed.
- `pytest tests/test_skill_cli.py` — 13 passed (regression check on the only other file that imports `cli.main`).

Test coverage added in `tests/test_cli_tabby.py`:

- `TestTabbyHttpErrors` — happy path, HTTP error preservation (regression), connection refused, DNS failure (`gaierror`), explicit timeout naming.
- `TestGetSessions` — default-swallow vs `raise_on_error=True` propagation, plus a payload sanity check.
- `TestLoginValidateErrorSurfacing` — timeout message includes the last polling error when one was seen; classic `noui tabby session ensure` hint preserved when polling succeeded with no HEALTHY session.
- `TestLoginRegisterOutput` — the line printed under `Tabby profile ID` shows the slug, not the DB UUID.

All tests mock at the `urllib` / `time` / Tabby-helper boundary so they complete in well under a second and don't touch the network.

## Checklist

- [x] Tests added or updated
- [x] Ran `ruff check`, `ruff format --check`, `mypy`, `pytest` locally
- [x] Updated `CHANGELOG.md` if user-visible — these are CLI-only error-message changes; not adding a new bullet to keep the noise down, but happy to add one if maintainers prefer.
- [x] No secrets or customer data in the diff
- [x] If bumping the Tabby submodule, ran the compat matrix — N/A, no submodule changes
