### PR TITLE
feat(cli): load repo-root .env and normalise Tabby API host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/noui-record-workflow` skill now documents the CDP default under *How
   Execution Works*; `/noui-generalize` reframed around hand-edit cases on top
   of the default (SPA DOM scraping, HITL login).
+- CLI now loads the repo-root `.env` (matching `backend/config.py`) so
+  `TABBY_API_HOST` set in `.env` is honoured by every `noui` subcommand
+  instead of being silently ignored. Values without a scheme (e.g.
+  `localhost:8080`) are normalised to `http://localhost:8080` and trailing
+  slashes are stripped, eliminating opaque `urlopen` failures.
 
 ### Added
 

--- a/cli/env.py
+++ b/cli/env.py
@@ -1,0 +1,80 @@
+"""Environment resolution for the NoUI CLI.
+
+The CLI historically read ``TABBY_API_HOST`` straight from ``os.environ`` at
+import time, which meant a ``.env`` file in the repository root (the canonical
+location documented in ``.env.example`` and consumed by ``backend/config.py``)
+was silently ignored when running ``noui`` subcommands. The result was a
+confusing setup-time mismatch: the backend would talk to the user's configured
+Tabby host while the CLI kept reaching for ``http://localhost:8080``.
+
+This module centralises that resolution. It exposes two pure helpers:
+
+* :func:`load_env_files` populates ``os.environ`` from the repo-root ``.env``.
+  It is idempotent, never overrides values that already live in the process
+  environment, and is a no-op when ``python-dotenv`` is not installed.
+
+* :func:`resolve_tabby_api_host` returns a normalised Tabby API base URL,
+  applying the same default as ``backend/config.py`` and adding a missing
+  scheme when callers wrote ``localhost:8080`` instead of
+  ``http://localhost:8080``.
+
+Keeping these as side-effect-free functions means tests can exercise them
+without importing the rest of ``cli/main.py`` (which has substantial
+import-time work).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+DEFAULT_TABBY_API_HOST = "http://localhost:8080"
+
+_CLI_DIR = Path(__file__).resolve().parent
+_NOUI_ROOT = _CLI_DIR.parent
+
+
+def load_env_files(noui_root: Path | None = None) -> None:
+    """Populate ``os.environ`` from the repo-root ``.env`` if present.
+
+    Existing process-environment values always win (``override=False``),
+    matching the behaviour of :mod:`backend.config`. Safe to call more than
+    once. A missing ``python-dotenv`` install is treated as a no-op so the
+    CLI keeps working in minimal environments.
+    """
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        return
+
+    root = noui_root if noui_root is not None else _NOUI_ROOT
+    env_path = root / ".env"
+    if env_path.is_file():
+        load_dotenv(env_path, override=False)
+
+
+def resolve_tabby_api_host(env: Mapping[str, str] | None = None) -> str:
+    """Return a normalised Tabby API base URL.
+
+    Resolution order:
+
+    1. ``TABBY_API_HOST`` from the supplied mapping (defaults to
+       :data:`os.environ`, which callers are expected to have populated via
+       :func:`load_env_files`).
+    2. :data:`DEFAULT_TABBY_API_HOST` when the value is missing or empty.
+
+    The returned string is guaranteed to:
+
+    * include an explicit scheme (``http://`` is prepended when absent so
+      common abbreviations like ``localhost:8080`` keep working);
+    * have no trailing slash, so callers can safely concatenate paths
+      starting with ``/``.
+    """
+    src = env if env is not None else os.environ
+    raw = (src.get("TABBY_API_HOST") or "").strip()
+    if not raw:
+        raw = DEFAULT_TABBY_API_HOST
+    if "://" not in raw:
+        raw = "http://" + raw
+    return raw.rstrip("/")

--- a/cli/main.py
+++ b/cli/main.py
@@ -70,8 +70,21 @@ from urllib.parse import urlparse
 # Paths
 # ---------------------------------------------------------------------------
 
-CLI_DIR = Path(__file__).parent
+CLI_DIR = Path(__file__).resolve().parent
 NOUI_DIR = CLI_DIR.parent
+# Make ``cli`` importable as a package when running this file directly
+# (``python cli/main.py``). When invoked via ``python -m cli.main`` or from
+# tests, ``NOUI_DIR`` is already on the path and the insert is a no-op.
+if str(NOUI_DIR) not in sys.path:
+    sys.path.insert(0, str(NOUI_DIR))
+
+from cli.env import load_env_files, resolve_tabby_api_host  # noqa: E402
+
+# Populate os.environ from the repo-root ``.env`` *before* reading any
+# Tabby/NoUI config below. Mirrors what ``backend/config.py`` already does so
+# the CLI and backend agree on values when launched from the same checkout.
+load_env_files(NOUI_DIR)
+
 WORKBENCH_DIR = NOUI_DIR / "workbench"
 MCP_SERVERS_DIR = WORKBENCH_DIR / "mcp_servers"
 LOGIN_RECORDINGS_DIR = WORKBENCH_DIR / "login_recordings"
@@ -87,7 +100,7 @@ TABBY_DIR = (
     if os.environ.get("TABBY_DIR")
     else NOUI_DIR / "tabby"
 )
-TABBY_API_HOST = os.environ.get("TABBY_API_HOST", "http://localhost:8080")
+TABBY_API_HOST = resolve_tabby_api_host()
 ENV_LOCAL = TABBY_DIR / ".env.local"
 ENV_EXAMPLE = TABBY_DIR / ".env.example"
 

--- a/tests/test_cli_env.py
+++ b/tests/test_cli_env.py
@@ -1,0 +1,150 @@
+"""Tests for cli/env.py.
+
+These exercise the env-loading and Tabby-host normalisation helpers in
+isolation. They never import ``cli.main`` (which has side-effecting
+import-time work) so they can manipulate ``os.environ`` and dotenv state
+without disturbing the wider test suite.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+if str(_NOUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(_NOUI_ROOT))
+
+from cli.env import DEFAULT_TABBY_API_HOST, load_env_files, resolve_tabby_api_host
+
+# ---------------------------------------------------------------------------
+# resolve_tabby_api_host
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTabbyApiHost:
+    def test_default_when_unset(self) -> None:
+        assert resolve_tabby_api_host(env={}) == DEFAULT_TABBY_API_HOST
+
+    def test_default_when_blank(self) -> None:
+        """Empty / whitespace-only values fall back to the default rather
+        than producing an unusable bare 'http://' URL."""
+        for raw in ("", "   ", "\t"):
+            assert resolve_tabby_api_host(env={"TABBY_API_HOST": raw}) == DEFAULT_TABBY_API_HOST
+
+    def test_explicit_value_passes_through(self) -> None:
+        assert (
+            resolve_tabby_api_host(env={"TABBY_API_HOST": "http://tabby.example:8080"})
+            == "http://tabby.example:8080"
+        )
+
+    def test_https_scheme_preserved(self) -> None:
+        assert (
+            resolve_tabby_api_host(env={"TABBY_API_HOST": "https://tabby.example"})
+            == "https://tabby.example"
+        )
+
+    def test_missing_scheme_gets_http_prefix(self) -> None:
+        """A common user mistake — writing ``localhost:8080`` without a scheme.
+        We normalise this so urllib.request doesn't raise an opaque
+        ``unknown url type`` error downstream."""
+        assert (
+            resolve_tabby_api_host(env={"TABBY_API_HOST": "localhost:8080"})
+            == "http://localhost:8080"
+        )
+        assert (
+            resolve_tabby_api_host(env={"TABBY_API_HOST": "10.0.0.5:9000"})
+            == "http://10.0.0.5:9000"
+        )
+
+    def test_trailing_slash_stripped(self) -> None:
+        """Callers concatenate path strings starting with '/', so the host
+        must not end with one — keeps the existing _tabby_http() shape valid."""
+        assert (
+            resolve_tabby_api_host(env={"TABBY_API_HOST": "http://localhost:8080/"})
+            == "http://localhost:8080"
+        )
+
+    def test_surrounding_whitespace_stripped(self) -> None:
+        """Common typo when copy-pasting from docs."""
+        assert (
+            resolve_tabby_api_host(env={"TABBY_API_HOST": "  http://localhost:8080  "})
+            == "http://localhost:8080"
+        )
+
+    def test_defaults_to_os_environ(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TABBY_API_HOST", "http://from-os-env:1234")
+        assert resolve_tabby_api_host() == "http://from-os-env:1234"
+
+    def test_default_constant_value(self) -> None:
+        """Pin the default literal so it can't drift away from
+        backend/config.py and .env.example without a deliberate change."""
+        assert DEFAULT_TABBY_API_HOST == "http://localhost:8080"
+
+
+# ---------------------------------------------------------------------------
+# load_env_files
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEnvFiles:
+    def test_populates_missing_keys(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / ".env").write_text("TABBY_API_HOST=http://from-dotenv:8090\n")
+        monkeypatch.delenv("TABBY_API_HOST", raising=False)
+        load_env_files(tmp_path)
+        assert resolve_tabby_api_host() == "http://from-dotenv:8090"
+
+    def test_existing_env_wins(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``override=False`` semantics — if the user already exported the
+        variable in their shell, the dotenv value must NOT clobber it. This
+        matches backend/config.py and is the principle of least surprise for
+        anyone running ``TABBY_API_HOST=... noui ...``."""
+        (tmp_path / ".env").write_text("TABBY_API_HOST=http://from-dotenv:8090\n")
+        monkeypatch.setenv("TABBY_API_HOST", "http://from-shell:7000")
+        load_env_files(tmp_path)
+        assert resolve_tabby_api_host() == "http://from-shell:7000"
+
+    def test_missing_dotenv_file_is_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When no .env exists, nothing is added to os.environ and the
+        default is used. Nothing should raise."""
+        monkeypatch.delenv("TABBY_API_HOST", raising=False)
+        load_env_files(tmp_path)
+        assert resolve_tabby_api_host() == DEFAULT_TABBY_API_HOST
+
+    def test_missing_dotenv_package_is_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If python-dotenv is not installed, the helper must silently
+        no-op rather than crash the CLI on import."""
+        (tmp_path / ".env").write_text("TABBY_API_HOST=http://from-dotenv:8090\n")
+        monkeypatch.delenv("TABBY_API_HOST", raising=False)
+
+        real_import = (
+            __builtins__["__import__"]
+            if isinstance(__builtins__, dict)
+            else __builtins__.__import__
+        )  # type: ignore[index]
+
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "dotenv":
+                raise ImportError("simulated missing python-dotenv")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=fake_import):
+            load_env_files(tmp_path)
+
+        assert resolve_tabby_api_host() == DEFAULT_TABBY_API_HOST
+
+    def test_idempotent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Calling twice in the same process must not raise or change the
+        resolved value."""
+        (tmp_path / ".env").write_text("TABBY_API_HOST=http://from-dotenv:8090\n")
+        monkeypatch.delenv("TABBY_API_HOST", raising=False)
+        load_env_files(tmp_path)
+        load_env_files(tmp_path)
+        assert resolve_tabby_api_host() == "http://from-dotenv:8090"


### PR DESCRIPTION
## Problem

The CLI captured `TABBY_API_HOST` from `os.environ` at import time and never loaded the repo-root `.env`. A value placed in `.env` — the location documented in `.env.example` and consumed by `backend/config.py` — was silently ignored by every `noui` subcommand. The result was a confusing setup-time mismatch:

- `backend/config.py` calls `load_dotenv(<repo>/.env)` so the backend honoured `.env`.
- `cli/main.py` did not, so the CLI quietly stayed on `http://localhost:8080` even when the user had set `TABBY_API_HOST=http://localhost:8090` in `.env`.

After PR #22 the CLI now says *"Cannot reach Tabby at http://localhost:8080. Is Tabby running?"*, which makes the wrong-host case worse — the host it prints is the wrong one. There was also no normalisation, so `TABBY_API_HOST=localhost:8080` (no scheme, an easy-to-make typo) caused `urllib.request.urlopen` to raise an opaque `unknown url type` error.

## What this PR changes

A small, additive PR.

**New `cli/env.py`** — single source of truth for CLI env resolution. Two pure helpers:

- `load_env_files(noui_root=None)` — idempotently populates `os.environ` from `<repo>/.env` with `override=False`, matching `backend/config.py`. No-op when `python-dotenv` is missing or the `.env` file does not exist.
- `resolve_tabby_api_host(env=None)` — returns a normalised base URL, prepending `http://` when the scheme is missing (so `localhost:8080` keeps working) and stripping trailing slashes (so concatenation with paths starting with `/` still yields a valid URL).

**`cli/main.py`** — calls both helpers once during startup; the existing module-level `TABBY_API_HOST` constant and every call site that reads it are otherwise unchanged. A `sys.path.insert(0, NOUI_DIR)` makes `from cli.env import ...` work both when invoked as `python cli/main.py` (script mode) and as `python -m cli.main`.

**`tests/test_cli_env.py`** — 14 new tests covering scheme normalisation, default fallback, blank-string fallback, trailing-slash stripping, `os.environ` precedence (existing exports win over `.env`, matching backend semantics), missing `python-dotenv` no-op, missing `.env` no-op, and idempotency. Pure unit tests, run in <0.2s.

**`CHANGELOG.md`** — entry under `## [Unreleased] -> ### Changed`.

## What this PR does not change

- `backend/config.py` — already does this correctly; no behavioural change.
- Any existing call site of `TABBY_API_HOST` in `cli/main.py` — they continue to read the module-level constant.
- Generated `noui_runtime/auth.py` and `runtime/tabby_auth.py` — they load their own server-local `.env`, which is correct and out of scope.
- Tabby submodule's `TABBY_DIR/.env.local` — left alone.
- No new env vars, no Pydantic Settings refactor.

## Independence from PR #21 and PR #22

- PR #21 touches `compiler/`, `backend/workflow/`, tests — zero overlap.
- PR #22 modifies the *body* of `_tabby_http()` (lines 544-550 in that PR). This PR only changes how `TABBY_API_HOST` is *assigned* (lines 85-92). Disjoint line ranges; no rebase conflict expected regardless of merge order.

## Test plan

- [x] `ruff check cli/__init__.py cli/env.py cli/main.py tests/test_cli_env.py` — clean
- [x] `ruff format --check` on the same set — already formatted
- [x] `mypy cli/env.py` — no issues found
- [x] `pytest tests/test_cli_env.py` — 14/14 pass in 0.13s
- [x] `python cli/main.py --help` — still works (proves the new import path)
- [x] Manual: `TABBY_API_HOST=localhost:9999 python -c "from cli.env import resolve_tabby_api_host; print(resolve_tabby_api_host())"` → `http://localhost:9999`
