### PR TITLE
feat: replace CDP adapter with Tabby execute/fetch endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ backend/data/
 .noui-backend.log
 poetry.lock
 .coverage
+.claude/worktrees/*

--- a/backend/autopilot/router.py
+++ b/backend/autopilot/router.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.autopilot.models import AutopilotRecordingRun
 from backend.autopilot.schemas import AutopilotRunCreate, AutopilotRunOut
 from backend.database import get_db
-from backend.elicitation.browser_bridge import execute_command
+from backend.elicitation.browser_bridge import _use_tabby_driver, execute_command
 
 logger = logging.getLogger(__name__)
 
@@ -138,27 +138,32 @@ class CaptureControlIn(BaseModel):
 
 @router.post("/start-capture")
 async def start_capture(data: CaptureControlIn):
-    """Start HAR + click + URL capture via the extension.
+    """Start HAR + click + URL capture.
 
-    Sends the composite START_CAPTURE_SESSION message to the extension
-    through the browser command queue.
+    In Tabby mode: sends har_start to the worker via execute/browser.
+    In extension mode: verifies extension liveness and injects click tracker.
     """
+    if _use_tabby_driver():
+        result = await execute_command("har_start", {})
+        return {
+            "status": "started",
+            "capture_session_id": data.capture_session_id,
+            "driver": "tabby",
+            "note": "HAR capture started on the Tabby worker via execute/browser.",
+            "har_status": result.get("data", {}),
+        }
+
+    # Extension mode (original behavior)
     try:
-        # Get active tab
         page_info = await execute_command("get_page_info", {})
         tab_id = page_info.get("tabId")
     except TimeoutError:
         tab_id = None
 
-    # Use individual commands since START_CAPTURE_SESSION is a message handler,
-    # not a command handler.  We replicate its steps here.
     try:
-        # 1. Set capture state (so click events get tagged)
         await execute_command(
             "eval_js",
-            {
-                "code": "document.title"  # no-op to verify extension is alive
-            },
+            {"code": "document.title"},
         )
     except TimeoutError as exc:
         raise HTTPException(
@@ -166,11 +171,6 @@ async def start_capture(data: CaptureControlIn):
             "Extension not responding. Is Chrome running with the NoUI extension?",
         ) from exc
 
-    # The extension's SET_CAPTURE_STATE is a message handler, not a command handler.
-    # We can't call it through the command queue.  Instead, we set up capture
-    # by injecting the click tracker and starting HAR via command handlers.
-
-    # Inject click tracker
     if tab_id:
         try:
             await execute_command(
@@ -187,25 +187,53 @@ async def start_capture(data: CaptureControlIn):
                 },
             )
         except Exception:
-            pass  # click tracker injection is best-effort here
+            pass
 
     return {
         "status": "started",
         "capture_session_id": data.capture_session_id,
         "tab_id": tab_id,
+        "driver": "extension",
         "note": "HAR capture is managed by the extension capture session. Use the extension or call PUT /capture-sessions/{id}/start first.",
     }
 
 
 @router.post("/stop-capture")
 async def stop_capture(data: CaptureControlIn):
-    """Stop capture and trigger HAR upload.
+    """Stop capture and retrieve HAR.
 
-    The extension uploads the HAR when the capture session is stopped
-    via PUT /capture-sessions/{id}/stop.
+    In Tabby mode: sends har_stop to the worker, receives HAR JSON, and
+    stores it locally via the HAR storage path.
+    In extension mode: the extension uploads HAR when the capture session is stopped.
     """
+    if _use_tabby_driver():
+        result = await execute_command("har_stop", {})
+        result_data = result.get("data", {})
+        har_json = result_data.get("har")
+
+        # Store HAR locally if returned
+        if har_json:
+            import os
+            from pathlib import Path
+
+            data_dir = os.environ.get("NOUI_DATA_DIR", "data")
+            har_dir = Path(data_dir) / "har" / "autopilot"
+            har_dir.mkdir(parents=True, exist_ok=True)
+            har_path = har_dir / f"{data.capture_session_id}.har"
+            har_path.write_text(json.dumps(har_json, indent=2), encoding="utf-8")
+            logger.info("HAR saved to %s (%d entries)", har_path, result_data.get("entry_count", 0))
+
+        return {
+            "status": "stopped",
+            "capture_session_id": data.capture_session_id,
+            "driver": "tabby",
+            "entry_count": result_data.get("entry_count", 0),
+            "note": "HAR captured server-side by the Tabby worker.",
+        }
+
     return {
         "status": "stopped",
         "capture_session_id": data.capture_session_id,
+        "driver": "extension",
         "note": "Call PUT /capture-sessions/{id}/stop to finalize. The extension uploads HAR on stop.",
     }

--- a/backend/elicitation/browser_bridge.py
+++ b/backend/elicitation/browser_bridge.py
@@ -14,6 +14,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import Any
 
 import httpx
 
@@ -25,7 +26,7 @@ COMMAND_TIMEOUT_SECONDS = 30
 # Tabby driver configuration
 # ---------------------------------------------------------------------------
 
-_agent_token_cache: dict[str, any] = {"token": "", "expires_at": 0.0}
+_agent_token_cache: dict[str, Any] = {"token": "", "expires_at": 0.0}
 
 
 def _use_tabby_driver() -> bool:

--- a/backend/elicitation/browser_bridge.py
+++ b/backend/elicitation/browser_bridge.py
@@ -2,17 +2,111 @@
 
 Commands are created by MCP tool handlers and consumed by the Chrome extension
 via polling. Results flow back through asyncio.Event synchronization.
+
+When TABBY_API_HOST, TABBY_CLIENT_ID, and TABBY_PROFILE_ID are set, commands
+are routed to Tabby's POST /execute/browser endpoint instead — no extension needed.
 """
 
 import asyncio
 import logging
+import os
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
+import httpx
+
 logger = logging.getLogger(__name__)
 
 COMMAND_TIMEOUT_SECONDS = 30
+
+# ---------------------------------------------------------------------------
+# Tabby driver configuration
+# ---------------------------------------------------------------------------
+
+_agent_token_cache: dict[str, any] = {"token": "", "expires_at": 0.0}
+
+
+def _use_tabby_driver() -> bool:
+    return bool(
+        os.environ.get("TABBY_API_HOST")
+        and os.environ.get("TABBY_CLIENT_ID")
+        and os.environ.get("TABBY_PROFILE_ID")
+    )
+
+
+async def _get_agent_token() -> str:
+    """Exchange client credentials for an agent bearer token, with caching."""
+    now = time.time()
+    if _agent_token_cache["token"] and _agent_token_cache["expires_at"] > now + 30:
+        return _agent_token_cache["token"]
+
+    api_host = os.environ["TABBY_API_HOST"].rstrip("/")
+    client_id = os.environ["TABBY_CLIENT_ID"]
+    client_secret = os.environ["TABBY_CLIENT_SECRET"]
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{api_host}/auth/agent-token",
+            json={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "grant_type": "client_credentials",
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+    token = data.get("access_token") or data.get("token", "")
+    if not token:
+        raise RuntimeError(f"POST /auth/agent-token returned no token: {data}")
+
+    # Cache for ~50 minutes (agent tokens default to 1 hour TTL)
+    _agent_token_cache["token"] = token
+    _agent_token_cache["expires_at"] = now + 3000
+
+    return token
+
+
+async def _execute_command_via_tabby(command_type: str, params: dict) -> dict:
+    """Execute a browser command via Tabby's POST /execute/browser endpoint.
+
+    Returns the same {success, data, error} shape as the extension driver.
+    """
+    api_host = os.environ["TABBY_API_HOST"].rstrip("/")
+    profile_id = os.environ["TABBY_PROFILE_ID"]
+    token = await _get_agent_token()
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{api_host}/execute/browser",
+            json={
+                "profile_id": profile_id,
+                "command": command_type,
+                "params": params,
+                "timeout_ms": COMMAND_TIMEOUT_SECONDS * 1000,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=COMMAND_TIMEOUT_SECONDS + 5,
+        )
+
+    if resp.status_code == 409:
+        raise RuntimeError(
+            f"Tabby session conflict: {resp.text}. Another consumer may be driving this session."
+        )
+    if resp.status_code == 429:
+        raise RuntimeError(f"Rate limited by Tabby: {resp.text}")
+    if resp.status_code >= 400:
+        raise RuntimeError(f"Tabby execute/browser failed ({resp.status_code}): {resp.text[:500]}")
+
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Extension driver (original queue-based approach)
+# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -68,12 +162,8 @@ def set_result(cmd_id: str, result: dict) -> bool:
     return True
 
 
-async def execute_command(command_type: str, params: dict) -> dict:
-    """Create a command, wait for the extension to execute it, return the result.
-
-    Raises:
-        TimeoutError: If the extension does not respond within COMMAND_TIMEOUT_SECONDS.
-    """
+async def _execute_command_via_extension(command_type: str, params: dict) -> dict:
+    """Create a command, wait for the extension to execute it, return the result."""
     cmd = create_command(command_type, params)
     try:
         await asyncio.wait_for(cmd.event.wait(), timeout=COMMAND_TIMEOUT_SECONDS)
@@ -86,3 +176,27 @@ async def execute_command(command_type: str, params: dict) -> dict:
         ) from None
     assert cmd.result is not None
     return cmd.result
+
+
+# ---------------------------------------------------------------------------
+# Public API — routes to Tabby or extension based on environment
+# ---------------------------------------------------------------------------
+
+
+async def execute_command(command_type: str, params: dict) -> dict:
+    """Execute a browser command, routing to Tabby or the extension.
+
+    When TABBY_API_HOST, TABBY_CLIENT_ID, and TABBY_PROFILE_ID are set,
+    commands go to Tabby's POST /execute/browser. Otherwise, they go to
+    the Chrome extension via the in-memory queue.
+
+    Raises:
+        TimeoutError: If the extension does not respond within COMMAND_TIMEOUT_SECONDS.
+        RuntimeError: If the Tabby driver encounters an error.
+    """
+    if _use_tabby_driver():
+        logger.debug("Routing command '%s' via Tabby driver", command_type)
+        return await _execute_command_via_tabby(command_type, params)
+
+    logger.debug("Routing command '%s' via extension driver", command_type)
+    return await _execute_command_via_extension(command_type, params)

--- a/cli/main.py
+++ b/cli/main.py
@@ -574,6 +574,15 @@ def _tabby_http(
         ) from exc
 
 
+def _is_tabby_mode() -> bool:
+    """True when all three Tabby env vars are set (headless browser driver)."""
+    return bool(
+        os.environ.get("TABBY_API_HOST")
+        and os.environ.get("TABBY_CLIENT_ID")
+        and os.environ.get("TABBY_PROFILE_ID")
+    )
+
+
 def _tabby_alive() -> bool:
     try:
         with urllib.request.urlopen(TABBY_API_HOST + "/health/live", timeout=3) as resp:
@@ -1620,77 +1629,93 @@ def cmd_autopilot_start_capture(args: argparse.Namespace) -> int:
         print(_red(f"Failed to start capture: {exc}"))
         return 1
 
-    # Start HAR + click tracking via extension (best effort)
+    # Start HAR + click tracking
     har_started = False
-    try:
-        result = _http(
-            "POST",
-            "/browser-commands/execute",
-            {
-                "command_type": "start_capture_session",
-                "params": {
-                    "projectId": project_id,
-                    "processId": process_id,
-                    "captureSessionId": cs_id,
-                },
-            },
-            timeout=10,
-        )
-        # The execute endpoint returns HTTP 200 even on extension errors —
-        # check the success field to detect failures.
-        if isinstance(result, dict) and result.get("success") is False:
-            raise RuntimeError(result.get("error", "Extension command failed"))
-        har_started = True
-    except Exception:
-        # Fallback: try individual commands
+    if _is_tabby_mode():
+        # Tabby mode: use the backend's start-capture endpoint which sends
+        # har_start to the worker.  Extension commands are not supported.
         try:
             _http(
                 "POST",
-                "/browser-commands/execute",
+                "/autopilot-recordings/start-capture",
                 {
-                    "command_type": "set_capture_state",
-                    "params": {
-                        "projectId": project_id,
-                        "processId": process_id,
-                        "captureSessionId": cs_id,
-                    },
+                    "capture_session_id": cs_id,
+                    "project_id": project_id,
+                    "process_id": process_id,
                 },
-                timeout=10,
-            )
-            _http(
-                "POST",
-                "/browser-commands/execute",
-                {
-                    "command_type": "start_har_capture",
-                    "params": {"captureSessionId": cs_id},
-                },
-                timeout=10,
-            )
-            _http(
-                "POST",
-                "/browser-commands/execute",
-                {
-                    "command_type": "inject_click_tracker",
-                    "params": {},
-                },
-                timeout=10,
-            )
-            _http(
-                "POST",
-                "/browser-commands/execute",
-                {
-                    "command_type": "start_url_monitoring",
-                    "params": {
-                        "projectId": project_id,
-                        "processId": process_id,
-                        "captureSessionId": cs_id,
-                    },
-                },
-                timeout=10,
+                timeout=15,
             )
             har_started = True
         except Exception as exc:
-            print(_yellow(f"  Extension not responding — HAR capture not started: {exc}"))
+            print(_yellow(f"  Tabby HAR capture not started: {exc}"))
+    else:
+        # Extension mode: send commands to the Chrome extension
+        try:
+            result = _http(
+                "POST",
+                "/browser-commands/execute",
+                {
+                    "command_type": "start_capture_session",
+                    "params": {
+                        "projectId": project_id,
+                        "processId": process_id,
+                        "captureSessionId": cs_id,
+                    },
+                },
+                timeout=10,
+            )
+            if isinstance(result, dict) and result.get("success") is False:
+                raise RuntimeError(result.get("error", "Extension command failed"))
+            har_started = True
+        except Exception:
+            try:
+                _http(
+                    "POST",
+                    "/browser-commands/execute",
+                    {
+                        "command_type": "set_capture_state",
+                        "params": {
+                            "projectId": project_id,
+                            "processId": process_id,
+                            "captureSessionId": cs_id,
+                        },
+                    },
+                    timeout=10,
+                )
+                _http(
+                    "POST",
+                    "/browser-commands/execute",
+                    {
+                        "command_type": "start_har_capture",
+                        "params": {"captureSessionId": cs_id},
+                    },
+                    timeout=10,
+                )
+                _http(
+                    "POST",
+                    "/browser-commands/execute",
+                    {
+                        "command_type": "inject_click_tracker",
+                        "params": {},
+                    },
+                    timeout=10,
+                )
+                _http(
+                    "POST",
+                    "/browser-commands/execute",
+                    {
+                        "command_type": "start_url_monitoring",
+                        "params": {
+                            "projectId": project_id,
+                            "processId": process_id,
+                            "captureSessionId": cs_id,
+                        },
+                    },
+                    timeout=10,
+                )
+                har_started = True
+            except Exception as exc:
+                print(_yellow(f"  Extension not responding — HAR capture not started: {exc}"))
 
     print()
     print(_bold("Capture started:"))
@@ -2104,68 +2129,84 @@ def cmd_autopilot_resume_capture(args: argparse.Namespace) -> int:
         print(_red(f"Failed to start capture: {exc}"))
         return 1
 
-    # Start HAR + click tracking via extension
+    # Start HAR + click tracking
     har_started = False
-    try:
-        result = _http(
-            "POST",
-            "/browser-commands/execute",
-            {
-                "command_type": "start_capture_session",
-                "params": {
-                    "projectId": project_id,
-                    "processId": process_id,
-                    "captureSessionId": cs_id,
-                },
-            },
-            timeout=10,
-        )
-        if isinstance(result, dict) and result.get("success") is False:
-            raise RuntimeError(result.get("error", "Extension command failed"))
-        har_started = True
-    except Exception:
+    if _is_tabby_mode():
         try:
             _http(
                 "POST",
-                "/browser-commands/execute",
+                "/autopilot-recordings/start-capture",
                 {
-                    "command_type": "set_capture_state",
-                    "params": {
-                        "projectId": project_id,
-                        "processId": process_id,
-                        "captureSessionId": cs_id,
-                    },
+                    "capture_session_id": cs_id,
+                    "project_id": project_id,
+                    "process_id": process_id,
                 },
-                timeout=10,
-            )
-            _http(
-                "POST",
-                "/browser-commands/execute",
-                {"command_type": "start_har_capture", "params": {"captureSessionId": cs_id}},
-                timeout=10,
-            )
-            _http(
-                "POST",
-                "/browser-commands/execute",
-                {"command_type": "inject_click_tracker", "params": {}},
-                timeout=10,
-            )
-            _http(
-                "POST",
-                "/browser-commands/execute",
-                {
-                    "command_type": "start_url_monitoring",
-                    "params": {
-                        "projectId": project_id,
-                        "processId": process_id,
-                        "captureSessionId": cs_id,
-                    },
-                },
-                timeout=10,
+                timeout=15,
             )
             har_started = True
         except Exception as exc:
-            print(_yellow(f"  Extension not responding — HAR capture not started: {exc}"))
+            print(_yellow(f"  Tabby HAR capture not started: {exc}"))
+    else:
+        try:
+            result = _http(
+                "POST",
+                "/browser-commands/execute",
+                {
+                    "command_type": "start_capture_session",
+                    "params": {
+                        "projectId": project_id,
+                        "processId": process_id,
+                        "captureSessionId": cs_id,
+                    },
+                },
+                timeout=10,
+            )
+            if isinstance(result, dict) and result.get("success") is False:
+                raise RuntimeError(result.get("error", "Extension command failed"))
+            har_started = True
+        except Exception:
+            try:
+                _http(
+                    "POST",
+                    "/browser-commands/execute",
+                    {
+                        "command_type": "set_capture_state",
+                        "params": {
+                            "projectId": project_id,
+                            "processId": process_id,
+                            "captureSessionId": cs_id,
+                        },
+                    },
+                    timeout=10,
+                )
+                _http(
+                    "POST",
+                    "/browser-commands/execute",
+                    {"command_type": "start_har_capture", "params": {"captureSessionId": cs_id}},
+                    timeout=10,
+                )
+                _http(
+                    "POST",
+                    "/browser-commands/execute",
+                    {"command_type": "inject_click_tracker", "params": {}},
+                    timeout=10,
+                )
+                _http(
+                    "POST",
+                    "/browser-commands/execute",
+                    {
+                        "command_type": "start_url_monitoring",
+                        "params": {
+                            "projectId": project_id,
+                            "processId": process_id,
+                            "captureSessionId": cs_id,
+                        },
+                    },
+                    timeout=10,
+                )
+                har_started = True
+            except Exception as exc:
+                print(_yellow(f"  Extension not responding — HAR capture not started: {exc}"))
 
     print()
     print(_bold("Capture resumed:"))

--- a/compiler/mcp/server_generator.py
+++ b/compiler/mcp/server_generator.py
@@ -21,7 +21,6 @@ import json
 import re
 from datetime import UTC, datetime
 from pathlib import Path
-from urllib.parse import urlparse
 
 from compiler.mcp.api_doc_generator import generate_api_markdown
 from compiler.mcp.auth_plan import generate_auth_plan

--- a/compiler/mcp/server_generator.py
+++ b/compiler/mcp/server_generator.py
@@ -27,7 +27,7 @@ from compiler.mcp.api_doc_generator import generate_api_markdown
 from compiler.mcp.auth_plan import generate_auth_plan
 from compiler.mcp.har_to_tools import har_to_tool_defs
 from compiler.runtime.auth_adapter import generate_auth_adapter
-from compiler.runtime.cdp_adapter import generate_cdp_adapter
+from compiler.runtime.execute_adapter import generate_execute_adapter
 
 _VALID_EXECUTION_MODES = ("cdp", "http")
 
@@ -136,7 +136,7 @@ def compile_workflow(
         generate_auth_adapter(_settings.tabby_api_host), encoding="utf-8"
     )
     if execution_mode == "cdp":
-        (runtime_dir / "cdp.py").write_text(generate_cdp_adapter(), encoding="utf-8")
+        (runtime_dir / "execute.py").write_text(generate_execute_adapter(), encoding="utf-8")
 
     # ── 4. Write operations/*.py ──────────────────────────────────────────────
     ops_dir = out_path / "operations"
@@ -196,7 +196,7 @@ def compile_workflow(
         "API.md",
     ]
     if execution_mode == "cdp":
-        all_files.append("noui_runtime/cdp.py")
+        all_files.append("noui_runtime/execute.py")
     if auth_plan:
         all_files.append("auth_plan.json")
 
@@ -214,7 +214,7 @@ def compile_workflow(
     auth_strategy = auth_plan.get("strategy", "") if auth_plan else ""
     resolved_auth_strategy = auth_strategy or ("tabby_credentials" if has_auth else None)
     execution_strategy = (
-        "cdp_browser_session" if execution_mode == "cdp" else resolved_auth_strategy
+        "tabby_execute_fetch" if execution_mode == "cdp" else resolved_auth_strategy
     )
 
     manifest: dict = {
@@ -332,10 +332,11 @@ def _render_operation(td: dict, *, auth_plan: dict, execution_mode: str = "cdp")
     """Render a single operation module.
 
     Two execution modes:
-      - "cdp" (default): the operation opens a WebSocket to Tabby's CDP endpoint
-        (localhost:9222), locates a page target for the recorded domain, and
-        fetches via Runtime.evaluate with `credentials: 'include'`. Cookies and
-        TLS fingerprint come from the real authenticated browser.
+      - "cdp" (default): the operation calls Tabby's POST /execute/fetch
+        endpoint, which runs fetch() inside the authenticated browser via
+        page.evaluate() with `credentials: 'include'`. Cookies and TLS
+        fingerprint come from the real authenticated browser. No WebSocket,
+        no direct CDP access.
       - "http" (legacy): the operation runs httpx in-process and resolves
         credentials via noui_runtime.auth.resolve_auth(). Strategy is driven by
         auth_plan["strategy"]:
@@ -345,12 +346,12 @@ def _render_operation(td: dict, *, auth_plan: dict, execution_mode: str = "cdp")
         live auth headers so they are not dropped.
     """
     if execution_mode == "cdp":
-        return _render_operation_cdp(td)
+        return _render_operation_cdp(td, auth_plan=auth_plan)
     return _render_operation_http(td, auth_plan=auth_plan)
 
 
-def _render_operation_cdp(td: dict) -> str:
-    """Render an operation that executes inside Tabby's browser via CDP."""
+def _render_operation_cdp(td: dict, *, auth_plan: dict) -> str:
+    """Render an operation that executes inside Tabby's browser via execute/fetch."""
     name = td["name"]
     method = td["method"].upper()
     path_template = td["path"]
@@ -360,7 +361,7 @@ def _render_operation_cdp(td: dict) -> str:
     request_headers: list[dict] = td.get("request_headers", [])
     description = td.get("description", "")
 
-    netloc = urlparse(base_url).netloc if base_url else ""
+    profile_slug = auth_plan.get("profile_slug", "") if auth_plan else ""
 
     static_headers = {
         h["name"]: h["value"] for h in request_headers if h.get("name") and h.get("value")
@@ -375,8 +376,8 @@ def _render_operation_cdp(td: dict) -> str:
         f"Method: {method}",
         f"Path: {path_template}",
         "",
-        "Executes inside Tabby's authenticated browser via CDP. Requires a live",
-        f"Tabby session with a page open on {netloc or 'the target domain'}.",
+        "Executes inside Tabby's authenticated browser via the execute/fetch endpoint.",
+        "Requires a live Tabby session for the configured profile.",
         '"""',
         "",
         "from __future__ import annotations",
@@ -386,10 +387,10 @@ def _render_operation_cdp(td: dict) -> str:
         lines.append("import urllib.parse")
         lines.append("")
     lines += [
-        "from noui_runtime.cdp import cdp_fetch, find_page",
+        "from noui_runtime.execute import execute_fetch",
         "",
         f"BASE_URL = {base_url!r}",
-        f"CDP_HOST_MATCH = {netloc!r}",
+        f"PROFILE_SLUG = {profile_slug!r}",
         "",
         "",
     ]
@@ -422,21 +423,17 @@ def _render_operation_cdp(td: dict) -> str:
     if static_headers:
         lines.append(f"    headers = {static_headers!r}")
     else:
-        lines.append("    headers: dict[str, str] = {}")
+        lines.append("    headers: dict[str, str] | None = None")
 
-    lines.append("    ws_url = await find_page(CDP_HOST_MATCH)")
-    lines.append("    if not ws_url:")
-    lines.append(
-        "        raise RuntimeError("
-        'f"No Tabby page matching {CDP_HOST_MATCH!r}. '
-        "Open the site in Tabby (run `tabby session ensure --profile <slug>`) "
-        'or re-export with --execution-mode http.")'
-    )
-
-    call_kwargs: list[str] = ["ws_url", "url", f'method="{method}"', "headers=headers"]
+    call_kwargs: list[str] = [
+        "PROFILE_SLUG",
+        "url",
+        f'method="{method}"',
+        "headers=headers",
+    ]
     if has_body:
         call_kwargs.append("body=body")
-    lines.append(f"    return await cdp_fetch({', '.join(call_kwargs)})")
+    lines.append(f"    return await execute_fetch({', '.join(call_kwargs)})")
     lines.append("")
 
     return "\n".join(lines)

--- a/compiler/runtime/execute_adapter.py
+++ b/compiler/runtime/execute_adapter.py
@@ -112,7 +112,7 @@ async def _get_agent_token() -> str:
     async with httpx.AsyncClient() as client:
         resp = await client.post(
             f"{_tabby_api_host()}/auth/agent-token",
-            json={"client_id": client_id, "client_secret": client_secret},
+            json={"grant_type": "client_credentials", "client_id": client_id, "client_secret": client_secret},
             timeout=10,
         )
         resp.raise_for_status()

--- a/compiler/runtime/execute_adapter.py
+++ b/compiler/runtime/execute_adapter.py
@@ -1,0 +1,197 @@
+"""Generate the noui_runtime/execute.py source code for a compiled MCP server or Skill.
+
+Pure function — no web framework or DB dependencies.
+
+The generated module lets operations execute HTTP calls from *inside* Tabby's
+authenticated browser via the `POST /execute/fetch` HTTP endpoint on the Tabby
+API. Cookies ride on `credentials: 'include'`; the real browser's TLS
+fingerprint is preserved.
+
+Replaces the direct CDP WebSocket approach (cdp_adapter.py). No WebSocket,
+no `websockets` dependency — plain HTTP via httpx.
+"""
+
+from __future__ import annotations
+
+
+def generate_execute_adapter() -> str:
+    """Generate noui_runtime/execute.py source code as a string.
+
+    The generated module provides:
+      - execute_fetch(profile_id, url, method, body, headers) — fetch inside the browser
+
+    Returns:
+        Python source code string for noui_runtime/execute.py.
+    """
+    return '''\
+"""NoUI runtime execute adapter — fetch inside Tabby's authenticated browser session.
+
+Shared across MCP-server and Skill output formats. Calls the Tabby API's
+POST /execute/fetch endpoint, which routes to the worker pod and runs
+fetch() inside the real authenticated browser via page.evaluate().
+
+Why this module exists:
+  - Cookies and TLS fingerprint come from the real authenticated browser.
+  - No credential extraction on the Python side.
+  - Bypasses Akamai / Cloudflare false positives that fire on httpx requests.
+  - No WebSocket or CDP access needed — plain HTTP to the Tabby API.
+
+Requires:
+  - A running Tabby session for the target profile.
+  - TABBY_API_HOST / TABBY_API_URL env var (or .env) pointing to the Tabby API.
+  - Agent credentials (TABBY_CLIENT_ID / TABBY_CLIENT_SECRET) for token exchange.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+def _find_env_file() -> str | None:
+    """Walk up from this file to find .env, matching the auth adapter pattern."""
+    if os.environ.get("NOUI_ENV_FILE"):
+        return os.environ["NOUI_ENV_FILE"]
+    here = Path(__file__).resolve().parent
+    for _ in range(7):
+        candidate = here / ".env"
+        if candidate.exists():
+            return str(candidate)
+        here = here.parent
+    for fallback in (
+        Path.home() / ".config" / "noui" / ".env",
+        Path.home() / ".noui" / ".env",
+    ):
+        if fallback.exists():
+            return str(fallback)
+    return None
+
+
+def _load_env() -> None:
+    """Best-effort dotenv load."""
+    env_file = _find_env_file()
+    if not env_file:
+        return
+    try:
+        from dotenv import load_dotenv
+        load_dotenv(env_file, override=False)
+    except ImportError:
+        pass
+
+
+_load_env()
+
+
+def _tabby_api_host() -> str:
+    """Resolve the Tabby API base URL from environment."""
+    return (
+        os.environ.get("TABBY_API_HOST")
+        or os.environ.get("TABBY_API_URL")
+        or "http://localhost:8000"
+    )
+
+
+async def _get_agent_token() -> str:
+    """Exchange client credentials for an agent bearer token.
+
+    Reads TABBY_CLIENT_ID and TABBY_CLIENT_SECRET from env.
+    Caches nothing — the caller (execute_fetch) is typically invoked once per
+    tool call, and token exchange is cheap relative to the browser fetch.
+    """
+    client_id = os.environ.get("TABBY_CLIENT_ID", "")
+    client_secret = os.environ.get("TABBY_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "TABBY_CLIENT_ID and TABBY_CLIENT_SECRET must be set. "
+            "Create an agent client in the Tabby admin UI."
+        )
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{_tabby_api_host()}/auth/agent-token",
+            json={"client_id": client_id, "client_secret": client_secret},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    return data["access_token"]
+
+
+async def execute_fetch(
+    profile_id: str,
+    url: str,
+    *,
+    method: str = "GET",
+    body: Any = None,
+    headers: dict[str, str] | None = None,
+    timeout_ms: int = 30000,
+) -> Any:
+    """Execute fetch() inside the authenticated Tabby browser session.
+
+    The Tabby API resolves the profile to a healthy session, routes to the
+    worker pod, and runs page.evaluate(fetch(url, {credentials: \'include\'}))
+    inside the real browser.
+
+    Args:
+        profile_id: Tabby profile slug (known at compile time from the workflow export).
+        url: Absolute URL to fetch.
+        method: HTTP method; defaults to GET.
+        body: Optional JSON-serializable body.
+        headers: Optional extra request headers.
+        timeout_ms: Timeout in milliseconds (default 30000, max 60000).
+
+    Returns:
+        Parsed JSON body on 2xx; raises RuntimeError on non-2xx or errors.
+    """
+    token = await _get_agent_token()
+
+    request_body: dict[str, Any] = {
+        "profile_id": profile_id,
+        "url": url,
+        "method": method.upper(),
+        "timeout_ms": timeout_ms,
+    }
+    if headers:
+        request_body["headers"] = headers
+    if body is not None:
+        request_body["body"] = json.dumps(body) if not isinstance(body, str) else body
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{_tabby_api_host()}/execute/fetch",
+            json=request_body,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=timeout_ms / 1000 + 5,
+        )
+
+    if resp.status_code == 429:
+        raise RuntimeError(f"Rate limited by Tabby API: {resp.text}")
+    if resp.status_code == 409:
+        raise RuntimeError(
+            f"No healthy Tabby session for profile \\"{profile_id}\\". "
+            "Run `tabby session ensure --profile <slug>` or check the admin UI."
+        )
+    if resp.status_code >= 400:
+        snippet = resp.text[:500]
+        raise RuntimeError(
+            f"Tabby execute/fetch failed ({resp.status_code}): {snippet}"
+        )
+
+    data = resp.json()
+
+    # The worker returns {status, headers, body} — unwrap the response body
+    status = data.get("status", 0)
+    raw_body = data.get("body", "")
+
+    if not (200 <= status < 300):
+        snippet = (raw_body or "")[:500]
+        raise RuntimeError(f"{method.upper()} {url} -> {status}: {snippet}")
+
+    try:
+        return json.loads(raw_body) if raw_body else {}
+    except (ValueError, TypeError):
+        return {"status": status, "text": raw_body}
+'''

--- a/compiler/skill/operation_generator.py
+++ b/compiler/skill/operation_generator.py
@@ -26,16 +26,16 @@ def render_skill_operation(td: dict, *, auth_plan: dict, execution_mode: str = "
     works from inside the Skill directory, with `noui_runtime/` one level up.
 
     `execution_mode` matches the MCP compiler:
-      - "cdp" (default): execute inside Tabby's browser via CDP
+      - "cdp" (default): execute inside Tabby's browser via execute/fetch endpoint
       - "http" (legacy): execute via httpx + resolve_auth()
     """
     if execution_mode == "cdp":
-        return _render_skill_operation_cdp(td)
+        return _render_skill_operation_cdp(td, auth_plan=auth_plan)
     return _render_skill_operation_http(td, auth_plan=auth_plan)
 
 
-def _render_skill_operation_cdp(td: dict) -> str:
-    """Render a skill op that executes inside Tabby's browser via CDP."""
+def _render_skill_operation_cdp(td: dict, *, auth_plan: dict) -> str:
+    """Render a skill op that executes inside Tabby's browser via execute/fetch."""
     name = td["name"]
     method = td["method"].upper()
     path_template = td["path"]
@@ -45,7 +45,7 @@ def _render_skill_operation_cdp(td: dict) -> str:
     request_headers: list[dict] = td.get("request_headers", [])
     description = td.get("description", "")
 
-    netloc = urlparse(base_url).netloc if base_url else ""
+    profile_slug = auth_plan.get("profile_slug", "") if auth_plan else ""
 
     static_headers = {
         h["name"]: h["value"] for h in request_headers if h.get("name") and h.get("value")
@@ -65,7 +65,7 @@ def _render_skill_operation_cdp(td: dict) -> str:
         f"Path: {path_template}",
         "",
         "Skill-variant entry point. Executes inside Tabby's authenticated browser",
-        f"via CDP. Requires a live Tabby session with a page open on {netloc or 'the target domain'}.",
+        "via the execute/fetch endpoint. Requires a live Tabby session for the configured profile.",
         '"""',
         "",
         "from __future__ import annotations",
@@ -86,10 +86,10 @@ def _render_skill_operation_cdp(td: dict) -> str:
         "if str(_SKILL_ROOT) not in sys.path:",
         "    sys.path.insert(0, str(_SKILL_ROOT))",
         "",
-        "from noui_runtime.cdp import cdp_fetch, find_page  # noqa: E402",
+        "from noui_runtime.execute import execute_fetch  # noqa: E402",
         "",
         f"BASE_URL = {base_url!r}",
-        f"CDP_HOST_MATCH = {netloc!r}",
+        f"PROFILE_SLUG = {profile_slug!r}",
         "",
         "",
     ]
@@ -111,29 +111,23 @@ def _render_skill_operation_cdp(td: dict) -> str:
 
     if has_body:
         body_dict = ", ".join(f"{p['name']!r}: {p['name']}" for p in body_params)
-        # Content type influences Content-Type header only; body is JSON-encoded
-        # by cdp_fetch regardless.
         _ = content_type
         lines.append(f"    body = {{{body_dict}}}")
 
     if static_headers:
         lines.append(f"    headers = {static_headers!r}")
     else:
-        lines.append("    headers: dict[str, str] = {}")
+        lines.append("    headers: dict[str, str] | None = None")
 
-    lines.append("    ws_url = await find_page(CDP_HOST_MATCH)")
-    lines.append("    if not ws_url:")
-    lines.append(
-        "        raise RuntimeError("
-        'f"No Tabby page matching {CDP_HOST_MATCH!r}. '
-        "Open the site in Tabby (run `tabby session ensure --profile <slug>`) "
-        'or re-export with --execution-mode http.")'
-    )
-
-    call_kwargs: list[str] = ["ws_url", "url", f'method="{method}"', "headers=headers"]
+    call_kwargs: list[str] = [
+        "PROFILE_SLUG",
+        "url",
+        f'method="{method}"',
+        "headers=headers",
+    ]
     if has_body:
         call_kwargs.append("body=body")
-    lines.append(f"    return await cdp_fetch({', '.join(call_kwargs)})")
+    lines.append(f"    return await execute_fetch({', '.join(call_kwargs)})")
     lines.append("")
     lines.append("")
 

--- a/compiler/skill/operation_generator.py
+++ b/compiler/skill/operation_generator.py
@@ -16,8 +16,6 @@ payloads: exits 2 (still prints the JSON). On success: exits 0.
 
 from __future__ import annotations
 
-from urllib.parse import urlparse
-
 
 def render_skill_operation(td: dict, *, auth_plan: dict, execution_mode: str = "cdp") -> str:
     """Render the full Python source for a single Skill operation.

--- a/compiler/skill/skill_generator.py
+++ b/compiler/skill/skill_generator.py
@@ -30,7 +30,7 @@ from compiler.mcp.api_doc_generator import generate_api_markdown
 from compiler.mcp.auth_plan import generate_auth_plan
 from compiler.mcp.har_to_tools import har_to_tool_defs
 from compiler.runtime.auth_adapter import generate_auth_adapter
-from compiler.runtime.cdp_adapter import generate_cdp_adapter
+from compiler.runtime.execute_adapter import generate_execute_adapter
 from compiler.skill.operation_generator import render_skill_operation
 from compiler.skill.skill_md_generator import render_skill_md
 
@@ -137,13 +137,11 @@ def compile_workflow_to_skill(
         generate_auth_adapter(_settings.tabby_api_host), encoding="utf-8"
     )
     if execution_mode == "cdp":
-        (runtime_dir / "cdp.py").write_text(generate_cdp_adapter(), encoding="utf-8")
+        (runtime_dir / "execute.py").write_text(generate_execute_adapter(), encoding="utf-8")
 
     # 4. pyproject.toml + .python-version — per-skill Python environment (retro D1).
-    # Needs httpx for any CDP or HTTP operation; websockets only for CDP mode.
+    # Needs httpx for any execution mode (execute endpoint or direct HTTP).
     pyproject_deps = ['"httpx>=0.27"']
-    if execution_mode == "cdp":
-        pyproject_deps.append('"websockets>=12"')
     pyproject_toml = (
         f"[project]\n"
         f'name = "{skill_id}"\n'
@@ -242,14 +240,14 @@ def compile_workflow_to_skill(
         *op_files,
     ]
     if execution_mode == "cdp":
-        all_files.append("noui_runtime/cdp.py")
+        all_files.append("noui_runtime/execute.py")
     if auth_plan:
         all_files.append("auth_plan.json")
 
     auth_strategy = auth_plan.get("strategy", "") if auth_plan else ""
     resolved_auth_strategy = auth_strategy or ("tabby_credentials" if has_auth else None)
     execution_strategy = (
-        "cdp_browser_session" if execution_mode == "cdp" else resolved_auth_strategy
+        "tabby_execute_fetch" if execution_mode == "cdp" else resolved_auth_strategy
     )
 
     manifest: dict = {

--- a/skills/expedia-stay-search/SKILL.md
+++ b/skills/expedia-stay-search/SKILL.md
@@ -7,7 +7,7 @@ description: Use this skill when the user wants to search for hotels on Expedia 
 
 Search Expedia for available hotels by destination and dates using an authenticated Tabby browser session. Returns a Hotel-Search URL and extracted listings (name, nightly price, total price, rating, reviews, refundable flag, link).
 
-This skill drives the real Expedia site inside a Tabby-managed browser via CDP (Chrome DevTools Protocol) instead of a Python HTTP client. That is intentional: Expedia sits behind Akamai, which blocks non-browser TLS fingerprints. Do not try to port the operations to `httpx` or `requests` — you will get 429 Too Many Requests.
+This skill drives the real Expedia site inside a Tabby-managed browser via the `execute/fetch` endpoint instead of a Python HTTP client. That is intentional: Expedia sits behind Akamai, which blocks non-browser TLS fingerprints. Do not try to port the operations to `httpx` or `requests` — you will get 429 Too Many Requests.
 
 ## Prerequisites
 
@@ -78,8 +78,8 @@ Prints a JSON object to stdout on success. Exits non-zero on failure with a diag
 
 ## Troubleshooting
 
-- **`No Expedia browser session found. Is Tabby running?`** — no Tabby CDP target found at `localhost:9222` matching `expedia.com`. Run `tabby session ensure --profile expedia` and retry.
-- **`Expedia API returned 429: ...`** — Akamai is rate-limiting even through the browser. This is rare via CDP; if it happens repeatedly the Tabby session may need to rotate IPs or the profile needs re-recording.
+- **`No healthy Tabby session for profile "expedia"`** — no healthy session found. Run `tabby session ensure --profile expedia` and retry.
+- **`Expedia API returned 429: ...`** — Akamai is rate-limiting even through the browser. This is rare via the execute endpoint; if it happens repeatedly the Tabby session may need to rotate IPs or the profile needs re-recording.
 - **Empty `listings`, non-zero `listings_count`** — Expedia changed its DOM. The DOM-scrape selectors in `search_hotels.py` (`[data-stid="lodging-card-responsive"]`) need updating. Report to the NoUI maintainers; do not guess at selectors.
 - **`auth_plan.json missing profile_slug`** — this skill was mis-installed. The `auth_plan.json` file sitting next to `noui_runtime/` must have `profile_slug: "expedia"`. Reinstall the skill.
 

--- a/skills/noui-autopilot/SKILL.md
+++ b/skills/noui-autopilot/SKILL.md
@@ -11,7 +11,7 @@ All commands run from the `noui/` directory using `.venv/bin/python cli/main.py`
 
 **Prerequisite:** `/noui-setup` must be complete. Chrome must be open with the NoUI extension loaded and connected to `localhost:8002`.
 
-**Execution mode:** autopilot-exported servers inherit the CDP default — generated operations run inside Tabby's browser session via `noui_runtime.cdp`. Pass `--execution-mode http` to `noui autopilot export` if you need the legacy `httpx + resolve_auth` path. See `/noui-record-workflow` → *How Execution Works*.
+**Execution mode:** autopilot-exported servers inherit the execute-fetch default — generated operations run inside Tabby's browser session via `noui_runtime.execute`. Pass `--execution-mode http` to `noui autopilot export` if you need the legacy `httpx + resolve_auth` path. See `/noui-record-workflow` → *How Execution Works*.
 
 ---
 

--- a/skills/noui-autopilot/SKILL.md
+++ b/skills/noui-autopilot/SKILL.md
@@ -5,13 +5,24 @@ description: Use this skill when the user wants to automatically record a browse
 
 # NoUI Autopilot Recording
 
-You ARE the browser automation agent. You will drive a real Chrome browser through the NoUI extension to record a workflow, then compile it into a FastMCP server. No separate agent or API key is needed — you control the browser directly via HTTP commands.
+You ARE the browser automation agent. You will drive a real browser to record a workflow, then compile it into a FastMCP server. You control the browser directly via HTTP commands.
 
 All commands run from the `noui/` directory using `.venv/bin/python cli/main.py`.
 
-**Prerequisite:** `/noui-setup` must be complete. Chrome must be open with the NoUI extension loaded and connected to `localhost:8002`.
-
 **Execution mode:** autopilot-exported servers inherit the execute-fetch default — generated operations run inside Tabby's browser session via `noui_runtime.execute`. Pass `--execution-mode http` to `noui autopilot export` if you need the legacy `httpx + resolve_auth` path. See `/noui-record-workflow` → *How Execution Works*.
+
+### Browser driver modes
+
+The autopilot has two browser driver modes, selected automatically by environment:
+
+| Mode | When | Prerequisites |
+|------|------|---------------|
+| **Tabby** (headless, no extension) | `TABBY_API_HOST` + `TABBY_CLIENT_ID` + `TABBY_PROFILE_ID` are set | A healthy Tabby session for the profile. No Chrome extension needed. |
+| **Extension** (local Chrome) | Tabby env vars not set | Chrome with the NoUI extension loaded and connected to `localhost:8002`. `/noui-setup` must be complete. |
+
+In Tabby mode, browser commands go to Tabby's `POST /execute/browser` endpoint — the worker drives Playwright directly. HAR capture is server-side (`har_start`/`har_stop`), no extension capture session needed. This enables headless/server-side autopilot for agent-builder pipelines.
+
+In extension mode (the original path), commands go through the Chrome extension's in-memory queue. HAR capture is extension-managed. The "Verify Extension" preflight step (Step 1.5) applies only to this mode.
 
 ---
 

--- a/skills/noui-generalize/SKILL.md
+++ b/skills/noui-generalize/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: noui-generalize
-description: Use this skill when the user wants to generalize a recorded MCP workflow, rename tools to readable names, replace raw API params with natural-language parameters, fix bot detection issues (Akamai, Cloudflare, PerimeterX), rewrite operations to use CDP browser execution, or make a generated MCP server usable by Claude Code. Triggers on "generalize a recorded workflow", "rename MCP tools", "replace raw API params with readable names", "make the MCP usable by Claude Code", "generalize tool signatures", "I can't use the MCP tools", "Akamai is blocking", "429 with valid cookies", "TLS fingerprinting", "CDP fetch", "execute from inside the browser", "anti-bot workaround", "tabby credentials are empty", or "browser is authenticated but API calls fail".
+description: Use this skill when the user wants to generalize a recorded MCP workflow, rename tools to readable names, replace raw API params with natural-language parameters, fix bot detection issues (Akamai, Cloudflare, PerimeterX), rewrite operations to use browser execution, or make a generated MCP server usable by Claude Code. Triggers on "generalize a recorded workflow", "rename MCP tools", "replace raw API params with readable names", "make the MCP usable by Claude Code", "generalize tool signatures", "I can't use the MCP tools", "Akamai is blocking", "429 with valid cookies", "TLS fingerprinting", "execute fetch", "execute from inside the browser", "anti-bot workaround", "tabby credentials are empty", or "browser is authenticated but API calls fail".
 ---
 
 # NoUI Generalize
 
 Take a generated FastMCP server (or Skill) and make it **work** and **usable**:
 
-1. **Execution strategy** — generated servers execute inside the Tabby browser via CDP by default (see `/noui-record-workflow` → *How Execution Works*). This skill handles the edge cases: SPA content that needs navigation + DOM scraping, sites requiring HITL login, profiles that need credential-type fixes, or rare cases where the `--execution-mode http` fallback is the right call.
+1. **Execution strategy** — generated servers execute inside the Tabby browser via the `execute/fetch` endpoint by default (see `/noui-record-workflow` → *How Execution Works*). This skill handles the edge cases: sites requiring HITL login, profiles that need credential-type fixes, or rare cases where the `--execution-mode http` fallback is the right call.
 2. **Interface cleanup** — replace raw internal API parameters (`f_sid`, `bl`, `reqid`) with natural-language names (`origin`, `destination`, `departure_date`) so Claude Code can invoke tools without domain knowledge.
 
 **Prerequisite:** `/noui-record-workflow` must be complete and the MCP server must exist under `workbench/mcp_servers/`. For authenticated sites, `/noui-record-login` must also be complete with a running Tabby session.
@@ -30,12 +30,11 @@ After generalizing a skill, use `/noui-generate-skill` (not `/noui-generate-mcp`
 ## Critical Rules (Never Violate)
 
 - **NEVER** rewrite all tools at once — propose the new name and parameter list for each tool and get user approval before editing any files
-- **ALWAYS** preserve existing execution mechanics (URL, method, headers, CDP vs. httpx) unless deliberately switching modes — only the Python function interface changes
+- **ALWAYS** preserve existing execution mechanics (URL, method, headers, execute_fetch vs. httpx) unless deliberately switching modes — only the Python function interface changes
 - **ALWAYS** hardcode values that were static in the recording (session routing params, build labels, `bl`, `f_sid`, `reqid`, `soc_app`, etc.) — do not expose infrastructure params to the caller
 - **NEVER** ask questions that can be answered by reading the code or URL
-- `httpx` only appears in generated operations when `--execution-mode http` was used explicitly. Default generated operations use `noui_runtime.cdp.cdp_fetch`. If you see `httpx` in a default-mode server, something is wrong.
-- **ALWAYS** connect to the direct CDP port (`localhost:9222`) for `Runtime.evaluate` — the Tabby relay (`localhost:9223`) only allows screencast and input events.
-- **ALWAYS** use `credentials: 'include'` in browser-side `fetch()` calls — the generated `cdp_fetch` helper already does this; preserve it when hand-editing.
+- `httpx` only appears in generated operations when `--execution-mode http` was used explicitly. Default generated operations use `noui_runtime.execute.execute_fetch`. If you see `httpx` in a default-mode server, something is wrong.
+- **ALWAYS** use the `execute_fetch` adapter for browser-side requests — it calls Tabby's `POST /execute/fetch` endpoint, which runs `fetch(url, {credentials: 'include'})` inside the real browser. Preserve this when hand-editing.
 - **NEVER** assume "Login successful" in worker logs means login actually worked — CloakBrowser reports success when the DSL finishes, not when auth cookies appear. Always verify by checking cookies.
 - After rewriting, always remind the user to restart Claude Code to reload the updated tools
 
@@ -70,43 +69,44 @@ asyncio.run(test())
 | Result | Diagnosis | Next step |
 |---|---|---|
 | 200 with real data | Tool works — skip to Phase 2 (interface cleanup) |
-| `No Tabby page matching '<domain>'` | No tab open on the target site | Open the site in the Tabby browser, or `tabby session ensure --profile <id>` |
-| Connection refused on 9222 | Tabby session not running | `tabby session ensure --profile <id>` |
-| CORS error / `credentials include not allowed` | Cross-origin fetch blocked | Re-export with `--execution-mode http` |
-| 429 / "Too Many Requests" from CDP | Very rare — Akamai flagging in-browser too | Phase 1 — verify the account, consider HITL re-login |
-| Server was generated with `--execution-mode http` and returns 429 | httpx blocked by TLS fingerprinting | Re-export without `--execution-mode http` to land on the CDP default |
+| `No healthy Tabby session for profile` | Session not running or profile not HEALTHY | `tabby session ensure --profile <slug>` |
+| `TABBY_CLIENT_ID and TABBY_CLIENT_SECRET must be set` | Agent credentials missing | Set `TABBY_CLIENT_ID` and `TABBY_CLIENT_SECRET` in `noui/.env` |
+| CORS error / `credentials include not allowed` | Cross-origin fetch blocked | Re-export with `--execution-mode http` (error manifests as network error, not 403) |
+| 429 / "Rate limited by Tabby API" | Per-profile rate limit hit | Wait and retry, or adjust `EXECUTE_RATE_LIMIT_PER_MIN` on the Tabby API |
+| Server was generated with `--execution-mode http` and returns 429 | httpx blocked by TLS fingerprinting | Re-export without `--execution-mode http` to land on the execute-fetch default |
 | Empty credentials / `name: ""` (http mode only) | Tabby credential_types format bug | Phase 1, Fix A |
 | `No active profile found` (http mode only) | Profile still STAGING | Phase 1, Fix B |
 
-### 0c. Confirm bot detection (if 429)
+### 0c. Confirm bot detection (if 429 with http mode)
 
-Verify the browser itself can make the call:
+Verify the browser itself can make the call via the execute endpoint:
 
 ```python
-# Execute fetch from INSIDE the browser via CDP
-import asyncio, json, websockets, httpx
+# Execute fetch from INSIDE the browser via Tabby's execute/fetch endpoint
+import asyncio, json, httpx, os
 
 async def test():
-    resp = await httpx.AsyncClient().get("http://localhost:9222/json", timeout=5)
-    targets = resp.json()
-    ws_url = [t["webSocketDebuggerUrl"] for t in targets if t["type"] == "page"][0]
+    # Get agent token
+    api = os.environ.get("TABBY_API_HOST", "http://localhost:8000")
+    async with httpx.AsyncClient() as client:
+        token_resp = await client.post(f"{api}/auth/agent-token", json={
+            "client_id": os.environ["TABBY_CLIENT_ID"],
+            "client_secret": os.environ["TABBY_CLIENT_SECRET"],
+        })
+        token = token_resp.json()["access_token"]
 
-    js = """
-    fetch('/api/endpoint/test', { credentials: 'include' })
-      .then(r => r.text().then(t => JSON.stringify({status: r.status, body: t.substring(0, 200)})))
-    """
-    async with websockets.connect(ws_url) as ws:
-        await ws.send(json.dumps({
-            "id": 1, "method": "Runtime.evaluate",
-            "params": {"expression": js, "awaitPromise": True, "returnByValue": True}
-        }))
-        resp = json.loads(await ws.recv())
-        print(resp["result"]["result"]["value"])
+        # Execute fetch inside the browser
+        resp = await client.post(f"{api}/execute/fetch", json={
+            "profile_id": "<profile_slug>",
+            "url": "https://target-site.com/api/endpoint/test",
+            "method": "GET",
+        }, headers={"Authorization": f"Bearer {token}"})
+        print(json.dumps(resp.json(), indent=2)[:2000])
 
 asyncio.run(test())
 ```
 
-If 200 from browser but 429 from httpx → **confirmed TLS fingerprinting**. Proceed to Phase 1.
+If 200 from execute/fetch but 429 from httpx → **confirmed TLS fingerprinting**. The default execution mode (execute_fetch) already handles this. If the server was generated with `--execution-mode http`, re-export without that flag.
 
 ---
 
@@ -158,99 +158,60 @@ WHERE name ILIKE '%<app_name>%';
 
 ### Fix D — HITL login (when CloakBrowser fails)
 
-If the automated login DSL can't complete (Akamai blocks form interactions), log in manually:
+If the automated login DSL can't complete (Akamai blocks form interactions), log in manually via the Tabby VNC/CDP screencast viewer, then force re-export:
 
-1. Open Chrome → `chrome://inspect`
-2. Click "Configure..." → add `localhost:9222`
-3. Click **inspect** on the page target
-4. In DevTools Console: `window.location = 'https://example.com/login'`
-5. Complete login manually via the screencast panel
-6. Force re-export:
-   ```sql
-   UPDATE sessions SET artifacts_last_exported_at = NULL WHERE id = '<session_id>';
-   ```
+```sql
+UPDATE sessions SET artifacts_last_exported_at = NULL WHERE id = '<session_id>';
+```
 
-> **Port 9222 vs 9223:** Port 9222 is the direct CDP endpoint (full access). Port 9223 is Tabby's relay that only allows `Page.screencast*` and `Input.dispatch*Event`. Use 9222 for all workaround steps.
+### Fix E — Execute-fetch is the default (no rewrite needed)
 
-### Fix E — CDP execution is the default (no rewrite needed)
-
-CDP-based execution is now the **default** generated output. A recently exported
-server already has operations that call `find_page` and `cdp_fetch` from
-`noui_runtime/cdp.py`. If you are hand-editing or need to reason about the
-pattern, the primitives are:
+The execute-fetch adapter is now the **default** generated output. A recently
+exported server already has operations that call `execute_fetch` from
+`noui_runtime/execute.py`. If you are hand-editing or need to reason about the
+pattern:
 
 ```python
-from noui_runtime.cdp import find_page, cdp_fetch
+from noui_runtime.execute import execute_fetch
 
-ws_url = await find_page("api.example.com")           # match the recorded domain
-result = await cdp_fetch(                             # fetch inside the browser
-    ws_url,
+result = await execute_fetch(
+    "example-profile",                                # profile slug (set at compile time)
     "https://api.example.com/v1/items",
     method="POST",
     headers={"Accept": "application/json"},
-    body={"name": "x"},                               # JSON-encoded automatically
+    body={"name": "x"},                               # JSON-serialized automatically
 )
 ```
 
-`cdp_fetch` always sets `credentials: 'include'`. The full specification lives
-in `compiler/runtime/cdp_adapter.py`.
+`execute_fetch` calls Tabby's `POST /execute/fetch` endpoint, which runs
+`fetch(url, {credentials: 'include'})` inside the real browser. The full
+specification lives in `compiler/runtime/execute_adapter.py`.
 
 **When you still need to re-generate or hand-edit:**
 
 - The server was generated with `--execution-mode http` and keeps getting 429.
-  → Re-export without the flag to land on the CDP default.
-- You need SPA content that isn't exposed as a JSON API. → see *DOM-scrape
-  generalization* below.
+  → Re-export without the flag to land on the execute-fetch default.
 - The API truly cannot be reached from the browser origin (CORS, or
   server-to-server endpoint). → keep `--execution-mode http` and fix the
   underlying auth / credential issue instead.
 
-For the rationale (TLS fingerprinting, why 9222, why `credentials: 'include'`),
-see `/noui-record-workflow` → *How Execution Works*.
+For the rationale (TLS fingerprinting, why browser-side execution, why
+`credentials: 'include'`), see `/noui-record-workflow` → *How Execution Works*.
 
 ### DOM-scrape generalization (SPA-rendered content)
 
 When data is rendered by client-side JS and not available as a JSON API, the
-generated `cdp_fetch` path won't work — you need to navigate and scrape the
-rendered DOM. This is a hand-written generalization on top of the CDP default:
+`execute_fetch` path won't work — you need to navigate and scrape the rendered
+DOM. This requires the Tabby `POST /execute/browser` endpoint (see the
+extensionless autopilot plan) which provides `navigate`, `get_page_summary`,
+and other Playwright commands over HTTP.
 
-```python
-import asyncio, json
-import websockets
+Until `execute/browser` is available, DOM-scraping requires manual hand-editing
+with direct CDP access (localhost:9222), which only works in local development.
+For production use, prefer discovering the underlying JSON API that the SPA
+consumes — it's almost always there, and `execute_fetch` handles it cleanly.
 
-async def _navigate_and_scrape(ws_url: str, url: str, extract_js: str, wait_seconds: int = 7) -> dict:
-    """Navigate to a URL, wait for SPA render, then extract data via JS."""
-    async with websockets.connect(ws_url) as ws:
-        await ws.send(json.dumps({
-            "id": 1, "method": "Page.navigate", "params": {"url": url}
-        }))
-        await ws.recv()
-    await asyncio.sleep(wait_seconds)
-    # Reuse the CDP runtime's eval helper — same session, same cookies
-    from noui_runtime.cdp import cdp_eval
-    return await cdp_eval(ws_url, extract_js)
-```
-
-To find the right DOM selectors, inspect `data-stid` or similar attributes:
-
-```python
-# Discovery: list all data-stid values on the page
-js = """
-JSON.stringify([...new Set(
-  [...document.querySelectorAll('[data-stid]')]
-    .map(e => e.getAttribute('data-stid'))
-)].sort())
-"""
-```
-
-**What to change when adding DOM-scrape to an operation:**
-
-1. Keep `from noui_runtime.cdp import find_page, cdp_eval` (the default module already exposes both).
-2. Add `import asyncio, json, websockets` for `Page.navigate`.
-3. Replace the `cdp_fetch(...)` call with `_navigate_and_scrape(ws_url, target_url, extract_js)`.
-4. Extract the shape you need via a JS expression that returns `JSON.stringify(...)`.
-
-> **Single browser instance caveat:** Tabby runs one CloakBrowser per session. CDP navigation changes the page — if keepalive actions need the homepage, coordinate or set keepalive to `dom_check` on `body` only.
+> **Single browser instance caveat:** Tabby runs one CloakBrowser per session. Navigation changes the page — if keepalive actions need the homepage, coordinate or set keepalive to `dom_check` on `body` only.
 
 ---
 
@@ -303,7 +264,7 @@ Hardcoded (from recording):
   - reqid: <value>
   - soc_app: <value>
 
-Execution: CDP fetch / httpx (state which)
+Execution: execute_fetch / httpx (state which)
 
 Approve this? (yes / adjust: ...)
 ```
@@ -317,7 +278,7 @@ Once approved, make four edits:
    - New parameters are natural-language (`origin`, `destination`, etc.)
    - Infrastructure params are hardcoded as local variables
    - Build the raw request from the natural params (string formatting, encoding)
-   - Use CDP fetch if Phase 1 flagged bot detection; otherwise preserve the existing HTTP call
+   - Use execute_fetch if Phase 1 flagged bot detection; otherwise preserve the existing HTTP call
 
 2. **`tools.json`** — update the entry:
    - `name` → new tool name
@@ -360,9 +321,9 @@ When the user reports results, fix any issues:
 | Missing required parameter | Add it to signature and body |
 | Tool call fails with HTTP error | Read the error body, compare to original recording values |
 | Body encoding wrong | Check if original body was URL-encoded, JSON, or protobuf — reconstruct accordingly |
-| 429 from tool call on a CDP-default server | Verify Tabby has an authenticated tab open; if yes, the account may be flagged — redo HITL login (Phase 1, Fix D) |
-| 429 from tool call on `--execution-mode http` server | Re-export without the flag to use the CDP default |
-| CDP connection refused | Tabby session not running — `tabby session ensure --profile <id>` |
+| 429 from tool call on a default-mode server | Verify Tabby has a healthy session for the profile; if yes, the account may be flagged — redo HITL login (Phase 1, Fix D) |
+| 429 from tool call on `--execution-mode http` server | Re-export without the flag to use the execute-fetch default |
+| `No healthy Tabby session for profile` | Tabby session not running — `tabby session ensure --profile <slug>` |
 | `fetch()` returns 403 inside browser | Session expired — redo HITL login (Phase 1, Fix D) |
 
 Keep iterating until the user can successfully invoke the workflow using natural language.
@@ -385,7 +346,7 @@ When in doubt: if the value was the same every time during recording and doesn't
 
 ## Dynamic-Header-Injection Sites (JS-injected auth)
 
-Some SPAs acquire a short-lived bearer token in-memory (fetch from `/auth/init` or similar on page load), then wrap `window.fetch` / `XMLHttpRequest` with an interceptor that sets `Authorization: Bearer <jwt>` right before every XHR. The cookie jar is **empty** of auth material, `localStorage` / `sessionStorage` don't hold the bearer either, yet every real API call carries it. Calling the API from `cdp_fetch` with `credentials: 'include'` alone will get you a 401 or 403.
+Some SPAs acquire a short-lived bearer token in-memory (fetch from `/auth/init` or similar on page load), then wrap `window.fetch` / `XMLHttpRequest` with an interceptor that sets `Authorization: Bearer <jwt>` right before every XHR. The cookie jar is **empty** of auth material, `localStorage` / `sessionStorage` don't hold the bearer either, yet every real API call carries it. Calling the API via `execute_fetch` with `credentials: 'include'` alone will get you a 401 or 403.
 
 ### Detect
 
@@ -394,9 +355,9 @@ Some SPAs acquire a short-lived bearer token in-memory (fetch from `/auth/init` 
 - `localStorage` and `sessionStorage` dumps don't contain the bearer either.
 - The recorded API host is on a different subdomain from `www.*` (e.g. `api-prod-*`, `api.*`).
 
-### Workaround — CDP Network-event sniffing
+### Workaround — Sniff the Authorization header
 
-Enable CDP's `Network` domain, reload the page, listen for `Network.requestWillBeSent`, and grab the `Authorization` off the first request that matches your target host. Cache in `/tmp` with a TTL, invalidate on 401/403, retry once.
+The bearer token must be captured from the browser at runtime. Once the `POST /execute/browser` endpoint is available (extensionless autopilot plan), this can be done via `get_page_summary` or a targeted JS eval. Until then, this is a manual workaround requiring direct CDP access (localhost:9222, local dev only).
 
 Reference implementation (10-line core):
 
@@ -430,8 +391,8 @@ Sites of this shape often pair the dynamic JWT with a stable `user_key` / `x-api
 
 | Site | Bot Detection | CloakBrowser Login | Workaround |
 |---|---|---|---|
-| Expedia | Akamai Bot Manager | Form blocked silently; reaches homepage but can't submit | HITL login + CDP fetch + DOM scrape |
-| Generic SPA with JS-injected auth | Token not in cookies/localStorage; `Authorization` is set by a fetch interceptor in the page's JS bundle | n/a (site may be anonymous) | Sniff the `Authorization` via CDP `Network.requestWillBeSent` on page reload; cache per session. See *Dynamic-Header-Injection Sites* above. |
+| Expedia | Akamai Bot Manager | Form blocked silently; reaches homepage but can't submit | HITL login + execute_fetch |
+| Generic SPA with JS-injected auth | Token not in cookies/localStorage; `Authorization` is set by a fetch interceptor in the page's JS bundle | n/a (site may be anonymous) | Sniff the `Authorization` at runtime — see *Dynamic-Header-Injection Sites* above. |
 | IndiGo (`api-prod-*-skyplus6e.goindigo.in`) | Anonymous session; per-host `user_key` + rotating JWT; Akamai cookies | n/a | Hardcode per-host `user_key`s; sniff JWT at runtime. Reference: `indigo-flight-search` skill. |
 
 ---
@@ -439,9 +400,8 @@ Sites of this shape often pair the dynamic JWT with a stable `user_key` / `x-api
 ## Architecture Notes
 
 - **Why cookies alone fail:** Akamai fingerprints the TLS ClientHello, HTTP/2 settings frame, header order, and other transport-layer signals. `httpx`/`curl` have distinctly different fingerprints from Chrome, even with identical cookies.
-- **Why CDP works:** `Runtime.evaluate` + `fetch()` executes inside the real Chrome process. The HTTP request goes through Chrome's network stack with its native TLS implementation and fingerprint.
-- **Port 9222 vs 9223:** Port 9222 is the direct CDP endpoint (full access). Port 9223 is Tabby's relay proxy that only allows `Page.startScreencast`, `Page.stopScreencast`, `Page.screencastFrameAck`, and `Input.dispatch*Event`. Use 9222 for this workaround.
-- **Single browser instance:** Tabby runs one CloakBrowser per session. CDP navigation changes the page for that session — if keepalive needs the homepage, set keepalive health checks to `dom_check` on `body` rather than URL-based checks.
+- **Why browser-side execution works:** The Tabby worker runs `fetch()` inside the real Chrome process via `page.evaluate()`. The HTTP request goes through Chrome's network stack with its native TLS implementation and fingerprint. No WebSocket or CDP port exposure needed — the Tabby API routes the request to the worker pod.
+- **Single browser instance:** Tabby runs one CloakBrowser per session. Navigation changes the page for that session — if keepalive needs the homepage, set keepalive health checks to `dom_check` on `body` rather than URL-based checks.
 
 ---
 
@@ -465,7 +425,7 @@ Start
   │     └─ Phase 1: Fix D (HITL re-login) — the session or account is flagged
   │
   ├─ 429 on an `--execution-mode http` server?
-  │     └─ Re-export without the flag to land on the CDP default
+  │     └─ Re-export without the flag to land on the execute-fetch default
   │
   ├─ Empty credentials / name: "" (http mode)?
   │     └─ Phase 1: Fix A (credential_types format)
@@ -476,7 +436,7 @@ Start
   ├─ Login didn't actually work?
   │     └─ Phase 1: Fix D (HITL login)
   │
-  ├─ 401/403 on default CDP server, cookies appear correct?
+  ├─ 401/403 on default-mode server, cookies appear correct?
   │     └─ Check HAR: is `Authorization` present and does its JWT `jti` rotate across recordings?
   │         └─ Yes → Dynamic-header-injection pattern; see *Dynamic-Header-Injection Sites* section
   │

--- a/skills/noui-generate-mcp/SKILL.md
+++ b/skills/noui-generate-mcp/SKILL.md
@@ -11,7 +11,7 @@ All commands run from the `noui/` directory using `.venv/bin/python cli/main.py`
 
 **Prerequisite:** At least one server must exist under `workbench/mcp_servers/`. Run `/noui-record-workflow` first if none exist.
 
-**How requests are executed:** by default, each tool opens a WebSocket to Tabby's CDP endpoint and runs `fetch(..., {credentials: 'include'})` inside the authenticated browser. A live Tabby session with the target site open is required at invocation time. See `/noui-record-workflow` → *How Execution Works* for the full explanation and the `--execution-mode http` escape hatch.
+**How requests are executed:** by default, each tool calls Tabby's `POST /execute/fetch` endpoint, which runs `fetch(..., {credentials: 'include'})` inside the authenticated browser. A healthy Tabby session for the target profile is required at invocation time. See `/noui-record-workflow` → *How Execution Works* for the full explanation and the `--execution-mode http` escape hatch.
 
 ---
 
@@ -70,11 +70,11 @@ workbench/mcp_servers/<app_slug>/<server_id>/.mcp-<server_id>.log
 .venv/bin/python cli/main.py mcp status <server_id>
 ```
 
-For servers that use CDP (Akamai-protected sites like Expedia), status also shows browser session health:
+For servers that use the execute endpoint (browser-based execution), status also shows Tabby session health:
 
 ```
-  CDP       : ✓ reachable (localhost:9222)   ← worker is running
-  CDP       : ✗ not reachable (localhost:9222) ← run: noui tabby session ensure
+  Tabby     : ✓ session healthy              ← worker is running
+  Tabby     : ✗ no healthy session           ← run: tabby session ensure --profile <slug>
 ```
 
 ---
@@ -158,7 +158,7 @@ Start
 | `.venv/bin/python cli/main.py mcp list` | List all generated servers with running status |
 | `.venv/bin/python cli/main.py mcp start <server_id>` | Start a server process in the background |
 | `.venv/bin/python cli/main.py mcp stop <server_id>` | Stop a running server process |
-| `.venv/bin/python cli/main.py mcp status <server_id>` | Show running state, tool count, manifest path, and CDP reachability (for browser-based servers) |
+| `.venv/bin/python cli/main.py mcp status <server_id>` | Show running state, tool count, manifest path, and Tabby session health (for browser-based servers) |
 | `.venv/bin/python cli/main.py mcp docs <server_id>` | Regenerate `API.md` from current `tools.json` |
 | `.venv/bin/python cli/main.py mcp docs <server_id> --check` | Exit non-zero if `API.md` is stale (for CI / agent validation) |
 | `.venv/bin/python cli/main.py mcp verify <server_id>` | Run AuthVerifier — reports PASS / REPAIR_APPLIED / NEEDS_SECRET / UNSUPPORTED |
@@ -179,6 +179,6 @@ Start
 | Auth errors at runtime (authenticated server) | Run `mcp diagnose-auth <server_id>` — shows missing env vars and repair steps |
 | `NEEDS_SECRET <VAR>` from verify | Set `<VAR>=<value>` in `noui/.env` and re-run `mcp verify <server_id>` |
 | Server is v1 (no `auth_plan.json`) | Re-export with `workflow export --as mcp ... --profile-slug <slug> --verify` to upgrade to v2 |
-| Tool fails with "All connection attempts failed" | CDP-based server needs browser session — run `mcp status <server_id>` to check CDP, then `noui tabby session ensure` |
+| Tool fails with "No healthy Tabby session" | Browser-based server needs a healthy session — run `mcp status <server_id>` to check, then `tabby session ensure --profile <slug>` |
 | Tabby session shows HEALTHY but tools still fail | Worker crashed but DB state is stale — run `noui tabby session ensure` (auto-detects and restarts dead workers) |
 | Exported server has `profile_slug: null` | No `--profile-slug` was passed at export time — re-export: `workflow export --as mcp <session_id> --profile-slug <slug>` |

--- a/skills/noui-generate-skill/SKILL.md
+++ b/skills/noui-generate-skill/SKILL.md
@@ -145,7 +145,7 @@ Removes the skill from that specific agent's skills directory. If you installed 
 | `skill install` fails with "not found" | Run `skill list` to confirm the exact `skill_id`. `install` looks up by `skill_id` in `manifest.json`, not by folder name (though they are usually identical) |
 | Operation fails with `Missing TABBY_CLIENT_ID` | Set `TABBY_CLIENT_ID` / `TABBY_CLIENT_SECRET` in `noui/.env` or `~/.config/noui/.env`; the installed skill's runtime walks up from its own file to find these |
 | Operation fails with `Tabby returned empty credentials` | The Tabby session worker isn't live. Run `tabby session ensure --profile <slug>` |
-| Operation fails with 429 / bot detection | Rewrite the operation to use CDP browser-side `fetch()` — run `/noui-generalize` |
+| Operation fails with 429 / bot detection | Re-export with the default execution mode (execute_fetch via Tabby browser) — run `/noui-generalize` if already exported |
 | Need to pass a different Tabby profile for testing | Regenerate with `workflow export --as skill --profile-slug <other-slug>`, then re-install — re-exporting with a different slug updates `auth_plan.json` |
 | Installed to `codex` but Claude Code can't see the skill | Expected. Claude Code doesn't read `.agents/skills/`. Run `skill install <id> claude-code` too. |
 | Installed to `agents` but Cline can't see the skill | Expected. Cline's docs only list `.cline/skills/` and `.claude/skills/` as discovery paths. Run `skill install <id> cline` too. |

--- a/skills/noui-record-login/SKILL.md
+++ b/skills/noui-record-login/SKILL.md
@@ -7,7 +7,7 @@ description: Use this skill when the user wants to record a login flow for an au
 
 Record a login flow for an authenticated app and register it with Tabby to produce a `tabby_profile_id`. That ID is required when exporting a workflow as a FastMCP server for an app that needs authentication.
 
-**Runtime prerequisite:** the CDP-default execution path (see `/noui-record-workflow` → *How Execution Works*) needs a live Tabby browser session with the app loaded *at invocation time*, not only during recording. Plan to keep Tabby running wherever the generated MCP server or Skill is used.
+**Runtime prerequisite:** the default execution path (see `/noui-record-workflow` → *How Execution Works*) needs a healthy Tabby session for the profile *at invocation time*, not only during recording. Plan to keep Tabby running wherever the generated MCP server or Skill is used.
 
 All commands run from the `noui/` directory using `.venv/bin/python cli/main.py`.
 

--- a/skills/noui-record-workflow/SKILL.md
+++ b/skills/noui-record-workflow/SKILL.md
@@ -35,19 +35,26 @@ The default is `--as both`. The rest of this skill focuses on the MCP output (au
 ## How Execution Works
 
 Generated operations run **inside Tabby's authenticated browser** by default.
-Each operation:
+Each operation calls the Tabby API's `POST /execute/fetch` endpoint, which
+routes to the worker pod and runs `fetch()` inside the real browser via
+Playwright's `page.evaluate()`:
 
-1. Opens a WebSocket to Tabby's CDP endpoint at `localhost:9222`.
-2. Finds the tab whose URL matches the recorded domain (via `find_page`).
-3. Calls `cdp_fetch(ws_url, url, method=..., headers=..., body=...)`, which
-   runs `fetch(url, {credentials: 'include'})` via `Runtime.evaluate` — so the
-   real browser's cookies, TLS fingerprint, and origin are used.
+1. The operation calls `execute_fetch(PROFILE_SLUG, url, method=..., headers=...)`.
+2. The adapter exchanges agent credentials for a bearer token, then POSTs to
+   `{TABBY_API_HOST}/execute/fetch` with the profile ID, URL, and parameters.
+3. The Tabby API resolves the profile to a healthy session, routes to the
+   worker pod, and the worker runs `fetch(url, {credentials: 'include'})`
+   inside the authenticated browser — so the real browser's cookies, TLS
+   fingerprint, and origin are used.
 
-The two primitives live in the generated `noui_runtime/cdp.py` module:
+The runtime adapter lives in the generated `noui_runtime/execute.py` module:
 
 ```python
-from noui_runtime.cdp import find_page, cdp_fetch
+from noui_runtime.execute import execute_fetch
 ```
+
+No WebSocket, no CDP port access, no `websockets` dependency — plain HTTP
+from the MCP process to the Tabby API.
 
 ### Why this is the default
 
@@ -58,16 +65,19 @@ from noui_runtime.cdp import find_page, cdp_fetch
   Python HTTP clients.
 - **Safer under session refresh.** Cookie rotation is handled by the browser;
   the MCP never sees a stale cookie.
+- **No CDP exposure.** The MCP process never connects to Chromium's debug
+  protocol. The Tabby API is the only entry point, with its own auth and
+  rate limiting.
 
 ### Runtime prerequisites
 
-- Tabby must be running with a live session for the app.
-- A page on the target domain must be open in that session. If not, the first
-  call raises a clear error naming `tabby session ensure --profile <slug>`.
+- Tabby must be running with a healthy session for the profile.
+- `TABBY_API_HOST`, `TABBY_CLIENT_ID`, and `TABBY_CLIENT_SECRET` must be set
+  (in `noui/.env` or environment). If not, the first call raises a clear error.
 
 ### Escape hatch — `--execution-mode http`
 
-Switch to the legacy Python-side path when CDP cannot work:
+Switch to the legacy Python-side path when the execute endpoint cannot work:
 
 ```bash
 .venv/bin/python cli/main.py workflow export <session_id> --execution-mode http
@@ -77,7 +87,8 @@ Use `http` mode when:
 
 - The API is server-to-server and not reachable from the browser origin.
 - CORS blocks `credentials: 'include'` cross-origin (no
-  `Access-Control-Allow-Credentials: true`).
+  `Access-Control-Allow-Credentials: true`). The error manifests as a network
+  error, not an HTTP 403.
 - You are running the MCP on a host without a live Tabby.
 
 Under `--execution-mode http` the generator emits the classic
@@ -224,7 +235,8 @@ workbench/mcp_servers/<app_slug>/<server_id>/
 ├── API.md               # Human-readable API reference (auto-generated)
 ├── auth_plan.json       # Auth strategy + fallback recipes (Path A/B only; never stores secrets)
 ├── noui_runtime/
-│   └── auth.py          # Runtime auth adapter (2-step Tabby flow or static env var)
+│   ├── auth.py          # Runtime auth adapter (2-step Tabby flow or static env var)
+│   └── execute.py       # Execute adapter (calls Tabby's POST /execute/fetch)
 └── operations/
     └── <tool_name>.py   # One file per generated tool
 ```

--- a/skills/noui-setup/SKILL.md
+++ b/skills/noui-setup/SKILL.md
@@ -157,5 +157,5 @@ Start
 | Extension shows "Manifest file is missing" | Confirm you selected `noui/extension/` (the dir containing `manifest.json`) |
 | Extension loads but popup is blank | Check `chrome://extensions/` for errors; remove and re-load unpacked |
 | Port 8002 already in use on start | `lsof -i :8002` to find conflicting process; set `NOUI_PORT=8003` in `.env` to use another port |
-| Generated tool raises "No Tabby page matching ..." | Open the target site in the Tabby browser, or `tabby session ensure --profile <slug>` |
-| Generated tool raises `Connection refused` on port 9222 | Tabby's CDP endpoint is down — `tabby session ensure --profile <slug>` |
+| Generated tool raises "No healthy Tabby session for profile" | Tabby session not running — `tabby session ensure --profile <slug>` |
+| Generated tool raises "TABBY_CLIENT_ID and TABBY_CLIENT_SECRET must be set" | Agent credentials missing — set them in `noui/.env` |

--- a/tests/test_compile_workflow.py
+++ b/tests/test_compile_workflow.py
@@ -224,9 +224,7 @@ class TestStaticApiKeyApp:
                 assert "resolve_auth" not in content, (
                     f"{path}: resolve_auth() must not be used under CDP default"
                 )
-                assert "PROFILE_SLUG" in content, (
-                    f"{path}: PROFILE_SLUG constant must be embedded"
-                )
+                assert "PROFILE_SLUG" in content, f"{path}: PROFILE_SLUG constant must be embedded"
 
     def test_manifest_profile_slug_not_uuid(self) -> None:
         auth = self.manifest["auth"]
@@ -524,7 +522,9 @@ class TestCdpIsDefault:
         self.manifest, self.files = _compile(har, app_slug="defapp", profile_slug="defapp")
 
     def test_execute_runtime_module_written(self) -> None:
-        assert "noui_runtime/execute.py" in self.files, "CDP default must write noui_runtime/execute.py"
+        assert "noui_runtime/execute.py" in self.files, (
+            "CDP default must write noui_runtime/execute.py"
+        )
 
     def test_no_cdp_runtime_written(self) -> None:
         assert "noui_runtime/cdp.py" not in self.files, "CDP mode should no longer write cdp.py"
@@ -550,16 +550,12 @@ class TestCdpIsDefault:
     def test_no_websockets_in_operations(self) -> None:
         for p, content in self.files.items():
             if p.startswith("operations/") and p.endswith(".py") and p != "operations/__init__.py":
-                assert "websockets" not in content, (
-                    f"{p}: websockets must not appear in operations"
-                )
+                assert "websockets" not in content, f"{p}: websockets must not appear in operations"
 
     def test_operations_have_profile_slug(self) -> None:
         for p, content in self.files.items():
             if p.startswith("operations/") and p.endswith(".py") and p != "operations/__init__.py":
-                assert "PROFILE_SLUG" in content, (
-                    f"{p}: operations must reference PROFILE_SLUG"
-                )
+                assert "PROFILE_SLUG" in content, f"{p}: operations must reference PROFILE_SLUG"
 
     def test_manifest_execution_strategy(self) -> None:
         assert self.manifest["auth"]["execution_strategy"] == "tabby_execute_fetch"

--- a/tests/test_compile_workflow.py
+++ b/tests/test_compile_workflow.py
@@ -209,23 +209,23 @@ class TestStaticApiKeyApp:
             "runtime_identifier must be the slug, never the UUID"
         )
 
-    def test_operations_use_cdp_fetch(self) -> None:
-        """Default execution mode (cdp) wires operations through noui_runtime.cdp."""
+    def test_operations_use_execute_fetch(self) -> None:
+        """Default execution mode (cdp) wires operations through noui_runtime.execute."""
         for path, content in self.files.items():
             if (
                 path.startswith("operations/")
                 and path.endswith(".py")
                 and path != "operations/__init__.py"
             ):
-                assert "from noui_runtime.cdp import" in content, (
-                    f"{path} must import from noui_runtime.cdp under CDP default"
+                assert "from noui_runtime.execute import" in content, (
+                    f"{path} must import from noui_runtime.execute under CDP default"
                 )
-                assert "cdp_fetch" in content, f"{path} must call cdp_fetch()"
+                assert "execute_fetch" in content, f"{path} must call execute_fetch()"
                 assert "resolve_auth" not in content, (
                     f"{path}: resolve_auth() must not be used under CDP default"
                 )
-                assert "TABBY_PROFILE_ID" not in content, (
-                    f"{path}: TABBY_PROFILE_ID constant must not be embedded"
+                assert "PROFILE_SLUG" in content, (
+                    f"{path}: PROFILE_SLUG constant must be embedded"
                 )
 
     def test_manifest_profile_slug_not_uuid(self) -> None:
@@ -509,7 +509,7 @@ class TestOutputFiles:
 
 
 class TestCdpIsDefault:
-    """Not passing execution_mode must produce CDP-based operations and a cdp.py runtime."""
+    """Not passing execution_mode must produce execute-adapter operations and execute.py runtime."""
 
     def setup_method(self) -> None:
         har = _har(
@@ -523,10 +523,13 @@ class TestCdpIsDefault:
         )
         self.manifest, self.files = _compile(har, app_slug="defapp", profile_slug="defapp")
 
-    def test_cdp_runtime_module_written(self) -> None:
-        assert "noui_runtime/cdp.py" in self.files, "CDP default must write noui_runtime/cdp.py"
+    def test_execute_runtime_module_written(self) -> None:
+        assert "noui_runtime/execute.py" in self.files, "CDP default must write noui_runtime/execute.py"
 
-    def test_operations_import_cdp(self) -> None:
+    def test_no_cdp_runtime_written(self) -> None:
+        assert "noui_runtime/cdp.py" not in self.files, "CDP mode should no longer write cdp.py"
+
+    def test_operations_import_execute_fetch(self) -> None:
         op_paths = [
             p
             for p in self.files
@@ -534,8 +537,8 @@ class TestCdpIsDefault:
         ]
         assert op_paths, "expected at least one operation"
         for p in op_paths:
-            assert "from noui_runtime.cdp import" in self.files[p]
-            assert "cdp_fetch" in self.files[p]
+            assert "from noui_runtime.execute import" in self.files[p]
+            assert "execute_fetch" in self.files[p]
 
     def test_no_httpx_in_operations(self) -> None:
         for p, content in self.files.items():
@@ -544,19 +547,33 @@ class TestCdpIsDefault:
                     f"{p}: httpx must not appear in CDP-default operations"
                 )
 
-    def test_manifest_execution_strategy_is_cdp(self) -> None:
-        assert self.manifest["auth"]["execution_strategy"] == "cdp_browser_session"
+    def test_no_websockets_in_operations(self) -> None:
+        for p, content in self.files.items():
+            if p.startswith("operations/") and p.endswith(".py") and p != "operations/__init__.py":
+                assert "websockets" not in content, (
+                    f"{p}: websockets must not appear in operations"
+                )
+
+    def test_operations_have_profile_slug(self) -> None:
+        for p, content in self.files.items():
+            if p.startswith("operations/") and p.endswith(".py") and p != "operations/__init__.py":
+                assert "PROFILE_SLUG" in content, (
+                    f"{p}: operations must reference PROFILE_SLUG"
+                )
+
+    def test_manifest_execution_strategy(self) -> None:
+        assert self.manifest["auth"]["execution_strategy"] == "tabby_execute_fetch"
 
     def test_manifest_auth_strategy_unchanged(self) -> None:
         """auth.strategy continues to describe the credential-source strategy."""
         assert self.manifest["auth"]["strategy"] == "static_secret_header"
 
-    def test_cdp_runtime_compiles(self) -> None:
+    def test_execute_runtime_compiles(self) -> None:
         import py_compile
         import tempfile
 
         with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
-            f.write(self.files["noui_runtime/cdp.py"])
+            f.write(self.files["noui_runtime/execute.py"])
             path = f.name
         py_compile.compile(path, doraise=True)
 
@@ -589,8 +606,10 @@ class TestHttpExecutionMode:
                 assert "import httpx" in content
                 assert "resolve_auth" in content
                 assert "from noui_runtime.cdp" not in content
+                assert "from noui_runtime.execute" not in content
 
-    def test_no_cdp_runtime_written(self) -> None:
+    def test_no_execute_runtime_written(self) -> None:
+        assert "noui_runtime/execute.py" not in self.files
         assert "noui_runtime/cdp.py" not in self.files
 
     def test_manifest_execution_strategy_mirrors_auth_strategy(self) -> None:

--- a/tests/test_compile_workflow_to_skill.py
+++ b/tests/test_compile_workflow_to_skill.py
@@ -303,8 +303,8 @@ class TestSharedRuntime:
         mcp_auth = (mcp_out / "noui_runtime" / "auth.py").read_bytes()
         assert skill_auth == mcp_auth
 
-    def test_cdp_py_matches_mcp_output(self) -> None:
-        """noui_runtime/cdp.py must be byte-identical for skill and MCP outputs."""
+    def test_execute_py_matches_mcp_output(self) -> None:
+        """noui_runtime/execute.py must be byte-identical for skill and MCP outputs."""
         from compiler.mcp.server_generator import compile_workflow
 
         har = _har([_entry("https://api.example.com/v1/widgets")])
@@ -330,9 +330,9 @@ class TestSharedRuntime:
             url_events=[],
             output_dir=str(mcp_out),
         )
-        skill_cdp = (skill_out / "noui_runtime" / "cdp.py").read_bytes()
-        mcp_cdp = (mcp_out / "noui_runtime" / "cdp.py").read_bytes()
-        assert skill_cdp == mcp_cdp
+        skill_execute = (skill_out / "noui_runtime" / "execute.py").read_bytes()
+        mcp_execute = (mcp_out / "noui_runtime" / "execute.py").read_bytes()
+        assert skill_execute == mcp_execute
 
 
 # ---------------------------------------------------------------------------
@@ -341,22 +341,23 @@ class TestSharedRuntime:
 
 
 class TestSkillCdpDefault:
-    """Skill compiler must match the MCP compiler's CDP default."""
+    """Skill compiler must match the MCP compiler's execute-fetch default."""
 
-    def test_cdp_runtime_written(self) -> None:
+    def test_execute_runtime_written(self) -> None:
         out, _ = _compile(_har([_entry("https://api.example.com/v1/widgets")]))
-        assert (out / "noui_runtime" / "cdp.py").is_file()
+        assert (out / "noui_runtime" / "execute.py").is_file()
+        assert not (out / "noui_runtime" / "cdp.py").exists()
 
-    def test_operations_import_cdp(self) -> None:
+    def test_operations_import_execute_fetch(self) -> None:
         out, manifest = _compile(_har([_entry("https://api.example.com/v1/widgets?id=1")]))
         op_name = manifest["operations"][0]["name"]
         src = (out / "operations" / f"{op_name}.py").read_text()
-        assert "from noui_runtime.cdp import" in src
-        assert "cdp_fetch" in src
+        assert "from noui_runtime.execute import" in src
+        assert "execute_fetch" in src
         assert "import httpx" not in src
         assert "resolve_auth" not in src
 
-    def test_manifest_execution_strategy_cdp(self) -> None:
+    def test_manifest_execution_strategy(self) -> None:
         har = _har(
             [
                 _entry(
@@ -366,7 +367,7 @@ class TestSkillCdpDefault:
             ]
         )
         _, manifest = _compile(har, profile_slug="example")
-        assert manifest["auth"]["execution_strategy"] == "cdp_browser_session"
+        assert manifest["auth"]["execution_strategy"] == "tabby_execute_fetch"
 
 
 class TestSkillHttpExecutionMode:
@@ -390,12 +391,14 @@ class TestSkillHttpExecutionMode:
         assert "import httpx" in src
         assert "resolve_auth" in src
         assert "from noui_runtime.cdp" not in src
+        assert "from noui_runtime.execute" not in src
 
-    def test_no_cdp_runtime_written(self) -> None:
+    def test_no_execute_runtime_written(self) -> None:
         out, _ = _compile(
             _har([_entry("https://api.example.com/widgets")]),
             execution_mode="http",
         )
+        assert not (out / "noui_runtime" / "execute.py").exists()
         assert not (out / "noui_runtime" / "cdp.py").exists()
 
     def test_manifest_execution_strategy_mirrors_auth_strategy(self) -> None:

--- a/tests/test_tool_generator.py
+++ b/tests/test_tool_generator.py
@@ -212,25 +212,24 @@ class TestOperationStructure:
 
 
 class TestCdpModeRender:
-    """CDP-mode invariants for _render_operation (now the default)."""
+    """Execute-fetch mode invariants for _render_operation (the default)."""
 
-    def test_imports_cdp_runtime(self) -> None:
+    def test_imports_execute_runtime(self) -> None:
         src = _render_cdp(_simple_tool(), auth_plan=_tabby_auth_plan())
-        assert "from noui_runtime.cdp import" in src
-        assert "cdp_fetch" in src
-        assert "find_page" in src
+        assert "from noui_runtime.execute import" in src
+        assert "execute_fetch" in src
 
     def test_no_httpx_or_resolve_auth(self) -> None:
         src = _render_cdp(_simple_tool(), auth_plan=_tabby_auth_plan())
         assert "import httpx" not in src
         assert "resolve_auth" not in src
 
-    def test_cdp_host_match_embedded(self) -> None:
-        """CDP_HOST_MATCH must come from the base_url's netloc so find_page finds the page."""
+    def test_profile_slug_embedded(self) -> None:
+        """PROFILE_SLUG must come from the auth_plan so execute_fetch can resolve the session."""
         src = _render_cdp(
             _simple_tool(base_url="https://api.myapp.com"), auth_plan=_tabby_auth_plan()
         )
-        assert "CDP_HOST_MATCH = 'api.myapp.com'" in src
+        assert "PROFILE_SLUG = 'example-bank'" in src
 
     def test_base_url_still_embedded(self) -> None:
         src = _render_cdp(
@@ -239,16 +238,11 @@ class TestCdpModeRender:
         assert "https://api.myapp.com" in src
 
     def test_recorded_headers_preserved(self) -> None:
-        """Recorded static headers must still be passed to cdp_fetch."""
+        """Recorded static headers must still be passed to execute_fetch."""
         tool = _simple_tool(request_headers=[{"name": "Accept", "value": "application/json"}])
         src = _render_cdp(tool, auth_plan={})
         assert "'Accept'" in src or '"Accept"' in src
         assert "'application/json'" in src or '"application/json"' in src
-
-    def test_raises_when_no_page_target(self) -> None:
-        src = _render_cdp(_simple_tool(), auth_plan=_tabby_auth_plan())
-        assert "No Tabby page matching" in src
-        assert "--execution-mode http" in src
 
     def test_query_params_url_encoded(self) -> None:
         tool = _simple_tool(
@@ -257,8 +251,8 @@ class TestCdpModeRender:
         src = _render_cdp(tool, auth_plan={})
         assert "urllib.parse.urlencode" in src
 
-    def test_unauth_still_generates_cdp(self) -> None:
-        """Even with no auth, CDP mode still generates in-browser execution."""
+    def test_unauth_still_generates_execute_fetch(self) -> None:
+        """Even with no auth, default mode still generates in-browser execution."""
         src = _render_cdp(_simple_tool(), auth_plan={})
-        assert "cdp_fetch" in src
-        assert "find_page" in src
+        assert "execute_fetch" in src
+        assert "PROFILE_SLUG" in src


### PR DESCRIPTION
## Summary

- New `compiler/runtime/execute_adapter.py`: generates `noui_runtime/execute.py` with `execute_fetch()` that calls Tabby's `POST /execute/fetch` via httpx — no WebSocket, no `websockets` dependency
- `server_generator.py`: CDP mode now writes `execute.py` (not `cdp.py`), renders operations with `execute_fetch` + `PROFILE_SLUG` instead of `cdp_fetch` + `find_page`
- `skill_generator.py` + `operation_generator.py`: lockstep changes, removed `websockets` from generated `pyproject.toml`
- Manifest `execution_strategy` changed from `"cdp_browser_session"` to `"tabby_execute_fetch"`
- Updated all 8 NoUI skill SKILL.md files to document the new execution architecture

## Depends on

- adoptai/tabby#55 — the Tabby-side `POST /execute/fetch` endpoint this adapter calls

## Test plan

- [x] 57 MCP compile tests pass (`test_compile_workflow.py`)
- [x] 26 skill compile tests pass (`test_compile_workflow_to_skill.py`)
- [x] Generated `execute.py` compiles cleanly (`py_compile`)
- [x] HTTP mode tests unchanged and passing
- [x] End-to-end: export a workflow, invoke a tool against a live Tabby session with the execute endpoint deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)