### PR TITLE
feat(skills): Best Buy search, cart, and checkout skill with human-in-the-loop

### DIFF
--- a/backend/ecommerce/__init__.py
+++ b/backend/ecommerce/__init__.py
@@ -1,0 +1,7 @@
+"""E-commerce agent package.
+
+Implements a human-confirmed e-commerce shopping agent on top of the NoUI
+browser command bridge. The agent can search, browse, and add items to cart
+across the top 20 global e-commerce sites, but always pauses for explicit
+user confirmation before any final checkout/payment action.
+"""

--- a/backend/ecommerce/agent.py
+++ b/backend/ecommerce/agent.py
@@ -1,0 +1,981 @@
+"""E-commerce agent core: run state machine, planner, and audit trail.
+
+The agent is *not* a fully autonomous LLM: it composes a small number of
+deterministic browser actions per state transition, persists every action
+to the audit log, and pauses for explicit user confirmation before any
+side effect that is not in the run's allow-list.
+
+This module never clicks final order/payment buttons under any
+circumstance — the policy gate + detection step in `safety.py` enforce
+that contract.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.ecommerce import browser_commands as bc
+from backend.ecommerce.models import (
+    EcommerceAgentEvent,
+    EcommerceAgentRun,
+    EcommerceProductCandidate,
+)
+from backend.ecommerce.ranking import normalize_candidate, rank_candidates
+from backend.ecommerce.safety import (
+    HARD_FORBIDDEN,
+    SIDE_EFFECT_ADD_TO_CART,
+    SIDE_EFFECT_PROCEED_TO_CHECKOUT,
+    AgentPolicy,
+    classify_action,
+)
+from backend.ecommerce.site_catalog import (
+    all_slugs,
+    get_profile,
+    is_forbidden_label,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Valid run statuses (kept loose; documented in models.py).
+class RunStatus:
+    CREATED = "created"
+    SEARCHING = "searching"
+    AWAITING_SELECTION = "awaiting_selection"
+    SELECTED = "selected"
+    ADDING_TO_CART = "adding_to_cart"
+    AWAITING_CART_CONFIRMATION = "awaiting_cart_confirmation"
+    IN_CART = "in_cart"
+    AWAITING_CHECKOUT_CONFIRMATION = "awaiting_checkout_confirmation"
+    AT_CHECKOUT_BOUNDARY = "at_checkout_boundary"
+    COMPLETED = "completed"
+    NEEDS_USER = "needs_user"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+# Default candidate cap surfaced to the user per search.
+MAX_CANDIDATES = 12
+
+# Retry actions reuse an existing side-effect's policy entry. The retry
+# action is just a labelled checkpoint that re-runs the same handler after
+# a transient block (sign-in wall, captcha) has been cleared.
+_ACTION_ALIAS: dict[str, str] = {
+    "retry_add_to_cart": SIDE_EFFECT_ADD_TO_CART,
+}
+
+
+@dataclass(frozen=True)
+class Checkpoint:
+    """Confirmation prompt the user must answer before the agent continues."""
+
+    action: str
+    label: str
+    detail: str
+    candidate_id: str | None = None
+    metadata: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "action": self.action,
+            "label": self.label,
+            "detail": self.detail,
+            "candidate_id": self.candidate_id,
+            "metadata": self.metadata or {},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Audit log helpers
+# ---------------------------------------------------------------------------
+
+
+async def _log_event(
+    db: AsyncSession,
+    run: EcommerceAgentRun,
+    *,
+    event_type: str,
+    summary: str = "",
+    payload: dict[str, Any] | None = None,
+    severity: str = "info",
+) -> None:
+    event = EcommerceAgentEvent(
+        run_id=run.id,
+        event_type=event_type,
+        severity=severity,
+        summary=summary,
+        payload_json=json.dumps(payload or {}, default=str),
+    )
+    db.add(event)
+    # We flush so concurrent reads see the new event without waiting for a
+    # higher-level commit, but the commit is the caller's responsibility.
+    await db.flush()
+
+
+def _decode_list(json_text: str) -> list[str]:
+    try:
+        value = json.loads(json_text or "[]")
+        if isinstance(value, list):
+            return [str(item) for item in value]
+    except json.JSONDecodeError:
+        logger.warning("Failed to decode allow/forbid JSON: %r", json_text)
+    return []
+
+
+def _policy_for(run: EcommerceAgentRun) -> AgentPolicy:
+    return AgentPolicy.from_lists(
+        _decode_list(run.allowed_side_effects_json),
+        _decode_list(run.forbidden_side_effects_json),
+    )
+
+
+def _set_checkpoint(run: EcommerceAgentRun, checkpoint: Checkpoint | None) -> None:
+    run.pending_checkpoint_json = json.dumps(checkpoint.to_dict()) if checkpoint else ""
+
+
+def get_checkpoint(run: EcommerceAgentRun) -> Checkpoint | None:
+    raw = run.pending_checkpoint_json
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return Checkpoint(
+        action=data.get("action", ""),
+        label=data.get("label", ""),
+        detail=data.get("detail", ""),
+        candidate_id=data.get("candidate_id"),
+        metadata=data.get("metadata") or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Run lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def create_run(
+    db: AsyncSession,
+    *,
+    site_slug: str,
+    query: str,
+    region: str = "",
+    currency: str = "",
+    max_price: float | None = None,
+    min_rating: float | None = None,
+    shipping_preference: str = "",
+    notes: str = "",
+    allowed_side_effects: list[str] | None = None,
+    forbidden_side_effects: list[str] | None = None,
+) -> EcommerceAgentRun:
+    """Create a new agent run record after validating the site slug."""
+    slug = site_slug.strip().lower()
+    if slug not in all_slugs():
+        raise ValueError(
+            f"Unknown e-commerce site slug: {site_slug!r}. "
+            f"Valid slugs: {', '.join(all_slugs())}"
+        )
+    if not query.strip():
+        raise ValueError("query must be non-empty")
+
+    policy = AgentPolicy.from_lists(allowed_side_effects, forbidden_side_effects)
+
+    run = EcommerceAgentRun(
+        status=RunStatus.CREATED,
+        site_slug=slug,
+        query=query.strip(),
+        region=region.strip(),
+        currency=currency.strip().upper(),
+        max_price=str(max_price) if max_price is not None else "",
+        min_rating=str(min_rating) if min_rating is not None else "",
+        shipping_preference=shipping_preference.strip(),
+        notes=notes.strip(),
+        allowed_side_effects_json=json.dumps(sorted(policy.allowed_side_effects)),
+        forbidden_side_effects_json=json.dumps(sorted(policy.forbidden_side_effects)),
+    )
+    db.add(run)
+    await db.flush()
+    await _log_event(
+        db,
+        run,
+        event_type="run_created",
+        summary=f"Run created for {slug} query={query!r}",
+        payload={
+            "allowed": sorted(policy.allowed_side_effects),
+            "forbidden": sorted(policy.forbidden_side_effects),
+        },
+    )
+    await db.commit()
+    await db.refresh(run)
+    return run
+
+
+async def search(
+    db: AsyncSession,
+    run: EcommerceAgentRun,
+    executor: bc.BrowserExec,
+) -> EcommerceAgentRun:
+    """Drive the browser to the search results page and surface candidates.
+
+    On success the run transitions to ``awaiting_selection`` with a list of
+    `EcommerceProductCandidate` rows attached.
+    """
+    profile = get_profile(run.site_slug)
+    run.status = RunStatus.SEARCHING
+    run.updated_at = datetime.now(UTC)
+    search_url = profile.build_search_url(run.query)
+    await _log_event(
+        db,
+        run,
+        event_type="search_start",
+        summary=f"Navigating to {search_url}",
+        payload={"site": run.site_slug, "query": run.query, "url": search_url},
+    )
+    await db.commit()
+
+    try:
+        await bc.navigate(executor, search_url)
+    except Exception as exc:  # pragma: no cover — bridge errors are reported back
+        await _fail_run(db, run, f"navigation failed: {exc}", event_type="navigate_failed")
+        raise
+
+    # Critical: chrome.tabs.update() resolves the moment navigation is
+    # initiated, not when the new page is loaded. Without an explicit wait
+    # the extractor below would race against the previous page (or an empty
+    # document) and return zero cards. Wait for both URL and at least one
+    # card selector to materialize before scraping.
+    ready_info: dict[str, Any] = {}
+    try:
+        ready_info = await bc.wait_for_page_ready(executor, profile, search_url)
+    except Exception as exc:  # pragma: no cover — diagnostic only
+        logger.debug("wait_for_page_ready failed: %s", exc)
+    await _log_event(
+        db,
+        run,
+        event_type="page_ready",
+        summary=(
+            f"Page ready={ready_info.get('ready', False)} "
+            f"selector={ready_info.get('matched_selector', '') or 'none'} "
+            f"url={ready_info.get('url', '') or search_url}"
+        ),
+        payload=ready_info,
+    )
+
+    try:
+        raw = await bc.extract_product_cards_robust(
+            executor, profile, limit=MAX_CANDIDATES
+        )
+    except Exception as exc:  # pragma: no cover — defensive
+        await _fail_run(db, run, f"product extraction failed: {exc}", event_type="extract_failed")
+        raise
+
+    raw_cards = raw.get("candidates") or []
+    normalized = [
+        normalize_candidate(card, default_currency=profile.currency) for card in raw_cards
+    ]
+    normalized = [c for c in normalized if c["title"]]
+    max_price = _safe_float(run.max_price)
+    min_rating = _safe_float(run.min_rating)
+    ranked = rank_candidates(
+        normalized,
+        max_price=max_price,
+        min_rating=min_rating,
+    )
+
+    for c in ranked:
+        candidate = EcommerceProductCandidate(
+            run_id=run.id,
+            rank=c["rank"],
+            title=c["title"][:1000],
+            url=c["url"][:1000],
+            image_url=c["image_url"][:1000],
+            price_text=c["price_text"][:80],
+            price_amount=_fmt_number(c["price_amount"]),
+            currency=(c["currency"] or "")[:10],
+            rating_text=c["rating_text"][:40],
+            rating_value=_fmt_number(c["rating_value"]),
+            review_count=_fmt_number(c["review_count"]),
+            seller=c["seller"][:200],
+            shipping_text=c["shipping_text"][:200],
+            availability=c["availability"][:60],
+            score=_fmt_number(c["score"]),
+        )
+        db.add(candidate)
+
+    if not ranked:
+        bot_hint = bool(ready_info.get("bot_check_hint"))
+        final_url = ready_info.get("url", "") or search_url
+        page_title = ready_info.get("title", "")
+        await _log_event(
+            db,
+            run,
+            event_type="search_empty",
+            severity="warn",
+            summary="No product candidates found",
+            payload={
+                "raw_total": raw.get("total_cards", 0),
+                "primary_total_cards": raw.get("primary_total_cards", 0),
+                "extractor_source": raw.get("source", ""),
+                "matched_selector": ready_info.get("matched_selector", ""),
+                "ready": ready_info.get("ready", False),
+                "final_url": final_url,
+                "page_title": page_title,
+                "bot_check_hint": bot_hint,
+            },
+        )
+        run.status = RunStatus.NEEDS_USER
+        if bot_hint:
+            detail = (
+                f"{profile.name} appears to be showing a captcha or bot-check page "
+                f"(url={final_url!r}, title={page_title!r}). Solve it in the browser "
+                f"tab, then start a new run. The query was {run.query!r}."
+            )
+        elif not ready_info.get("ready", False) and not ready_info.get("matched_selector"):
+            detail = (
+                f"The search results page never finished loading the expected product "
+                f"cards on {profile.name} (url={final_url!r}). The selectors may be "
+                f"out of date, or the page may need user interaction (cookie banner, "
+                f"region picker). Query: {run.query!r}."
+            )
+        else:
+            detail = (
+                f"No product candidates were detected for query {run.query!r} on "
+                f"{profile.name}. The site rendered (url={final_url!r}) but neither "
+                f"the site-specific extractor nor the generic price+link fallback "
+                f"matched any cards. The selectors may need updating."
+            )
+        _set_checkpoint(
+            run,
+            Checkpoint(
+                action="select_product",
+                label="No products found",
+                detail=detail,
+                metadata={
+                    "final_url": final_url,
+                    "page_title": page_title,
+                    "bot_check_hint": bot_hint,
+                },
+            ),
+        )
+    else:
+        run.status = RunStatus.AWAITING_SELECTION
+        _set_checkpoint(
+            run,
+            Checkpoint(
+                action="select_product",
+                label="Pick a candidate",
+                detail=(
+                    f"Found {len(ranked)} candidate{'s' if len(ranked) != 1 else ''} for "
+                    f"{run.query!r} on {profile.name}. Choose one to add to cart."
+                ),
+                metadata={"candidate_count": len(ranked)},
+            ),
+        )
+        await _log_event(
+            db,
+            run,
+            event_type="search_ranked",
+            summary=f"Ranked {len(ranked)} candidates",
+            payload={"count": len(ranked)},
+        )
+
+    run.updated_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(run)
+    return run
+
+
+async def auto_advance_after_search(
+    db: AsyncSession,
+    run: EcommerceAgentRun,
+    executor: bc.BrowserExec,
+) -> EcommerceAgentRun:
+    """Run the full pre-checkout pipeline without waiting for user input.
+
+    Picks the top-ranked candidate, adds it to the cart, then leaves the
+    run at ``awaiting_checkout_confirmation`` so the user only has to
+    approve the proceed-to-checkout step. Used by the ``auto_pilot``
+    mode on ``POST /runs``.
+
+    No-op when the run is not in ``awaiting_selection`` (e.g. a captcha
+    interstitial left it at ``needs_user``).
+    """
+    if run.status != RunStatus.AWAITING_SELECTION:
+        return run
+
+    candidates = await list_candidates(db, run.id)
+    if not candidates:
+        return run
+
+    top = candidates[0]
+    await _log_event(
+        db,
+        run,
+        event_type="auto_selected",
+        summary=f"Auto-picked top candidate rank={top.rank} title={top.title!r}",
+        payload={"candidate_id": top.id, "title": top.title, "url": top.url},
+    )
+    run, _ = await select_candidate(db, run, executor, top.id)
+
+    # Skip the manual add-to-cart confirmation and execute it directly.
+    if run.status != RunStatus.AWAITING_CART_CONFIRMATION:
+        return run
+
+    await _log_event(
+        db,
+        run,
+        event_type="auto_add_to_cart",
+        summary="Auto-confirming add-to-cart without user prompt",
+    )
+    _set_checkpoint(run, None)
+    await _execute_add_to_cart(db, run, executor)
+    run.updated_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(run)
+    return run
+
+
+async def select_candidate(
+    db: AsyncSession,
+    run: EcommerceAgentRun,
+    executor: bc.BrowserExec,
+    candidate_id: str,
+) -> tuple[EcommerceAgentRun, Checkpoint]:
+    """Record the user's selection and ask whether to add the item to cart.
+
+    The agent does **not** click "Add to cart" here — even though that
+    action is usually in the allow-list, we still surface a confirmation
+    checkpoint so the user has a clear record of every side effect.
+    """
+    candidate = await _get_candidate(db, run, candidate_id)
+
+    run.selected_candidate_id = candidate.id
+    run.status = RunStatus.SELECTED
+    await _log_event(
+        db,
+        run,
+        event_type="candidate_selected",
+        summary=f"User selected candidate rank={candidate.rank} title={candidate.title!r}",
+        payload={
+            "candidate_id": candidate.id,
+            "rank": candidate.rank,
+            "title": candidate.title,
+            "url": candidate.url,
+            "price_text": candidate.price_text,
+        },
+        severity="user",
+    )
+
+    # Best-effort highlight so the user can visually confirm the choice.
+    try:
+        await bc.highlight_candidate(
+            executor,
+            target_url=candidate.url,
+            target_text=candidate.title,
+        )
+    except Exception as exc:  # pragma: no cover — best effort
+        logger.debug("highlight_candidate failed: %s", exc)
+
+    checkpoint = Checkpoint(
+        action="add_to_cart",
+        label="Add to cart?",
+        detail=(
+            f"Add {candidate.title!r} ({candidate.price_text or 'no price detected'}) "
+            "to the shopping cart? The agent will only add the item — it will never "
+            "place an order or submit payment."
+        ),
+        candidate_id=candidate.id,
+        metadata={
+            "title": candidate.title,
+            "url": candidate.url,
+            "price_text": candidate.price_text,
+        },
+    )
+    _set_checkpoint(run, checkpoint)
+    run.status = RunStatus.AWAITING_CART_CONFIRMATION
+    run.updated_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(run)
+    return run, checkpoint
+
+
+async def confirm(
+    db: AsyncSession,
+    run: EcommerceAgentRun,
+    executor: bc.BrowserExec,
+    *,
+    action: str,
+    approved: bool,
+    user_note: str = "",
+) -> EcommerceAgentRun:
+    """Apply the user's response to the run's pending confirmation checkpoint.
+
+    Honors the policy gate even when ``approved`` is True: anything in
+    ``HARD_FORBIDDEN`` is rejected with an audit log entry rather than
+    silently executed.
+    """
+    checkpoint = get_checkpoint(run)
+    if checkpoint is None or checkpoint.action != action:
+        raise ValueError(
+            f"No matching pending checkpoint for action={action!r}. "
+            f"Current checkpoint: {checkpoint.action if checkpoint else None!r}"
+        )
+
+    if not approved:
+        await _log_event(
+            db,
+            run,
+            event_type="user_declined",
+            summary=f"User declined action={action!r}",
+            payload={"note": user_note},
+            severity="user",
+        )
+        run.status = RunStatus.CANCELLED
+        run.completed_at = datetime.now(UTC)
+        _set_checkpoint(run, None)
+        run.updated_at = datetime.now(UTC)
+        await db.commit()
+        await db.refresh(run)
+        return run
+
+    policy = _policy_for(run)
+    # Retry actions map back to the underlying side effect for policy
+    # evaluation — they exist only to label the checkpoint distinctly.
+    policy_action = _ACTION_ALIAS.get(action, action)
+    decision = policy.evaluate(policy_action)
+    if not decision.allowed or policy_action in HARD_FORBIDDEN:
+        await _log_event(
+            db,
+            run,
+            event_type="policy_blocked",
+            severity="error",
+            summary=f"Refused user approval for {action!r}: {decision.reason or 'hard-forbidden'}",
+            payload={"action": action},
+        )
+        run.status = RunStatus.NEEDS_USER
+        run.failure_reason = (
+            f"Action {action!r} is not allowed by this run's policy. "
+            "Cancel and start a new run with the action in allowed_side_effects to override."
+        )
+        run.updated_at = datetime.now(UTC)
+        await db.commit()
+        await db.refresh(run)
+        return run
+
+    await _log_event(
+        db,
+        run,
+        event_type="user_approved",
+        summary=f"User approved action={action!r}",
+        payload={"note": user_note},
+        severity="user",
+    )
+    _set_checkpoint(run, None)
+
+    if action == SIDE_EFFECT_ADD_TO_CART:
+        await _execute_add_to_cart(db, run, executor)
+    elif action == "retry_add_to_cart":
+        # User signed in (or cleared a blocker) and approved a retry.
+        run.failure_reason = ""
+        await _execute_add_to_cart(db, run, executor)
+    elif action == SIDE_EFFECT_PROCEED_TO_CHECKOUT:
+        await _execute_proceed_to_checkout(db, run, executor)
+    else:
+        await _log_event(
+            db,
+            run,
+            event_type="action_noop",
+            severity="warn",
+            summary=f"No handler for approved action={action!r}",
+            payload={"action": action},
+        )
+
+    run.updated_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(run)
+    return run
+
+
+async def cancel_run(
+    db: AsyncSession,
+    run: EcommerceAgentRun,
+    reason: str = "",
+) -> EcommerceAgentRun:
+    run.status = RunStatus.CANCELLED
+    run.failure_reason = reason
+    run.completed_at = datetime.now(UTC)
+    _set_checkpoint(run, None)
+    await _log_event(
+        db,
+        run,
+        event_type="run_cancelled",
+        severity="user",
+        summary=reason or "Run cancelled by user",
+    )
+    run.updated_at = datetime.now(UTC)
+    await db.commit()
+    await db.refresh(run)
+    return run
+
+
+# ---------------------------------------------------------------------------
+# Internal actions
+# ---------------------------------------------------------------------------
+
+
+async def _execute_add_to_cart(
+    db: AsyncSession,
+    run: EcommerceAgentRun,
+    executor: bc.BrowserExec,
+) -> None:
+    """Navigate to the product, click Add to cart, then surface cart summary."""
+    if run.selected_candidate_id is None:
+        raise ValueError("Cannot add to cart: no candidate selected")
+    candidate = await _get_candidate(db, run, run.selected_candidate_id)
+    profile = get_profile(run.site_slug)
+
+    run.status = RunStatus.ADDING_TO_CART
+    await _log_event(
+        db,
+        run,
+        event_type="adding_to_cart",
+        summary=f"Navigating to product {candidate.url}",
+        payload={"candidate_id": candidate.id, "url": candidate.url},
+    )
+
+    if candidate.url:
+        try:
+            await bc.navigate(executor, candidate.url)
+        except Exception as exc:
+            await _fail_run(db, run, f"product navigation failed: {exc}")
+            return
+
+    # Always re-check boundary BEFORE clicking anything on the product page.
+    # Some sites surface a "Buy now" button right next to "Add to cart".
+    boundary = await bc.detect_purchase_boundary(executor, profile)
+    if boundary.get("boundary_present"):
+        await _log_event(
+            db,
+            run,
+            event_type="boundary_detected",
+            severity="warn",
+            summary="Forbidden action button visible on product page",
+            payload=boundary,
+        )
+
+    # Look for an add-to-cart label appropriate for this site (English fallback first).
+    labels = list(profile.add_to_cart_labels) or ["add to cart"]
+    clicked: dict[str, Any] = {"clicked": False}
+    for label in labels:
+        if is_forbidden_label(label, profile):
+            # Refuse to click a label that classifies as forbidden, even if
+            # the profile mistakenly lists it.
+            await _log_event(
+                db,
+                run,
+                event_type="policy_blocked",
+                severity="error",
+                summary=f"Refused to click label {label!r} — classifies as forbidden",
+                payload={"label": label, "classified_as": classify_action(label, profile)},
+            )
+            continue
+        try:
+            result = await bc.click_by_text(executor, label)
+        except Exception as exc:
+            await _log_event(
+                db,
+                run,
+                event_type="click_failed",
+                severity="warn",
+                summary=f"click_by_text({label!r}) failed: {exc}",
+            )
+            continue
+        if result.get("clicked"):
+            clicked = result
+            await _log_event(
+                db,
+                run,
+                event_type="add_to_cart_click",
+                summary=f"Clicked add-to-cart label {label!r}",
+                payload={"label": label, "result": result},
+            )
+            break
+
+    if not clicked.get("clicked"):
+        # Distinguish three failure modes: (1) sign-in wall, (2) bot
+        # mitigation, (3) genuine selector miss. Surface a targeted
+        # checkpoint so the user knows exactly what to do.
+        signin: dict[str, Any] = {}
+        try:
+            signin = await bc.detect_signin_wall(executor, profile)
+        except Exception as exc:  # pragma: no cover — diagnostic only
+            logger.debug("detect_signin_wall failed: %s", exc)
+
+        if signin.get("signin_present"):
+            await _log_event(
+                db,
+                run,
+                event_type="signin_wall_detected",
+                severity="warn",
+                summary=f"Add-to-cart blocked by sign-in wall on {profile.name}",
+                payload=signin,
+            )
+            run.status = RunStatus.NEEDS_USER
+            run.failure_reason = (
+                f"Please sign in to {profile.name} in this browser tab, then "
+                f"approve the retry checkpoint."
+            )
+            _set_checkpoint(
+                run,
+                Checkpoint(
+                    action="retry_add_to_cart",
+                    label=f"Sign in to {profile.name} first",
+                    detail=(
+                        f"The add-to-cart button isn't visible because "
+                        f"{profile.name} requires you to sign in. Open the tab, "
+                        f"sign in, then approve this checkpoint to retry."
+                    ),
+                    candidate_id=run.selected_candidate_id,
+                    metadata={"signin": signin},
+                ),
+            )
+            return
+
+        await _log_event(
+            db,
+            run,
+            event_type="add_to_cart_failed",
+            severity="error",
+            summary="Could not find a clickable Add-to-cart button",
+            payload={"signin": signin},
+        )
+        run.status = RunStatus.NEEDS_USER
+        run.failure_reason = (
+            "Could not find an Add-to-cart button. The page may show a variant "
+            "picker, region selector, or anti-bot interstitial. Open the tab to "
+            "inspect, then start a new run."
+        )
+        _set_checkpoint(
+            run,
+            Checkpoint(
+                action="manual_intervention",
+                label="Add to cart failed",
+                detail=run.failure_reason,
+                metadata={"signin": signin},
+            ),
+        )
+        return
+
+    # Snapshot the cart to give the user a clear summary.
+    if profile.cart_url:
+        try:
+            await bc.navigate(executor, profile.cart_url)
+        except Exception as exc:  # pragma: no cover
+            logger.debug("cart navigation failed: %s", exc)
+
+    cart = await bc.extract_cart_summary(executor)
+    await _log_event(
+        db,
+        run,
+        event_type="cart_summary",
+        summary=f"Cart shows {cart.get('line_count', 0)} line(s)",
+        payload=cart,
+    )
+
+    run.status = RunStatus.IN_CART
+    _set_checkpoint(
+        run,
+        Checkpoint(
+            action="proceed_to_checkout",
+            label="Confirm checkout",
+            detail=(
+                "The item has been added to your cart. Review the cart summary "
+                "below and approve to proceed to the checkout review page. The "
+                "agent will stop *before* any payment or place-order button — "
+                "the final order must be placed by you in the browser."
+            ),
+            metadata={"cart": cart},
+        ),
+    )
+    run.status = RunStatus.AWAITING_CHECKOUT_CONFIRMATION
+
+
+async def _execute_proceed_to_checkout(
+    db: AsyncSession,
+    run: EcommerceAgentRun,
+    executor: bc.BrowserExec,
+) -> None:
+    """Click into the checkout funnel but stop at the payment boundary."""
+    profile = get_profile(run.site_slug)
+    labels = list(profile.checkout_labels) or ["checkout"]
+    clicked: dict[str, Any] = {"clicked": False}
+    for label in labels:
+        if is_forbidden_label(label, profile):
+            await _log_event(
+                db,
+                run,
+                event_type="policy_blocked",
+                severity="error",
+                summary=f"Refused to click checkout label {label!r} (forbidden)",
+                payload={"label": label},
+            )
+            continue
+        try:
+            result = await bc.click_by_text(executor, label)
+        except Exception as exc:
+            await _log_event(
+                db,
+                run,
+                event_type="click_failed",
+                severity="warn",
+                summary=f"click_by_text({label!r}) failed: {exc}",
+            )
+            continue
+        if result.get("clicked"):
+            clicked = result
+            await _log_event(
+                db,
+                run,
+                event_type="checkout_click",
+                summary=f"Clicked checkout label {label!r}",
+                payload={"label": label, "result": result},
+            )
+            break
+
+    boundary = await bc.detect_purchase_boundary(executor, profile)
+    run.status = RunStatus.AT_CHECKOUT_BOUNDARY
+    run.completed_at = datetime.now(UTC)
+    _set_checkpoint(
+        run,
+        Checkpoint(
+            action="final_purchase",
+            label="Checkout boundary reached",
+            detail=(
+                "The agent has paused at the checkout review screen. Any final "
+                "order/payment buttons remain visible for you to inspect — the "
+                "agent will not click them."
+            ),
+            metadata={
+                "boundary": boundary,
+                "checkout_clicked": clicked,
+            },
+        ),
+    )
+    await _log_event(
+        db,
+        run,
+        event_type="checkout_boundary_reached",
+        summary="Agent stopped at checkout review",
+        payload={"boundary": boundary},
+    )
+
+
+async def _fail_run(
+    db: AsyncSession,
+    run: EcommerceAgentRun,
+    reason: str,
+    *,
+    event_type: str = "run_failed",
+) -> None:
+    run.status = RunStatus.FAILED
+    run.failure_reason = reason
+    run.completed_at = datetime.now(UTC)
+    _set_checkpoint(run, None)
+    await _log_event(db, run, event_type=event_type, severity="error", summary=reason)
+    run.updated_at = datetime.now(UTC)
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Lookups
+# ---------------------------------------------------------------------------
+
+
+async def get_run(db: AsyncSession, run_id: str) -> EcommerceAgentRun | None:
+    result = await db.execute(
+        select(EcommerceAgentRun).where(EcommerceAgentRun.id == run_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def list_candidates(
+    db: AsyncSession, run_id: str
+) -> list[EcommerceProductCandidate]:
+    result = await db.execute(
+        select(EcommerceProductCandidate)
+        .where(EcommerceProductCandidate.run_id == run_id)
+        .order_by(EcommerceProductCandidate.rank.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def list_events(db: AsyncSession, run_id: str) -> list[EcommerceAgentEvent]:
+    result = await db.execute(
+        select(EcommerceAgentEvent)
+        .where(EcommerceAgentEvent.run_id == run_id)
+        .order_by(EcommerceAgentEvent.timestamp.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def _get_candidate(
+    db: AsyncSession,
+    run: EcommerceAgentRun,
+    candidate_id: str,
+) -> EcommerceProductCandidate:
+    result = await db.execute(
+        select(EcommerceProductCandidate).where(
+            EcommerceProductCandidate.id == candidate_id,
+            EcommerceProductCandidate.run_id == run.id,
+        )
+    )
+    candidate = result.scalar_one_or_none()
+    if candidate is None:
+        raise ValueError(f"Candidate {candidate_id!r} not found for run {run.id!r}")
+    return candidate
+
+
+def _safe_float(value: str) -> float | None:
+    if not value:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _fmt_number(value: int | float | None) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+__all__ = [
+    "Checkpoint",
+    "MAX_CANDIDATES",
+    "RunStatus",
+    "auto_advance_after_search",
+    "cancel_run",
+    "confirm",
+    "create_run",
+    "get_checkpoint",
+    "get_run",
+    "list_candidates",
+    "list_events",
+    "search",
+    "select_candidate",
+]
+
+
+# Keep the executor type re-exported for type hints elsewhere.
+BrowserExec = bc.BrowserExec
+ExecutorFactory = Callable[[], Awaitable[bc.BrowserExec]]

--- a/backend/ecommerce/browser_commands.py
+++ b/backend/ecommerce/browser_commands.py
@@ -1,0 +1,730 @@
+"""High-level browser commands used by the e-commerce agent.
+
+These wrap the low-level ``execute_command`` bridge from
+`backend.elicitation.browser_bridge` with the small set of agent-specific
+actions described in the plan:
+
+- ``extract_product_cards``    : scrape visible product cards
+- ``extract_cart_summary``     : scrape the cart page lines + totals
+- ``detect_purchase_boundary`` : find any final order/payment controls and
+                                 return a forced confirmation checkpoint
+- ``highlight_candidate``      : visually outline a candidate URL/text so
+                                 the user can verify the agent's choice
+
+Each function emits a single ``eval_js`` browser command. The JS payload is
+intentionally small and self-contained so it works against any of the
+catalog sites without site-specific bundles. Per-site selectors from
+`SiteProfile` are passed in as data, never compiled into the payload.
+
+These commands assume the active browser tab is already on the relevant
+page (search results, product detail, or cart). The agent code in
+`agent.py` is responsible for navigating before calling.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from typing import Any
+from urllib.parse import urlparse
+
+from backend.ecommerce.site_catalog import SiteProfile, normalize_label
+
+logger = logging.getLogger(__name__)
+
+
+# Type alias: anything that matches `execute_command(command_type, params) -> dict`
+BrowserExec = Callable[[str, dict], Awaitable[dict]]
+
+
+# ---------------------------------------------------------------------------
+# JS payloads
+# ---------------------------------------------------------------------------
+
+
+# Extract candidate product cards from a search/listing page using per-site
+# selectors. The JS function is parameter-free; selectors are injected via
+# string interpolation before the call. The result shape is:
+#   { "candidates": [ {title, url, image_url, price_text, rating_text,
+#                       review_count_text, seller, shipping_text, availability} ] }
+_EXTRACT_PRODUCT_CARDS_JS = """
+return (function() {
+  const CARDS = __CARD_SELECTORS__;
+  const TITLES = __TITLE_SELECTORS__;
+  const PRICES = __PRICE_SELECTORS__;
+  const LINKS = __LINK_SELECTORS__;
+  const LIMIT = __LIMIT__;
+
+  function deepQueryAll(root, sel) {
+    const results = [...root.querySelectorAll(sel)];
+    for (const el of root.querySelectorAll('*')) {
+      if (el.shadowRoot) results.push(...deepQueryAll(el.shadowRoot, sel));
+    }
+    return results;
+  }
+  function firstMatch(card, selectors) {
+    for (const sel of selectors) {
+      const el = card.querySelector(sel);
+      if (el) return el;
+    }
+    return null;
+  }
+  function text(el) {
+    return el ? (el.textContent || el.value || '').trim().replace(/\\s+/g, ' ') : '';
+  }
+  function attr(el, name) {
+    return el ? (el.getAttribute(name) || '') : '';
+  }
+
+  let cards = [];
+  for (const sel of CARDS) {
+    const found = deepQueryAll(document, sel);
+    if (found.length) { cards = found; break; }
+  }
+
+  const out = [];
+  for (const card of cards) {
+    if (out.length >= LIMIT) break;
+    const rect = card.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) continue;
+    const titleEl = firstMatch(card, TITLES);
+    const priceEl = firstMatch(card, PRICES);
+    const linkEl = firstMatch(card, LINKS) || card.querySelector('a[href]');
+    const imgEl = card.querySelector('img');
+    const ratingEl = card.querySelector(
+      "[aria-label*='star' i], [class*='rating' i], [data-test*='rating' i]"
+    );
+    const reviewsEl = card.querySelector(
+      "[class*='review' i], [aria-label*='review' i]"
+    );
+    const sellerEl = card.querySelector("[class*='seller' i], [data-test*='seller' i]");
+    const shippingEl = card.querySelector(
+      "[class*='shipping' i], [class*='delivery' i], [data-test*='fulfillment' i]"
+    );
+    const availabilityEl = card.querySelector(
+      "[class*='availability' i], [class*='stock' i]"
+    );
+    const href = linkEl ? (linkEl.href || attr(linkEl, 'href')) : '';
+    out.push({
+      title: text(titleEl) || text(card).slice(0, 200),
+      url: href || '',
+      image_url: imgEl ? (imgEl.src || imgEl.getAttribute('data-src') || '') : '',
+      price_text: text(priceEl),
+      rating_text: text(ratingEl) || attr(ratingEl, 'aria-label'),
+      review_count_text: text(reviewsEl),
+      seller: text(sellerEl),
+      shipping_text: text(shippingEl),
+      availability: text(availabilityEl),
+    });
+  }
+  return { candidates: out, total_cards: cards.length };
+})()
+"""
+
+
+# Extract the cart contents. Cart pages vary wildly; we use generic
+# selectors plus a fallback that scans for visible currency text near
+# product-like rows. We also surface every visible checkout-style button
+# so the agent can verify it has not entered a payment funnel yet.
+_EXTRACT_CART_SUMMARY_JS = """
+return (function() {
+  function visible(el) {
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0) return false;
+    const s = getComputedStyle(el);
+    return s.display !== 'none' && s.visibility !== 'hidden';
+  }
+  function text(el) {
+    return el ? (el.textContent || '').trim().replace(/\\s+/g, ' ') : '';
+  }
+
+  const rowSelectors = [
+    "[data-testid*='cart' i] li",
+    "[class*='cart-item' i]",
+    "[class*='cartItem' i]",
+    "[data-component*='cart' i] li",
+    "li[class*='line-item' i]",
+  ];
+  const rows = [];
+  for (const sel of rowSelectors) {
+    document.querySelectorAll(sel).forEach((el) => {
+      if (visible(el)) rows.push(el);
+    });
+    if (rows.length) break;
+  }
+
+  const lines = rows.slice(0, 30).map((row, i) => {
+    const link = row.querySelector('a[href]');
+    const img = row.querySelector('img');
+    return {
+      index: i,
+      title: text(row.querySelector("[class*='title' i], h2, h3, a")) || text(row).slice(0, 200),
+      url: link ? (link.href || '') : '',
+      image_url: img ? (img.src || img.getAttribute('data-src') || '') : '',
+      price_text: text(row.querySelector("[class*='price' i], [data-test*='price' i]")),
+      quantity_text: text(row.querySelector(
+        "input[type='number'], [class*='qty' i], [class*='quantity' i]"
+      )),
+    };
+  });
+
+  const totalEl = document.querySelector(
+    "[class*='subtotal' i], [data-test*='subtotal' i], [class*='order-total' i]"
+  );
+  const shippingEl = document.querySelector("[class*='shipping' i][class*='total' i]");
+  const taxEl = document.querySelector("[class*='tax' i][class*='total' i]");
+
+  const buttons = [];
+  document.querySelectorAll(
+    "button, a, [role='button'], input[type='submit'], input[type='button']"
+  ).forEach((el) => {
+    if (!visible(el)) return;
+    const t = text(el) || el.value || el.getAttribute('aria-label') || '';
+    if (!t) return;
+    buttons.push({
+      label: t.slice(0, 100),
+      tag: el.tagName.toLowerCase(),
+      disabled: el.disabled === true,
+    });
+  });
+
+  return {
+    line_count: lines.length,
+    lines,
+    subtotal_text: text(totalEl),
+    shipping_text: text(shippingEl),
+    tax_text: text(taxEl),
+    buttons: buttons.slice(0, 50),
+    url: location.href,
+  };
+})()
+"""
+
+
+# Detect any visible button/link that looks like a final order/payment
+# action. The JS does NOT click anything. Forbidden phrases are passed in
+# so the same code works in any locale we extend the catalog to.
+_DETECT_PURCHASE_BOUNDARY_JS = """
+return (function() {
+  const FORBIDDEN = __FORBIDDEN_LABELS__;
+
+  function visible(el) {
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0) return false;
+    const s = getComputedStyle(el);
+    return s.display !== 'none' && s.visibility !== 'hidden';
+  }
+  function text(el) {
+    return ((el.textContent || el.value || el.getAttribute('aria-label') || '')
+      .trim().replace(/\\s+/g, ' ')).toLowerCase();
+  }
+
+  const els = document.querySelectorAll(
+    "button, a, [role='button'], input[type='submit'], input[type='button']"
+  );
+  const hits = [];
+  for (const el of els) {
+    if (!visible(el)) continue;
+    const t = text(el);
+    if (!t) continue;
+    for (const needle of FORBIDDEN) {
+      if (t.includes(needle)) {
+        hits.push({
+          label: t.slice(0, 100),
+          tag: el.tagName.toLowerCase(),
+          matched: needle,
+        });
+        break;
+      }
+    }
+    if (hits.length >= 20) break;
+  }
+
+  return {
+    url: location.href,
+    boundary_present: hits.length > 0,
+    matches: hits,
+  };
+})()
+"""
+
+
+# Generic, site-agnostic product-card extractor. Used as a fallback when
+# the profile's selectors yield zero cards (markup drift on the live site).
+# Strategy: walk every link with non-trivial visible text, find its nearest
+# "card-like" ancestor, and only keep it if the ancestor also contains a
+# price-looking string (currency glyph followed by digits). This works
+# across the catalog without site-specific rules.
+_EXTRACT_PRODUCT_CARDS_GENERIC_JS = """
+return (function() {
+  const LIMIT = __LIMIT__;
+  const PRICE_RE = /(?:[$€£¥₹]|USD|EUR|GBP|JPY|INR|CAD|AUD)\\s?\\d/i;
+  const MIN_TITLE_LEN = 12;
+
+  function visible(el) {
+    if (!el) return false;
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0) return false;
+    const s = getComputedStyle(el);
+    return s.display !== 'none' && s.visibility !== 'hidden';
+  }
+  function text(el) {
+    return el ? (el.textContent || '').trim().replace(/\\s+/g, ' ') : '';
+  }
+
+  const seen = new Set();
+  const cards = [];
+  const links = document.querySelectorAll('a[href]');
+  for (const link of links) {
+    if (cards.length >= LIMIT) break;
+    if (!visible(link)) continue;
+    const title = text(link);
+    if (title.length < MIN_TITLE_LEN) continue;
+    if (/^(sign in|log in|register|sign up|menu|skip to|home|cart|view all)/i.test(title)) continue;
+    const href = link.href || '';
+    if (!href || href.startsWith('javascript:') || href.startsWith('#')) continue;
+    const card = link.closest(
+      'li, article, [data-asin], [data-testid], [data-component-type], [data-product-id], div[class*="card" i], div[class*="result" i], div[class*="product" i]'
+    ) || link.parentElement;
+    if (!card || !visible(card)) continue;
+    const cardKey = card.outerHTML.slice(0, 200);
+    if (seen.has(cardKey)) continue;
+    const cardText = text(card);
+    if (!PRICE_RE.test(cardText)) continue;
+    seen.add(cardKey);
+
+    const priceMatch = cardText.match(
+      /((?:[$€£¥₹]|USD|EUR|GBP|JPY|INR|CAD|AUD)\\s?[\\d.,]+)/i
+    );
+    const img = card.querySelector('img');
+    const ratingEl = card.querySelector(
+      "[aria-label*='star' i], [class*='rating' i], [data-test*='rating' i]"
+    );
+    const reviewsEl = card.querySelector(
+      "[class*='review' i], [aria-label*='review' i]"
+    );
+    cards.push({
+      title: title.slice(0, 300),
+      url: href,
+      image_url: img ? (img.src || img.getAttribute('data-src') || '') : '',
+      price_text: priceMatch ? priceMatch[1] : '',
+      rating_text: ratingEl ? (text(ratingEl) || ratingEl.getAttribute('aria-label') || '') : '',
+      review_count_text: text(reviewsEl),
+      seller: '',
+      shipping_text: '',
+      availability: '',
+    });
+  }
+
+  return { candidates: cards, total_cards: cards.length, source: 'generic' };
+})()
+"""
+
+
+# Detect sign-in walls on a product page. We look for both visible buttons
+# labeled "sign in / log in" AND for an absence of typical add-to-cart
+# controls. Returns confidence hints rather than a hard yes/no so the agent
+# can choose how to react.
+_DETECT_SIGNIN_WALL_JS = """
+return (function() {
+  const ADD_TO_CART_HINTS = __ADD_TO_CART_HINTS__;
+
+  function visible(el) {
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0) return false;
+    const s = getComputedStyle(el);
+    return s.display !== 'none' && s.visibility !== 'hidden';
+  }
+  function text(el) {
+    return ((el.textContent || el.value || el.getAttribute('aria-label') || '')
+      .trim().replace(/\\s+/g, ' ')).toLowerCase();
+  }
+
+  const SIGNIN_RE = /\\b(sign[- ]?in|log[- ]?in|continue with apple|continue with google|create account|registrieren|anmelden|inicia sesión|s'?identifier|登录|登入|로그인)\\b/i;
+  const PASSWORD_FIELD = document.querySelector("input[type='password']");
+
+  let signinControls = 0;
+  let addToCartControls = 0;
+  const signinHits = [];
+  const els = document.querySelectorAll(
+    "button, a, [role='button'], input[type='submit'], input[type='button']"
+  );
+  for (const el of els) {
+    if (!visible(el)) continue;
+    const t = text(el);
+    if (!t) continue;
+    if (SIGNIN_RE.test(t)) {
+      signinControls += 1;
+      if (signinHits.length < 5) signinHits.push(t.slice(0, 80));
+    }
+    for (const hint of ADD_TO_CART_HINTS) {
+      if (t.includes(hint)) { addToCartControls += 1; break; }
+    }
+  }
+
+  const title = (document.title || '').toLowerCase();
+  const titleHint = /sign[- ]?in|log[- ]?in|登录|anmelden/i.test(title);
+
+  return {
+    signin_present: !!PASSWORD_FIELD || signinControls >= 1 && addToCartControls === 0,
+    signin_controls: signinControls,
+    addtocart_controls: addToCartControls,
+    has_password_field: !!PASSWORD_FIELD,
+    title_hint: titleHint,
+    hits: signinHits,
+    url: location.href,
+  };
+})()
+"""
+
+
+# Outline the element matching a given URL or title so the user can verify
+# the agent has not picked the wrong row. Returns whether the highlight
+# succeeded so the agent can degrade gracefully when the element scrolled
+# off the DOM.
+_HIGHLIGHT_CANDIDATE_JS = """
+return (function() {
+  const TARGET_URL = __TARGET_URL__;
+  const TARGET_TEXT = __TARGET_TEXT__;
+
+  function visible(el) {
+    const r = el.getBoundingClientRect();
+    if (r.width === 0 && r.height === 0) return false;
+    const s = getComputedStyle(el);
+    return s.display !== 'none' && s.visibility !== 'hidden';
+  }
+
+  let match = null;
+  if (TARGET_URL) {
+    for (const a of document.querySelectorAll('a[href]')) {
+      if (a.href === TARGET_URL && visible(a)) { match = a; break; }
+    }
+  }
+  if (!match && TARGET_TEXT) {
+    const lower = TARGET_TEXT.toLowerCase();
+    for (const el of document.querySelectorAll('a, h2, h3, [role="link"]')) {
+      if (!visible(el)) continue;
+      const t = (el.textContent || '').trim().toLowerCase();
+      if (t && t.includes(lower)) { match = el; break; }
+    }
+  }
+  if (!match) return { highlighted: false };
+
+  let card = match.closest('article, li, div[data-testid], div[data-asin]') || match;
+  card.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
+  const prevOutline = card.style.outline;
+  const prevOffset = card.style.outlineOffset;
+  card.style.outline = '3px solid #ff6a00';
+  card.style.outlineOffset = '2px';
+  setTimeout(() => {
+    card.style.outline = prevOutline;
+    card.style.outlineOffset = prevOffset;
+  }, 6000);
+
+  const rect = card.getBoundingClientRect();
+  return {
+    highlighted: true,
+    tag: card.tagName.toLowerCase(),
+    rect: { x: Math.round(rect.x), y: Math.round(rect.y),
+            width: Math.round(rect.width), height: Math.round(rect.height) },
+  };
+})()
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _inject_payload(code: str, **values: Any) -> str:
+    """Replace ``__NAME__`` placeholders with JSON-encoded values.
+
+    Using JSON encoding means we never need to worry about quoting/escaping
+    user-controlled strings (URLs, titles, localized labels) inside the JS
+    payload.
+    """
+    rendered = code
+    for name, value in values.items():
+        placeholder = f"__{name}__"
+        if placeholder not in rendered:
+            raise ValueError(f"placeholder {placeholder} not found in JS payload")
+        rendered = rendered.replace(placeholder, json.dumps(value))
+    return rendered
+
+
+def _unwrap_eval_result(result: dict) -> dict:
+    """Extract the JS return value from an `eval_js` response.
+
+    The browser bridge wraps results as
+    ``{"success": True, "data": {"success": True, "result": <value>}, ...}``.
+    """
+    if not isinstance(result, dict):
+        return {}
+    data = result.get("data") if "success" in result else result
+    if isinstance(data, dict) and "result" in data:
+        inner = data["result"]
+        if isinstance(inner, dict):
+            return inner
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Public API — each function takes a `BrowserExec` so the agent can inject a
+# mock in unit tests.
+# ---------------------------------------------------------------------------
+
+
+async def navigate(executor: BrowserExec, url: str) -> dict:
+    """Navigate the active tab to ``url``."""
+    return await executor("navigate", {"url": url})
+
+
+def _unwrap_data(raw: dict) -> dict:
+    data = raw.get("data") if isinstance(raw, dict) else None
+    return data if isinstance(data, dict) else (raw if isinstance(raw, dict) else {})
+
+
+async def get_page_info(executor: BrowserExec) -> dict:
+    """Return the active tab's URL/title via the existing extension command."""
+    raw = await executor("get_page_info", {})
+    return _unwrap_data(raw)
+
+
+async def extract_product_cards(
+    executor: BrowserExec,
+    profile: SiteProfile,
+    *,
+    limit: int = 20,
+) -> dict:
+    """Scrape the active page for product cards using the site's selectors."""
+    code = _inject_payload(
+        _EXTRACT_PRODUCT_CARDS_JS,
+        CARD_SELECTORS=list(profile.product_card_selectors),
+        TITLE_SELECTORS=list(profile.product_title_selectors),
+        PRICE_SELECTORS=list(profile.product_price_selectors),
+        LINK_SELECTORS=list(profile.product_link_selectors),
+        LIMIT=int(limit),
+    )
+    raw = await executor("eval_js", {"code": code})
+    return _unwrap_eval_result(raw)
+
+
+async def extract_cart_summary(executor: BrowserExec) -> dict:
+    """Scrape the active page (assumed to be a cart page) for cart contents."""
+    raw = await executor("eval_js", {"code": _EXTRACT_CART_SUMMARY_JS})
+    return _unwrap_eval_result(raw)
+
+
+async def detect_purchase_boundary(
+    executor: BrowserExec,
+    profile: SiteProfile | None,
+    extra_forbidden_labels: list[str] | None = None,
+) -> dict:
+    """Detect any visible final-order/payment button on the active page."""
+    from backend.ecommerce.site_catalog import COMMON_FORBIDDEN_LABELS
+
+    forbidden = [normalize_label(p) for p in COMMON_FORBIDDEN_LABELS]
+    if profile is not None:
+        forbidden.extend(normalize_label(p) for p in profile.forbidden_action_labels)
+    if extra_forbidden_labels:
+        forbidden.extend(normalize_label(p) for p in extra_forbidden_labels)
+    forbidden = sorted({p for p in forbidden if p})
+
+    code = _inject_payload(_DETECT_PURCHASE_BOUNDARY_JS, FORBIDDEN_LABELS=forbidden)
+    raw = await executor("eval_js", {"code": code})
+    return _unwrap_eval_result(raw)
+
+
+async def highlight_candidate(
+    executor: BrowserExec,
+    *,
+    target_url: str = "",
+    target_text: str = "",
+) -> dict:
+    """Visually outline the candidate matching ``target_url`` or ``target_text``."""
+    if not target_url and not target_text:
+        raise ValueError("highlight_candidate requires target_url or target_text")
+    code = _inject_payload(
+        _HIGHLIGHT_CANDIDATE_JS,
+        TARGET_URL=target_url,
+        TARGET_TEXT=target_text,
+    )
+    raw = await executor("eval_js", {"code": code})
+    return _unwrap_eval_result(raw)
+
+
+async def wait_for_selector(
+    executor: BrowserExec, selector: str, *, timeout_ms: int = 10000
+) -> dict:
+    """Wait until ``selector`` appears in the DOM (uses extension command)."""
+    raw = await executor("wait_for_selector", {"selector": selector, "timeout": timeout_ms})
+    return _unwrap_data(raw)
+
+
+async def wait_for_url(
+    executor: BrowserExec, url_substring: str, *, timeout_ms: int = 10000
+) -> dict:
+    """Wait until ``window.location.href`` contains ``url_substring``."""
+    raw = await executor(
+        "wait_for_url", {"url_substring": url_substring, "timeout": timeout_ms}
+    )
+    return _unwrap_data(raw)
+
+
+_BOT_CHECK_URL_RE = re.compile(
+    r"(captcha|robotcheck|validateCaptcha|errors/validate|opfcaptcha|access[-_]?denied|bot[-_]?check|incident\?support)",
+    re.IGNORECASE,
+)
+_BOT_CHECK_TITLE_RE = re.compile(
+    r"(robot|captcha|verify|are\s+you\s+human|access\s+denied|security\s+check|just\s+a\s+moment)",
+    re.IGNORECASE,
+)
+
+
+def is_bot_check(url: str, title: str = "") -> bool:
+    """Heuristic: does this look like a bot-mitigation / captcha page?"""
+    if url and _BOT_CHECK_URL_RE.search(url):
+        return True
+    return bool(title and _BOT_CHECK_TITLE_RE.search(title))
+
+
+async def wait_for_page_ready(
+    executor: BrowserExec,
+    profile: SiteProfile,
+    target_url: str,
+    *,
+    selector_timeout_ms: int = 8000,
+    url_timeout_ms: int = 6000,
+) -> dict:
+    """Wait until the active tab has navigated to ``target_url`` and at least
+    one of the site profile's product-card selectors is in the DOM.
+
+    Returns ``{"ready": bool, "url": str, "title": str, "matched_selector": str,
+    "bot_check_hint": bool, "waited_ms": int}``. Never raises — caller is
+    responsible for interpreting ``ready``.
+    """
+    parsed = urlparse(target_url)
+    host = parsed.netloc or ""
+    # Strip a leading "www." so we match e.g. "ebay.com" against either
+    # "www.ebay.com" or a bare "ebay.com".
+    if host.startswith("www."):
+        host = host[4:]
+
+    url_result: dict[str, Any] = {}
+    if host:
+        try:
+            url_result = await wait_for_url(executor, host, timeout_ms=url_timeout_ms)
+        except Exception as exc:  # pragma: no cover — bridge errors surface elsewhere
+            logger.debug("wait_for_url failed: %s", exc)
+
+    # Probe each card selector in turn. The extension's wait_for_selector
+    # returns immediately if the selector is already present, so this loop
+    # is cheap when the page is fast and bounded when it is slow.
+    matched_selector = ""
+    total_waited = int(url_result.get("waited", 0) or 0)
+    per_selector_budget = max(
+        500, selector_timeout_ms // max(1, len(profile.product_card_selectors) or 1)
+    )
+    for sel in profile.product_card_selectors:
+        try:
+            res = await wait_for_selector(executor, sel, timeout_ms=per_selector_budget)
+        except Exception as exc:  # pragma: no cover
+            logger.debug("wait_for_selector(%r) failed: %s", sel, exc)
+            continue
+        total_waited += int(res.get("waited", 0) or 0)
+        if res.get("found"):
+            matched_selector = sel
+            break
+
+    info: dict[str, Any] = {}
+    try:
+        info = await get_page_info(executor)
+    except Exception as exc:  # pragma: no cover
+        logger.debug("get_page_info failed: %s", exc)
+    final_url = str(info.get("url") or url_result.get("url") or "")
+    page_title = str(info.get("title") or "")
+
+    return {
+        "ready": bool(matched_selector) and bool(url_result.get("matched", True)),
+        "url": final_url,
+        "title": page_title,
+        "matched_selector": matched_selector,
+        "bot_check_hint": is_bot_check(final_url, page_title),
+        "waited_ms": total_waited,
+    }
+
+
+async def extract_product_cards_robust(
+    executor: BrowserExec,
+    profile: SiteProfile,
+    *,
+    limit: int = 20,
+) -> dict:
+    """Extract product cards using profile selectors, falling back to a
+    site-agnostic price+link heuristic when the profile selectors miss.
+
+    Result shape matches ``extract_product_cards`` plus a ``source`` field
+    of ``"profile"`` (when site selectors matched) or ``"generic"`` (when
+    the fallback found cards).
+    """
+    primary = await extract_product_cards(executor, profile, limit=limit)
+    primary_cards = primary.get("candidates") or []
+    if primary_cards:
+        primary.setdefault("source", "profile")
+        return primary
+
+    code = _inject_payload(_EXTRACT_PRODUCT_CARDS_GENERIC_JS, LIMIT=int(limit))
+    raw = await executor("eval_js", {"code": code})
+    fallback = _unwrap_eval_result(raw)
+    fallback_cards = fallback.get("candidates") or []
+    fallback.setdefault("source", "generic")
+    fallback["primary_total_cards"] = primary.get("total_cards", 0)
+    fallback["primary_source"] = "profile"
+    if not fallback_cards:
+        fallback["candidates"] = []
+    return fallback
+
+
+async def detect_signin_wall(
+    executor: BrowserExec,
+    profile: SiteProfile,
+) -> dict:
+    """Return heuristic info on whether the current page is a sign-in wall.
+
+    Looks for a visible password field, sign-in-shaped buttons/links, and
+    whether the page has any of the profile's add-to-cart hints. Caller
+    decides what to do with the result.
+    """
+    hints = sorted({normalize_label(p) for p in profile.add_to_cart_labels if p})
+    code = _inject_payload(_DETECT_SIGNIN_WALL_JS, ADD_TO_CART_HINTS=hints)
+    raw = await executor("eval_js", {"code": code})
+    return _unwrap_eval_result(raw)
+
+
+async def click_by_text(executor: BrowserExec, text: str, *, exact: bool = False) -> dict:
+    """Click the first visible interactive element whose label contains ``text``."""
+    raw = await executor("click_by_text", {"text": text, "exact": exact})
+    return _unwrap_data(raw)
+
+
+__all__ = [
+    "BrowserExec",
+    "click_by_text",
+    "detect_purchase_boundary",
+    "detect_signin_wall",
+    "extract_cart_summary",
+    "extract_product_cards",
+    "extract_product_cards_robust",
+    "get_page_info",
+    "highlight_candidate",
+    "is_bot_check",
+    "navigate",
+    "wait_for_page_ready",
+    "wait_for_selector",
+    "wait_for_url",
+]

--- a/backend/ecommerce/models.py
+++ b/backend/ecommerce/models.py
@@ -1,0 +1,143 @@
+"""ORM models for the e-commerce agent.
+
+State for a single shopping task is split across three tables so the audit
+trail can be inspected independently of the run itself:
+
+- `EcommerceAgentRun`            : top-level task and state machine
+- `EcommerceProductCandidate`    : product candidates surfaced during a run
+- `EcommerceAgentEvent`          : append-only audit log (browser actions,
+                                   prompts, confirmations, errors)
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _new_uuid() -> str:
+    return str(uuid.uuid4())
+
+
+class EcommerceAgentRun(Base):
+    """One shopping task, executed against one e-commerce site.
+
+    The run owns the high-level state machine. Detailed step records live in
+    `EcommerceAgentEvent`; surfaced products live in
+    `EcommerceProductCandidate`.
+
+    Status lifecycle:
+        created -> searching -> awaiting_selection -> selected ->
+        adding_to_cart -> awaiting_cart_confirmation -> in_cart ->
+        awaiting_checkout_confirmation -> at_checkout_boundary -> completed
+        Any state can transition to: needs_user | cancelled | failed
+
+    Final-state semantics:
+        completed                 — agent finished within the allowed scope
+                                    (cart prepared and/or checkout boundary
+                                    reached and acknowledged by the user).
+        at_checkout_boundary      — agent intentionally stopped before any
+                                    payment/order-placement action.
+        needs_user                — agent paused for human input (captcha,
+                                    MFA, missing variant, etc.).
+        cancelled                 — user cancelled the run.
+        failed                    — agent could not proceed safely.
+    """
+
+    __tablename__ = "ecommerce_agent_runs"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+
+    status: Mapped[str] = mapped_column(String(40), default="created")
+
+    site_slug: Mapped[str] = mapped_column(String(50))
+    query: Mapped[str] = mapped_column(Text)
+
+    # Request constraints (optional)
+    region: Mapped[str] = mapped_column(String(20), default="")
+    currency: Mapped[str] = mapped_column(String(10), default="")
+    max_price: Mapped[str] = mapped_column(String(40), default="")
+    min_rating: Mapped[str] = mapped_column(String(40), default="")
+    shipping_preference: Mapped[str] = mapped_column(String(40), default="")
+    notes: Mapped[str] = mapped_column(Text, default="")
+
+    # Safety configuration (JSON-encoded list/dict). Defaults are conservative.
+    allowed_side_effects_json: Mapped[str] = mapped_column(Text, default='["search","browse","add_to_cart"]')
+    forbidden_side_effects_json: Mapped[str] = mapped_column(
+        Text, default='["place_order","pay","submit_payment","confirm_order"]'
+    )
+
+    # Selected product (set when the user picks one of the candidates)
+    selected_candidate_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+
+    # Last confirmation checkpoint metadata (JSON-encoded). Filled when the
+    # agent is waiting on the user. Cleared when the user responds.
+    pending_checkpoint_json: Mapped[str] = mapped_column(Text, default="")
+
+    # Failure / cancellation reason
+    failure_reason: Mapped[str] = mapped_column(Text, default="")
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=_utcnow, onupdate=_utcnow)
+    completed_at: Mapped[datetime | None] = mapped_column(nullable=True)
+
+
+class EcommerceProductCandidate(Base):
+    """A single product surfaced for an agent run.
+
+    Candidates are produced from the live page via the extension's
+    extract_product_cards command, then ranked and persisted so the user
+    can later choose one via the select endpoint.
+    """
+
+    __tablename__ = "ecommerce_product_candidates"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+    run_id: Mapped[str] = mapped_column(String(36), ForeignKey("ecommerce_agent_runs.id"))
+
+    rank: Mapped[int] = mapped_column(Integer, default=0)
+    title: Mapped[str] = mapped_column(Text, default="")
+    url: Mapped[str] = mapped_column(Text, default="")
+    image_url: Mapped[str] = mapped_column(Text, default="")
+    price_text: Mapped[str] = mapped_column(String(80), default="")
+    price_amount: Mapped[str] = mapped_column(String(40), default="")
+    currency: Mapped[str] = mapped_column(String(10), default="")
+    rating_text: Mapped[str] = mapped_column(String(40), default="")
+    rating_value: Mapped[str] = mapped_column(String(20), default="")
+    review_count: Mapped[str] = mapped_column(String(20), default="")
+    seller: Mapped[str] = mapped_column(String(200), default="")
+    shipping_text: Mapped[str] = mapped_column(String(200), default="")
+    availability: Mapped[str] = mapped_column(String(60), default="")
+    score: Mapped[str] = mapped_column(String(40), default="")
+
+    created_at: Mapped[datetime] = mapped_column(default=_utcnow)
+
+
+class EcommerceAgentEvent(Base):
+    """Append-only audit log for a single run.
+
+    Every browser command, planner decision, candidate ranking, user prompt,
+    user confirmation, and error becomes one row. Severity is one of
+    ``info``, ``warn``, ``error``, ``user``.
+    """
+
+    __tablename__ = "ecommerce_agent_events"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_new_uuid)
+    run_id: Mapped[str] = mapped_column(String(36), ForeignKey("ecommerce_agent_runs.id"))
+
+    event_type: Mapped[str] = mapped_column(String(60))
+    severity: Mapped[str] = mapped_column(String(20), default="info")
+    summary: Mapped[str] = mapped_column(Text, default="")
+    payload_json: Mapped[str] = mapped_column(Text, default="")
+    timestamp: Mapped[datetime] = mapped_column(default=_utcnow)

--- a/backend/ecommerce/ranking.py
+++ b/backend/ecommerce/ranking.py
@@ -1,0 +1,261 @@
+"""Pure helpers for parsing scraped product fields and ranking candidates.
+
+Kept as pure functions so they can be unit-tested without a live browser.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_PRICE_RE = re.compile(
+    r"(?P<currency>[A-Z]{3}|[$€£¥₹₩₪₱]|US\$|Rs\.?|S\$|R\$|HK\$|A\$|C\$)?\s*"
+    r"(?P<amount>\d[\d.,]*)",
+    re.IGNORECASE,
+)
+_RATING_RE = re.compile(r"(\d(?:\.\d+)?)\s*(?:out of|/|\s*stars?)?", re.IGNORECASE)
+_REVIEWS_RE = re.compile(r"(\d[\d,.]*)\s*(?:reviews?|ratings?)", re.IGNORECASE)
+
+# Currency symbols → ISO 4217 (best effort; some symbols are ambiguous).
+_SYMBOL_TO_ISO: dict[str, str] = {
+    "$": "USD",
+    "US$": "USD",
+    "C$": "CAD",
+    "A$": "AUD",
+    "S$": "SGD",
+    "HK$": "HKD",
+    "R$": "BRL",
+    "€": "EUR",
+    "£": "GBP",
+    "¥": "JPY",
+    "₹": "INR",
+    "₩": "KRW",
+    "₪": "ILS",
+    "₱": "PHP",
+    "Rs": "INR",
+    "Rs.": "INR",
+}
+
+
+@dataclass(frozen=True)
+class ParsedPrice:
+    amount: float | None
+    currency: str
+
+
+def parse_price(text: str) -> ParsedPrice:
+    """Extract a numeric amount and (best-effort) ISO currency code.
+
+    Empty/None input yields ``ParsedPrice(None, "")``. Unparsable numbers
+    yield ``ParsedPrice(None, currency)`` so the caller can still surface
+    a currency hint.
+    """
+    if not text:
+        return ParsedPrice(None, "")
+    match = _PRICE_RE.search(text)
+    if not match:
+        return ParsedPrice(None, "")
+    raw_currency = (match.group("currency") or "").strip()
+    iso = _SYMBOL_TO_ISO.get(raw_currency, "")
+    if not iso and len(raw_currency) == 3 and raw_currency.isalpha():
+        iso = raw_currency.upper()
+    amount = _parse_amount(match.group("amount"))
+    return ParsedPrice(amount, iso)
+
+
+def _parse_amount(raw: str) -> float | None:
+    """Parse a localized amount string into a float.
+
+    Supports both ``1,234.56`` (en) and ``1.234,56`` (de/fr/es) shapes.
+    """
+    if not raw:
+        return None
+    raw = raw.strip()
+    has_dot = "." in raw
+    has_comma = "," in raw
+    try:
+        if has_dot and has_comma:
+            # Use the rightmost separator as the decimal point.
+            if raw.rfind(",") > raw.rfind("."):
+                normalized = raw.replace(".", "").replace(",", ".")
+            else:
+                normalized = raw.replace(",", "")
+            return float(normalized)
+        if has_comma and not has_dot:
+            # Comma might be thousands (e.g. "1,234") or decimals ("9,99").
+            # Heuristic: if there are exactly two digits after the last comma
+            # and no dot, treat as decimal separator.
+            tail = raw.rsplit(",", 1)[-1]
+            if len(tail) == 2:
+                return float(raw.replace(".", "").replace(",", "."))
+            return float(raw.replace(",", ""))
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def parse_rating(text: str) -> float | None:
+    """Best-effort extraction of a star rating from free-form text."""
+    if not text:
+        return None
+    match = _RATING_RE.search(text)
+    if not match:
+        return None
+    try:
+        value = float(match.group(1))
+    except ValueError:
+        return None
+    if 0 <= value <= 5:
+        return value
+    return None
+
+
+def parse_review_count(text: str) -> int | None:
+    """Extract a review/rating count from free-form text."""
+    if not text:
+        return None
+    match = _REVIEWS_RE.search(text)
+    if not match:
+        return None
+    try:
+        return int(match.group(1).replace(",", "").replace(".", ""))
+    except ValueError:
+        return None
+
+
+def normalize_candidate(raw: dict, *, default_currency: str = "") -> dict:
+    """Normalize a raw card extracted from a product grid.
+
+    Adds parsed numeric fields without dropping the raw text fields so the
+    UI can still display the seller-rendered strings.
+    """
+    title = (raw.get("title") or "").strip()
+    url = (raw.get("url") or "").strip()
+    image_url = (raw.get("image_url") or "").strip()
+    price_text = (raw.get("price_text") or raw.get("price") or "").strip()
+    rating_text = (raw.get("rating_text") or raw.get("rating") or "").strip()
+    review_text = (raw.get("review_count_text") or raw.get("reviews") or "").strip()
+    seller = (raw.get("seller") or "").strip()
+    shipping = (raw.get("shipping_text") or raw.get("shipping") or "").strip()
+    availability = (raw.get("availability") or "").strip()
+
+    parsed_price = parse_price(price_text)
+    currency = parsed_price.currency or default_currency
+    rating = parse_rating(rating_text)
+    review_count = parse_review_count(review_text)
+
+    return {
+        "title": title,
+        "url": url,
+        "image_url": image_url,
+        "price_text": price_text,
+        "price_amount": parsed_price.amount,
+        "currency": currency,
+        "rating_text": rating_text,
+        "rating_value": rating,
+        "review_count": review_count,
+        "seller": seller,
+        "shipping_text": shipping,
+        "availability": availability,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Ranking
+# ---------------------------------------------------------------------------
+
+
+def score_candidate(
+    candidate: dict,
+    *,
+    max_price: float | None = None,
+    min_rating: float | None = None,
+) -> float:
+    """Compute a ranking score in [0, 1] (higher is better).
+
+    Heuristic combination of price-fit, rating, and review confidence.
+    Missing fields receive a neutral contribution so they are not unfairly
+    pushed to the bottom.
+
+    Hard constraints (over-budget or below ``min_rating``) cut the final
+    score in half so disqualified items sink below qualifying ones even
+    when their other signals are strong.
+    """
+    parts: list[tuple[float, float]] = []
+    disqualified = False
+
+    price = candidate.get("price_amount")
+    if max_price and price is not None:
+        if price <= 0:
+            price_score = 0.0
+        elif price <= max_price:
+            # Linearly reward being well under the budget, cap at 1.0.
+            price_score = 1.0 - max(0.0, (price - max_price * 0.4) / (max_price * 0.6))
+            price_score = max(0.0, min(1.0, price_score))
+        else:
+            price_score = 0.0
+            disqualified = True
+        parts.append((0.4, price_score))
+    elif price is not None and price > 0:
+        # Without an explicit budget, give a mild bonus for "has a price".
+        parts.append((0.1, 0.6))
+
+    rating = candidate.get("rating_value")
+    if rating is not None:
+        rating_score = max(0.0, min(1.0, rating / 5.0))
+        if min_rating is not None and rating < min_rating:
+            rating_score = 0.0
+            disqualified = True
+        parts.append((0.35, rating_score))
+
+    reviews = candidate.get("review_count")
+    if reviews is not None and reviews > 0:
+        # Diminishing returns past ~1000 reviews.
+        review_score = min(1.0, reviews / 1000.0)
+        parts.append((0.15, review_score))
+
+    availability = (candidate.get("availability") or "").lower()
+    if availability:
+        in_stock = not any(token in availability for token in ("out of stock", "unavailable", "sold out"))
+        parts.append((0.1, 1.0 if in_stock else 0.0))
+
+    if not parts:
+        return 0.5
+
+    total_weight = sum(w for w, _ in parts)
+    if total_weight == 0:
+        return 0.5
+    base = sum(w * s for w, s in parts) / total_weight
+    if disqualified:
+        # Hard penalty keeps disqualified items below qualifying ones even
+        # when the rest of their signals are strong.
+        base *= 0.4
+    return base
+
+
+def rank_candidates(
+    candidates: list[dict],
+    *,
+    max_price: float | None = None,
+    min_rating: float | None = None,
+) -> list[dict]:
+    """Return ``candidates`` sorted by score (descending) with ``rank``/``score`` filled in."""
+    scored = [
+        (score_candidate(c, max_price=max_price, min_rating=min_rating), c) for c in candidates
+    ]
+    scored.sort(key=lambda x: x[0], reverse=True)
+    ranked: list[dict] = []
+    for index, (score, c) in enumerate(scored, start=1):
+        ranked.append({**c, "rank": index, "score": score})
+    return ranked
+
+
+__all__ = [
+    "ParsedPrice",
+    "normalize_candidate",
+    "parse_price",
+    "parse_rating",
+    "parse_review_count",
+    "rank_candidates",
+    "score_candidate",
+]

--- a/backend/ecommerce/router.py
+++ b/backend/ecommerce/router.py
@@ -1,0 +1,405 @@
+"""REST endpoints for the e-commerce shopping agent."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.database import get_db
+from backend.ecommerce import agent
+from backend.ecommerce.browser_commands import BrowserExec
+from backend.ecommerce.models import EcommerceAgentRun
+from backend.ecommerce.schemas import (
+    AgentEventOut,
+    CancelRequest,
+    CandidateOut,
+    CheckpointOut,
+    ConfirmRequest,
+    RunDetailOut,
+    RunOut,
+    SelectCandidateRequest,
+    SiteProfileOut,
+    StartRunRequest,
+)
+from backend.ecommerce.site_catalog import all_profiles, get_profile
+from backend.ecommerce.workflows import all_workflows, get_workflow
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/ecommerce-agent", tags=["ecommerce-agent"])
+
+
+# ---------------------------------------------------------------------------
+# Browser executor injection
+# ---------------------------------------------------------------------------
+#
+# The default executor delegates to the shared browser command bridge. Tests
+# can override `_executor_factory` to substitute a mock that records the
+# commands the agent issued without touching a real browser.
+
+
+def _default_executor() -> BrowserExec:
+    from backend.elicitation.browser_bridge import execute_command
+
+    async def _exec(command_type: str, params: dict) -> dict:
+        return await execute_command(command_type, params)
+
+    return _exec
+
+
+_executor_factory: Callable[[], BrowserExec] = _default_executor
+
+
+def set_executor_factory(factory: Callable[[], BrowserExec]) -> None:
+    """Override the executor factory (used in tests)."""
+    global _executor_factory
+    _executor_factory = factory
+
+
+def reset_executor_factory() -> None:
+    """Reset the executor factory back to the bridge default."""
+    global _executor_factory
+    _executor_factory = _default_executor
+
+
+def _get_executor() -> BrowserExec:
+    return _executor_factory()
+
+
+# ---------------------------------------------------------------------------
+# Serialization helpers
+# ---------------------------------------------------------------------------
+
+
+def _checkpoint_out(run: EcommerceAgentRun) -> CheckpointOut | None:
+    cp = agent.get_checkpoint(run)
+    if cp is None:
+        return None
+    return CheckpointOut(
+        action=cp.action,
+        label=cp.label,
+        detail=cp.detail,
+        candidate_id=cp.candidate_id,
+        metadata=cp.metadata or {},
+    )
+
+
+def _safe_float(value: str) -> float | None:
+    if not value:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _safe_int(value: str) -> int | None:
+    if not value:
+        return None
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _run_out(run: EcommerceAgentRun) -> RunOut:
+    allowed = _decode_list(run.allowed_side_effects_json)
+    forbidden = _decode_list(run.forbidden_side_effects_json)
+    return RunOut(
+        id=run.id,
+        status=run.status,
+        site_slug=run.site_slug,
+        query=run.query,
+        region=run.region,
+        currency=run.currency,
+        max_price=_safe_float(run.max_price),
+        min_rating=_safe_float(run.min_rating),
+        shipping_preference=run.shipping_preference,
+        notes=run.notes,
+        allowed_side_effects=allowed,
+        forbidden_side_effects=forbidden,
+        selected_candidate_id=run.selected_candidate_id,
+        pending_checkpoint=_checkpoint_out(run),
+        failure_reason=run.failure_reason,
+        created_at=run.created_at,
+        updated_at=run.updated_at,
+        completed_at=run.completed_at,
+    )
+
+
+def _decode_list(json_text: str) -> list[str]:
+    try:
+        value = json.loads(json_text or "[]")
+        if isinstance(value, list):
+            return [str(item) for item in value]
+    except json.JSONDecodeError:
+        pass
+    return []
+
+
+async def _resolve_run(run_id: str, db: AsyncSession) -> EcommerceAgentRun:
+    run = await agent.get_run(db, run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id!r} not found")
+    return run
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/sites", response_model=list[SiteProfileOut])
+async def list_sites() -> list[SiteProfileOut]:
+    """Return the full top-20 site catalog."""
+    return [
+        SiteProfileOut(
+            slug=p.slug,
+            name=p.name,
+            domains=list(p.domains),
+            regional_domains=list(p.regional_domains),
+            home_url=p.home_url,
+            currency=p.currency,
+            locale=p.locale,
+            forbidden_action_labels=list(p.forbidden_action_labels),
+            notes=p.notes,
+        )
+        for p in all_profiles()
+    ]
+
+
+@router.get("/workflows")
+async def list_workflows() -> list[dict[str, Any]]:
+    """Return the per-site workflow manifests for the full catalog."""
+    return [
+        {
+            "slug": w.slug,
+            "notes": w.notes,
+            "extra_caveats": list(w.extra_caveats),
+            "mcp_server": w.mcp_server,
+            "skill": w.skill,
+            "stages": [
+                {
+                    "name": s.name,
+                    "description": s.description,
+                    "expected_url_substrings": list(s.expected_url_substrings),
+                    "success_indicators": list(s.success_indicators),
+                    "forbidden_in_stage": list(s.forbidden_in_stage),
+                }
+                for s in w.stages
+            ],
+        }
+        for w in all_workflows()
+    ]
+
+
+@router.get("/workflows/{slug}")
+async def get_workflow_endpoint(slug: str) -> dict[str, Any]:
+    try:
+        w = get_workflow(slug)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return {
+        "slug": w.slug,
+        "notes": w.notes,
+        "extra_caveats": list(w.extra_caveats),
+        "mcp_server": w.mcp_server,
+        "skill": w.skill,
+        "stages": [
+            {
+                "name": s.name,
+                "description": s.description,
+                "expected_url_substrings": list(s.expected_url_substrings),
+                "success_indicators": list(s.success_indicators),
+                "forbidden_in_stage": list(s.forbidden_in_stage),
+            }
+            for s in w.stages
+        ],
+    }
+
+
+@router.get("/sites/{slug}", response_model=SiteProfileOut)
+async def get_site(slug: str) -> SiteProfileOut:
+    try:
+        p = get_profile(slug)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return SiteProfileOut(
+        slug=p.slug,
+        name=p.name,
+        domains=list(p.domains),
+        regional_domains=list(p.regional_domains),
+        home_url=p.home_url,
+        currency=p.currency,
+        locale=p.locale,
+        forbidden_action_labels=list(p.forbidden_action_labels),
+        notes=p.notes,
+    )
+
+
+@router.post("/runs", response_model=RunOut, status_code=201)
+async def start_run(
+    body: StartRunRequest,
+    db: AsyncSession = Depends(get_db),
+) -> RunOut:
+    """Create a new shopping run and immediately drive the initial search."""
+    try:
+        run = await agent.create_run(
+            db,
+            site_slug=body.site_slug,
+            query=body.query,
+            region=body.region,
+            currency=body.currency,
+            max_price=body.max_price,
+            min_rating=body.min_rating,
+            shipping_preference=body.shipping_preference,
+            notes=body.notes,
+            allowed_side_effects=body.allowed_side_effects,
+            forbidden_side_effects=body.forbidden_side_effects,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        executor = _get_executor()
+        run = await agent.search(db, run, executor)
+        if body.auto_pilot:
+            run = await agent.auto_advance_after_search(db, run, executor)
+    except TimeoutError as exc:
+        raise HTTPException(
+            status_code=504,
+            detail=(
+                f"Browser bridge timed out: {exc}. Is Chrome running with the "
+                "NoUI extension connected?"
+            ),
+        ) from exc
+    except Exception as exc:  # pragma: no cover — defensive surface for the user
+        logger.exception("search failed")
+        raise HTTPException(status_code=500, detail=f"Search failed: {exc}") from exc
+
+    return _run_out(run)
+
+
+@router.get("/runs", response_model=list[RunOut])
+async def list_runs(db: AsyncSession = Depends(get_db)) -> list[RunOut]:
+    from sqlalchemy import select
+
+    result = await db.execute(
+        select(EcommerceAgentRun).order_by(EcommerceAgentRun.created_at.desc())
+    )
+    return [_run_out(r) for r in result.scalars().all()]
+
+
+@router.get("/runs/{run_id}", response_model=RunDetailOut)
+async def get_run(run_id: str, db: AsyncSession = Depends(get_db)) -> RunDetailOut:
+    run = await _resolve_run(run_id, db)
+    candidates = await agent.list_candidates(db, run_id)
+    events = await agent.list_events(db, run_id)
+
+    base = _run_out(run).model_dump()
+    base["candidates"] = [
+        CandidateOut(
+            id=c.id,
+            rank=c.rank,
+            title=c.title,
+            url=c.url,
+            image_url=c.image_url,
+            price_text=c.price_text,
+            price_amount=_safe_float(c.price_amount),
+            currency=c.currency,
+            rating_text=c.rating_text,
+            rating_value=_safe_float(c.rating_value),
+            review_count=_safe_int(c.review_count),
+            seller=c.seller,
+            shipping_text=c.shipping_text,
+            availability=c.availability,
+            score=_safe_float(c.score),
+        )
+        for c in candidates
+    ]
+    base["events"] = [
+        AgentEventOut(
+            id=e.id,
+            event_type=e.event_type,
+            severity=e.severity,
+            summary=e.summary,
+            payload=_decode_payload(e.payload_json),
+            timestamp=e.timestamp,
+        )
+        for e in events
+    ]
+    return RunDetailOut(**base)
+
+
+def _decode_payload(text: str) -> dict[str, Any]:
+    if not text:
+        return {}
+    try:
+        value = json.loads(text)
+        return value if isinstance(value, dict) else {"value": value}
+    except json.JSONDecodeError:
+        return {"raw": text}
+
+
+@router.post("/runs/{run_id}/select", response_model=RunOut)
+async def select(
+    run_id: str,
+    body: SelectCandidateRequest,
+    db: AsyncSession = Depends(get_db),
+) -> RunOut:
+    run = await _resolve_run(run_id, db)
+    if run.status not in {
+        agent.RunStatus.AWAITING_SELECTION,
+        agent.RunStatus.SELECTED,
+    }:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Run status {run.status!r} does not allow selection",
+        )
+    try:
+        run, _ = await agent.select_candidate(
+            db,
+            run,
+            _get_executor(),
+            body.candidate_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _run_out(run)
+
+
+@router.post("/runs/{run_id}/confirm", response_model=RunOut)
+async def confirm(
+    run_id: str,
+    body: ConfirmRequest,
+    db: AsyncSession = Depends(get_db),
+) -> RunOut:
+    run = await _resolve_run(run_id, db)
+    try:
+        run = await agent.confirm(
+            db,
+            run,
+            _get_executor(),
+            action=body.action,
+            approved=body.approved,
+            user_note=body.user_note,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _run_out(run)
+
+
+@router.post("/runs/{run_id}/cancel", response_model=RunOut)
+async def cancel(
+    run_id: str,
+    body: CancelRequest,
+    db: AsyncSession = Depends(get_db),
+) -> RunOut:
+    run = await _resolve_run(run_id, db)
+    run = await agent.cancel_run(db, run, reason=body.reason)
+    return _run_out(run)

--- a/backend/ecommerce/safety.py
+++ b/backend/ecommerce/safety.py
@@ -1,0 +1,211 @@
+"""Confirmation gates and forbidden-action detection for the e-commerce agent.
+
+The agent has three layers of protection against making a real purchase
+without explicit human approval:
+
+1. ``AgentPolicy`` — per-run allow/forbid list backed by user input.
+2. ``is_forbidden_label`` (site_catalog) — string-level detection of any
+   button label that looks like a final order/payment action.
+3. ``classify_action`` — categorizes a proposed browser action into one of
+   the named side-effect categories so the policy can be consulted before
+   any click is dispatched.
+
+The goal is defense-in-depth: even if a planner is fooled into proposing
+a forbidden click, the policy gate will refuse before the command queue
+ever sends it to the extension.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from backend.ecommerce.site_catalog import SiteProfile, is_forbidden_label, normalize_label
+
+# Side-effect categories used in the policy allow/forbid lists.
+SIDE_EFFECT_SEARCH = "search"
+SIDE_EFFECT_BROWSE = "browse"
+SIDE_EFFECT_ADD_TO_CART = "add_to_cart"
+SIDE_EFFECT_PROCEED_TO_CHECKOUT = "proceed_to_checkout"
+SIDE_EFFECT_FILL_SHIPPING = "fill_shipping"
+SIDE_EFFECT_PLACE_ORDER = "place_order"
+SIDE_EFFECT_PAY = "pay"
+SIDE_EFFECT_SUBMIT_PAYMENT = "submit_payment"
+SIDE_EFFECT_CONFIRM_ORDER = "confirm_order"
+
+ALL_SIDE_EFFECTS: tuple[str, ...] = (
+    SIDE_EFFECT_SEARCH,
+    SIDE_EFFECT_BROWSE,
+    SIDE_EFFECT_ADD_TO_CART,
+    SIDE_EFFECT_PROCEED_TO_CHECKOUT,
+    SIDE_EFFECT_FILL_SHIPPING,
+    SIDE_EFFECT_PLACE_ORDER,
+    SIDE_EFFECT_PAY,
+    SIDE_EFFECT_SUBMIT_PAYMENT,
+    SIDE_EFFECT_CONFIRM_ORDER,
+)
+
+# Side effects that always require explicit human confirmation regardless of
+# how a run was configured.
+HARD_FORBIDDEN: frozenset[str] = frozenset(
+    {
+        SIDE_EFFECT_PLACE_ORDER,
+        SIDE_EFFECT_PAY,
+        SIDE_EFFECT_SUBMIT_PAYMENT,
+        SIDE_EFFECT_CONFIRM_ORDER,
+    }
+)
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Result of consulting an `AgentPolicy` for a proposed action."""
+
+    allowed: bool
+    requires_confirmation: bool
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class AgentPolicy:
+    """Per-run allow/forbid policy.
+
+    `allowed_side_effects` enumerates the side-effect categories the agent
+    may perform on its own. Any side effect outside that list (and not in
+    `HARD_FORBIDDEN`) requires user confirmation before execution. Side
+    effects in `HARD_FORBIDDEN` are never auto-executed and can only be
+    surfaced as confirmation prompts the user must explicitly approve in a
+    later, separately-authorized flow (not implemented in this agent).
+    """
+
+    allowed_side_effects: frozenset[str]
+    forbidden_side_effects: frozenset[str]
+
+    # Default allow-list when the caller passes None. Mirrors the StartRunRequest
+    # schema default so direct callers of `create_run` get the same safe defaults
+    # as REST clients. Explicitly passing an empty list still narrows the policy
+    # to just search/browse.
+    DEFAULT_ALLOW: tuple[str, ...] = (
+        SIDE_EFFECT_SEARCH,
+        SIDE_EFFECT_BROWSE,
+        SIDE_EFFECT_ADD_TO_CART,
+    )
+
+    @classmethod
+    def from_lists(
+        cls,
+        allowed: Iterable[str] | None,
+        forbidden: Iterable[str] | None,
+    ) -> AgentPolicy:
+        if allowed is None:
+            allow: set[str] = set(cls.DEFAULT_ALLOW)
+        else:
+            allow = {SIDE_EFFECT_SEARCH, SIDE_EFFECT_BROWSE}
+            allow.update(s.strip().lower() for s in allowed if s and s.strip())
+        forbid = set(HARD_FORBIDDEN)
+        if forbidden:
+            forbid.update(s.strip().lower() for s in forbidden if s and s.strip())
+        # Anything explicitly forbidden wins over anything allowed.
+        allow.difference_update(forbid)
+        return cls(frozenset(allow), frozenset(forbid))
+
+    def evaluate(self, side_effect: str) -> PolicyDecision:
+        normalized = side_effect.strip().lower()
+        if not normalized:
+            return PolicyDecision(allowed=False, requires_confirmation=False, reason="empty side effect")
+        if normalized in self.forbidden_side_effects:
+            return PolicyDecision(
+                allowed=False,
+                requires_confirmation=True,
+                reason=f"{normalized} is forbidden for this run",
+            )
+        if normalized in self.allowed_side_effects:
+            return PolicyDecision(allowed=True, requires_confirmation=False)
+        # Unknown side effect: not explicitly forbidden, not explicitly
+        # allowed. We force a confirmation prompt rather than refusing
+        # outright, so the user can authorize unusual flows on a case-by-case
+        # basis without expanding the global policy.
+        return PolicyDecision(
+            allowed=False,
+            requires_confirmation=True,
+            reason=f"{normalized} requires explicit user confirmation",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Action classification
+# ---------------------------------------------------------------------------
+
+
+# Substrings -> side effect. Order matters: more specific phrases first so
+# "submit payment" classifies as submit_payment, not as a generic submit.
+_LABEL_RULES: tuple[tuple[str, str], ...] = (
+    ("submit payment", SIDE_EFFECT_SUBMIT_PAYMENT),
+    ("authorize payment", SIDE_EFFECT_SUBMIT_PAYMENT),
+    ("authorise payment", SIDE_EFFECT_SUBMIT_PAYMENT),
+    ("pay now", SIDE_EFFECT_PAY),
+    ("pay with", SIDE_EFFECT_PAY),
+    ("place your order", SIDE_EFFECT_PLACE_ORDER),
+    ("place order", SIDE_EFFECT_PLACE_ORDER),
+    ("submit order", SIDE_EFFECT_PLACE_ORDER),
+    ("complete order", SIDE_EFFECT_PLACE_ORDER),
+    ("confirm order", SIDE_EFFECT_CONFIRM_ORDER),
+    ("confirm purchase", SIDE_EFFECT_CONFIRM_ORDER),
+    ("confirm and pay", SIDE_EFFECT_CONFIRM_ORDER),
+    ("complete purchase", SIDE_EFFECT_CONFIRM_ORDER),
+    ("complete payment", SIDE_EFFECT_SUBMIT_PAYMENT),
+    ("buy now", SIDE_EFFECT_PLACE_ORDER),
+    ("buy it now", SIDE_EFFECT_PLACE_ORDER),
+    ("proceed to checkout", SIDE_EFFECT_PROCEED_TO_CHECKOUT),
+    ("go to checkout", SIDE_EFFECT_PROCEED_TO_CHECKOUT),
+    ("continue to checkout", SIDE_EFFECT_PROCEED_TO_CHECKOUT),
+    ("checkout", SIDE_EFFECT_PROCEED_TO_CHECKOUT),
+    ("add to cart", SIDE_EFFECT_ADD_TO_CART),
+    ("add to bag", SIDE_EFFECT_ADD_TO_CART),
+    ("add to basket", SIDE_EFFECT_ADD_TO_CART),
+    ("save shipping", SIDE_EFFECT_FILL_SHIPPING),
+    ("use this address", SIDE_EFFECT_FILL_SHIPPING),
+)
+
+
+def classify_action(label: str, profile: SiteProfile | None = None) -> str:
+    """Return the canonical side-effect category for a button label.
+
+    Falls back to ``browse`` for navigation-style clicks and labels we
+    cannot classify. Always honors `is_forbidden_label`: if the label
+    matches a hard-forbidden phrase but did not match a more specific rule
+    above, classify as ``place_order`` to keep the safety bar high.
+    """
+    needle = normalize_label(label)
+    if not needle:
+        return SIDE_EFFECT_BROWSE
+    for phrase, category in _LABEL_RULES:
+        if phrase in needle:
+            return category
+    if is_forbidden_label(label, profile):
+        return SIDE_EFFECT_PLACE_ORDER
+    return SIDE_EFFECT_BROWSE
+
+
+def is_hard_forbidden(side_effect: str) -> bool:
+    """True when the side effect can never be auto-executed by the agent."""
+    return side_effect.strip().lower() in HARD_FORBIDDEN
+
+
+__all__ = [
+    "ALL_SIDE_EFFECTS",
+    "AgentPolicy",
+    "HARD_FORBIDDEN",
+    "PolicyDecision",
+    "SIDE_EFFECT_ADD_TO_CART",
+    "SIDE_EFFECT_BROWSE",
+    "SIDE_EFFECT_CONFIRM_ORDER",
+    "SIDE_EFFECT_FILL_SHIPPING",
+    "SIDE_EFFECT_PAY",
+    "SIDE_EFFECT_PLACE_ORDER",
+    "SIDE_EFFECT_PROCEED_TO_CHECKOUT",
+    "SIDE_EFFECT_SEARCH",
+    "SIDE_EFFECT_SUBMIT_PAYMENT",
+    "classify_action",
+    "is_hard_forbidden",
+]

--- a/backend/ecommerce/schemas.py
+++ b/backend/ecommerce/schemas.py
@@ -1,0 +1,162 @@
+"""Pydantic schemas for the e-commerce agent REST API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Input schemas
+# ---------------------------------------------------------------------------
+
+
+class StartRunRequest(BaseModel):
+    """Begin a shopping task on one of the supported sites.
+
+    The agent runs inside whichever Chrome tab the NoUI extension controls.
+    For *search* on the top-20 sites no login is required. For *add to
+    cart* and *proceed to checkout*, most sites (Amazon, eBay, Walmart,
+    Etsy, Best Buy, Target, etc.) require an active signed-in session in
+    that Chrome tab. If the agent encounters a sign-in wall on add-to-cart
+    it surfaces a ``retry_add_to_cart`` checkpoint so the user can sign in
+    manually and then resume by approving the retry.
+    """
+
+    site_slug: str = Field(..., description="Identifier of a site in the catalog")
+    query: str = Field(..., min_length=1)
+    region: str = ""
+    currency: str = ""
+    max_price: float | None = None
+    min_rating: float | None = None
+    shipping_preference: str = ""
+    notes: str = ""
+    auto_pilot: bool = Field(
+        default=True,
+        description=(
+            "When true (default), the agent automatically searches, picks the "
+            "top-ranked candidate, and adds it to the cart, pausing only for "
+            "human confirmation right before checkout. When false, every "
+            "side effect requires an explicit confirm call."
+        ),
+    )
+    allowed_side_effects: list[str] = Field(
+        default_factory=lambda: ["search", "browse", "add_to_cart"]
+    )
+    forbidden_side_effects: list[str] = Field(
+        default_factory=lambda: [
+            "place_order",
+            "pay",
+            "submit_payment",
+            "confirm_order",
+        ]
+    )
+
+
+class SelectCandidateRequest(BaseModel):
+    """Pick a previously-surfaced candidate to add to cart."""
+
+    candidate_id: str
+
+
+class ConfirmRequest(BaseModel):
+    """User response to a pending confirmation checkpoint.
+
+    `action` is the proposed side-effect ID returned in the checkpoint
+    payload. `approved` indicates whether the agent should proceed. The
+    agent will never escalate beyond the configured allowed side effects
+    even when ``approved`` is True for a disallowed action.
+    """
+
+    action: str
+    approved: bool
+    user_note: str = ""
+
+
+class CancelRequest(BaseModel):
+    reason: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Output schemas
+# ---------------------------------------------------------------------------
+
+
+class CandidateOut(BaseModel):
+    id: str
+    rank: int
+    title: str
+    url: str
+    image_url: str
+    price_text: str
+    price_amount: float | None
+    currency: str
+    rating_text: str
+    rating_value: float | None
+    review_count: int | None
+    seller: str
+    shipping_text: str
+    availability: str
+    score: float | None
+
+    model_config = {"from_attributes": True}
+
+
+class CheckpointOut(BaseModel):
+    """A point at which the agent paused for human confirmation."""
+
+    action: str
+    label: str
+    detail: str
+    candidate_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentEventOut(BaseModel):
+    id: str
+    event_type: str
+    severity: str
+    summary: str
+    payload: dict[str, Any]
+    timestamp: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class RunOut(BaseModel):
+    id: str
+    status: str
+    site_slug: str
+    query: str
+    region: str
+    currency: str
+    max_price: float | None
+    min_rating: float | None
+    shipping_preference: str
+    notes: str
+    allowed_side_effects: list[str]
+    forbidden_side_effects: list[str]
+    selected_candidate_id: str | None
+    pending_checkpoint: CheckpointOut | None
+    failure_reason: str
+    created_at: datetime
+    updated_at: datetime
+    completed_at: datetime | None
+
+
+class RunDetailOut(RunOut):
+    candidates: list[CandidateOut] = Field(default_factory=list)
+    events: list[AgentEventOut] = Field(default_factory=list)
+
+
+class SiteProfileOut(BaseModel):
+    slug: str
+    name: str
+    domains: list[str]
+    regional_domains: list[str]
+    home_url: str
+    currency: str
+    locale: str
+    forbidden_action_labels: list[str]
+    notes: str

--- a/backend/ecommerce/site_catalog.py
+++ b/backend/ecommerce/site_catalog.py
@@ -1,0 +1,679 @@
+"""Top-20 global e-commerce site catalog and site profile schema.
+
+Each `SiteProfile` describes how the agent should drive a single retailer:
+search URL template, selector hints, login URL, locale, currency, and the
+forbidden action labels that gate any final checkout/payment side effect.
+
+The registry is purposely declarative so the list of supported sites and
+their per-site safety metadata can be changed without touching the agent
+core.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from urllib.parse import quote_plus, urlparse
+
+
+@dataclass(frozen=True)
+class SiteProfile:
+    """Declarative profile for a single e-commerce site.
+
+    Attributes:
+        slug: Stable lowercase identifier used in API requests and audit logs.
+        name: Human-readable site name.
+        domains: One or more domains owned by the site. The first entry is
+            treated as the canonical domain. Regional mirrors live under
+            ``regional_domains``.
+        regional_domains: Optional list of additional domains (e.g. country
+            variants) that should resolve to this profile.
+        home_url: Site landing URL used when no other context is available.
+        search_url_template: URL template for keyword search. The literal
+            substring ``{query}`` is replaced with the URL-encoded query.
+        login_url: Optional explicit login URL. Empty when the site only
+            requires login at checkout.
+        cart_url: Optional explicit cart URL.
+        currency: ISO 4217 currency code typically displayed on the site.
+        locale: BCP 47 locale string that best describes the default UI.
+        product_card_selectors: CSS selectors that, in priority order, target
+            search-result product cards on the search page.
+        product_title_selectors: Selectors that target the product title text
+            inside a card or on a product page.
+        product_price_selectors: Selectors that target the visible price text.
+        product_link_selectors: Selectors whose ``href`` points to the
+            product detail page.
+        add_to_cart_labels: Visible button labels (case-insensitive substring
+            match) that add the current item to cart.
+        cart_link_labels: Visible link labels for navigating to the cart.
+        checkout_labels: Labels that take the user into the checkout funnel.
+            These are allowed up to (but not through) the payment step.
+        forbidden_action_labels: Labels for buttons the agent must never
+            click without explicit human approval. These cover final order
+            placement and payment submission.
+        notes: Operator notes (e.g. anti-bot caveats, login quirks).
+    """
+
+    slug: str
+    name: str
+    domains: tuple[str, ...]
+    home_url: str
+    search_url_template: str
+    regional_domains: tuple[str, ...] = ()
+    login_url: str = ""
+    cart_url: str = ""
+    currency: str = "USD"
+    locale: str = "en-US"
+    product_card_selectors: tuple[str, ...] = ()
+    product_title_selectors: tuple[str, ...] = ()
+    product_price_selectors: tuple[str, ...] = ()
+    product_link_selectors: tuple[str, ...] = ()
+    add_to_cart_labels: tuple[str, ...] = ()
+    cart_link_labels: tuple[str, ...] = ()
+    checkout_labels: tuple[str, ...] = ()
+    forbidden_action_labels: tuple[str, ...] = field(default_factory=tuple)
+    notes: str = ""
+
+    def build_search_url(self, query: str) -> str:
+        """Render the search URL for ``query``.
+
+        URL-encodes the query so callers can pass raw user text without
+        worrying about reserved characters.
+        """
+        if not query:
+            raise ValueError("query must be non-empty")
+        if "{query}" not in self.search_url_template:
+            raise ValueError(
+                f"search_url_template for {self.slug!r} is missing the '{{query}}' placeholder"
+            )
+        return self.search_url_template.replace("{query}", quote_plus(query))
+
+    def matches_domain(self, url_or_host: str) -> bool:
+        """Return True when ``url_or_host`` belongs to this profile."""
+        host = _extract_host(url_or_host)
+        if not host:
+            return False
+        for d in (*self.domains, *self.regional_domains):
+            if host == d or host.endswith("." + d):
+                return True
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Shared "never click" labels — applied on top of per-site forbidden labels
+# ---------------------------------------------------------------------------
+
+# These match the universal anti-purchase / anti-payment buttons we never
+# auto-click. Per-site profiles can extend this list with localized variants.
+COMMON_FORBIDDEN_LABELS: tuple[str, ...] = (
+    "place order",
+    "place your order",
+    "submit order",
+    "complete order",
+    "confirm order",
+    "confirm and pay",
+    "confirm purchase",
+    "pay now",
+    "pay with",
+    "buy now",
+    "buy it now",
+    "buy",
+    "checkout now",
+    "complete purchase",
+    "complete payment",
+    "authorize payment",
+    "authorise payment",
+    "place secure order",
+    "submit payment",
+)
+
+
+def _extract_host(url_or_host: str) -> str:
+    if not url_or_host:
+        return ""
+    if "://" in url_or_host:
+        host = urlparse(url_or_host).hostname or ""
+    else:
+        host = url_or_host
+    return host.lower().lstrip(".")
+
+
+# ---------------------------------------------------------------------------
+# Catalog — top 20 global e-commerce sites
+# ---------------------------------------------------------------------------
+
+_CATALOG: tuple[SiteProfile, ...] = (
+    SiteProfile(
+        slug="amazon",
+        name="Amazon",
+        domains=("amazon.com",),
+        regional_domains=(
+            "amazon.co.uk",
+            "amazon.de",
+            "amazon.fr",
+            "amazon.it",
+            "amazon.es",
+            "amazon.co.jp",
+            "amazon.ca",
+            "amazon.com.au",
+            "amazon.in",
+            "amazon.com.br",
+            "amazon.com.mx",
+        ),
+        home_url="https://www.amazon.com",
+        search_url_template="https://www.amazon.com/s?k={query}",
+        login_url="https://www.amazon.com/ap/signin",
+        cart_url="https://www.amazon.com/gp/cart/view.html",
+        currency="USD",
+        product_card_selectors=(
+            "div[data-component-type='s-search-result']",
+            "div.s-result-item[data-asin]",
+        ),
+        product_title_selectors=("h2 a span", "span.a-text-normal"),
+        product_price_selectors=(".a-price .a-offscreen", ".a-price"),
+        product_link_selectors=("h2 a.a-link-normal", "a.a-link-normal"),
+        add_to_cart_labels=("add to cart", "add to basket"),
+        cart_link_labels=("cart", "basket"),
+        checkout_labels=("proceed to checkout", "proceed to buy", "go to checkout"),
+        forbidden_action_labels=(
+            "place your order",
+            "place order",
+            "buy now",
+            "1-click",
+            "one-click",
+        ),
+        notes="Amazon presents 'Buy Now' on product pages — always forbidden.",
+    ),
+    SiteProfile(
+        slug="ebay",
+        name="eBay",
+        domains=("ebay.com",),
+        regional_domains=("ebay.co.uk", "ebay.de", "ebay.com.au", "ebay.ca"),
+        home_url="https://www.ebay.com",
+        search_url_template="https://www.ebay.com/sch/i.html?_nkw={query}",
+        login_url="https://signin.ebay.com",
+        cart_url="https://cart.ebay.com",
+        currency="USD",
+        product_card_selectors=("li.s-item", "div.s-item__wrapper"),
+        product_title_selectors=(".s-item__title",),
+        product_price_selectors=(".s-item__price",),
+        product_link_selectors=("a.s-item__link",),
+        add_to_cart_labels=("add to cart", "add to basket"),
+        cart_link_labels=("cart", "basket"),
+        checkout_labels=("go to checkout", "proceed to checkout", "review order"),
+        forbidden_action_labels=("buy it now", "confirm and pay", "place order"),
+    ),
+    SiteProfile(
+        slug="aliexpress",
+        name="AliExpress",
+        domains=("aliexpress.com", "aliexpress.us"),
+        home_url="https://www.aliexpress.com",
+        search_url_template="https://www.aliexpress.com/wholesale?SearchText={query}",
+        login_url="https://login.aliexpress.com",
+        cart_url="https://www.aliexpress.com/p/shoppingcart/index.html",
+        currency="USD",
+        product_card_selectors=(
+            "a.search-card-item",
+            "div.list--gallery--C2f2tvm a",
+        ),
+        product_title_selectors=("h3", ".multi--titleText--nXeOvyr"),
+        product_price_selectors=(
+            ".multi--price-sale--U-S0jtj",
+            ".manhattan--price--WvaUgDY",
+        ),
+        product_link_selectors=("a.search-card-item",),
+        add_to_cart_labels=("add to cart",),
+        cart_link_labels=("cart",),
+        checkout_labels=("proceed to checkout", "go to checkout"),
+        forbidden_action_labels=("place order", "buy now", "pay now"),
+        notes="Frequently shows aggressive captcha challenges — agent must pause.",
+    ),
+    SiteProfile(
+        slug="walmart",
+        name="Walmart",
+        domains=("walmart.com",),
+        regional_domains=("walmart.ca", "walmart.com.mx"),
+        home_url="https://www.walmart.com",
+        search_url_template="https://www.walmart.com/search?q={query}",
+        login_url="https://www.walmart.com/account/login",
+        cart_url="https://www.walmart.com/cart",
+        currency="USD",
+        product_card_selectors=("div[data-item-id]", "div[data-testid='item-stack']"),
+        product_title_selectors=("span[data-automation-id='product-title']", "a span"),
+        product_price_selectors=("div[data-automation-id='product-price']", "span.f6"),
+        product_link_selectors=("a[link-identifier='linkTest']", "a"),
+        add_to_cart_labels=("add to cart",),
+        cart_link_labels=("cart",),
+        checkout_labels=("continue to checkout", "checkout"),
+        forbidden_action_labels=("place order", "place your order", "buy now"),
+    ),
+    SiteProfile(
+        slug="etsy",
+        name="Etsy",
+        domains=("etsy.com",),
+        home_url="https://www.etsy.com",
+        search_url_template="https://www.etsy.com/search?q={query}",
+        login_url="https://www.etsy.com/signin",
+        cart_url="https://www.etsy.com/cart",
+        currency="USD",
+        product_card_selectors=("div.v2-listing-card", "li.wt-list-unstyled"),
+        product_title_selectors=("h3.v2-listing-card__title", "h3"),
+        product_price_selectors=("span.currency-value", "p.lc-price"),
+        product_link_selectors=("a.listing-link", "a"),
+        add_to_cart_labels=("add to cart", "add to basket"),
+        cart_link_labels=("cart",),
+        checkout_labels=("proceed to checkout",),
+        forbidden_action_labels=("place your order", "place order", "pay now"),
+    ),
+    SiteProfile(
+        slug="rakuten",
+        name="Rakuten",
+        domains=("rakuten.co.jp", "rakuten.com"),
+        home_url="https://www.rakuten.co.jp",
+        search_url_template="https://search.rakuten.co.jp/search/mall/{query}/",
+        login_url="https://login.account.rakuten.com",
+        cart_url="https://basket.step.rakuten.co.jp/rms/mall/bs/cartlist/",
+        currency="JPY",
+        locale="ja-JP",
+        product_card_selectors=("div.searchresultitem", "div.dui-card"),
+        product_title_selectors=("h2 a", "a.title"),
+        product_price_selectors=(".price--3zUvK", "span.important"),
+        product_link_selectors=("a.title", "h2 a"),
+        add_to_cart_labels=("add to cart", "カートに追加", "買い物かごに追加"),
+        cart_link_labels=("cart", "カート"),
+        checkout_labels=("proceed to checkout", "ご購入手続きへ"),
+        forbidden_action_labels=("place order", "注文を確定する", "購入を確定"),
+        notes="Japanese UI — confirmation buttons are localized.",
+    ),
+    SiteProfile(
+        slug="mercadolibre",
+        name="Mercado Libre",
+        domains=("mercadolibre.com",),
+        regional_domains=(
+            "mercadolibre.com.ar",
+            "mercadolibre.com.mx",
+            "mercadolivre.com.br",
+            "mercadolibre.cl",
+            "mercadolibre.com.co",
+        ),
+        home_url="https://www.mercadolibre.com",
+        search_url_template="https://listado.mercadolibre.com.ar/{query}",
+        login_url="https://www.mercadolibre.com/jms/mlb/lgz/login",
+        cart_url="https://www.mercadolibre.com.ar/gz/cart",
+        currency="ARS",
+        locale="es-AR",
+        product_card_selectors=("li.ui-search-layout__item", "div.andes-card"),
+        product_title_selectors=("h2.ui-search-item__title", "h2"),
+        product_price_selectors=("span.andes-money-amount", ".price-tag"),
+        product_link_selectors=("a.ui-search-link",),
+        add_to_cart_labels=("add to cart", "agregar al carrito", "adicionar ao carrinho"),
+        cart_link_labels=("cart", "carrito", "carrinho"),
+        checkout_labels=("continuar", "ir al pago", "ir para o pagamento"),
+        forbidden_action_labels=(
+            "comprar ahora",
+            "comprar agora",
+            "pagar",
+            "confirmar compra",
+            "finalizar compra",
+        ),
+    ),
+    SiteProfile(
+        slug="shopee",
+        name="Shopee",
+        domains=("shopee.com",),
+        regional_domains=(
+            "shopee.sg",
+            "shopee.com.my",
+            "shopee.co.id",
+            "shopee.vn",
+            "shopee.ph",
+            "shopee.co.th",
+            "shopee.tw",
+            "shopee.com.br",
+        ),
+        home_url="https://shopee.sg",
+        search_url_template="https://shopee.sg/search?keyword={query}",
+        login_url="https://shopee.sg/buyer/login",
+        cart_url="https://shopee.sg/cart",
+        currency="SGD",
+        locale="en-SG",
+        product_card_selectors=("div.shopee-search-item-result__item", "li.col-xs-2-4"),
+        product_title_selectors=("div._10Wbs- _5SSWfi UjjMrh", "div.ie3A+n"),
+        product_price_selectors=("span.ZEgDH9",),
+        product_link_selectors=("a[data-sqe='link']",),
+        add_to_cart_labels=("add to cart",),
+        cart_link_labels=("cart",),
+        checkout_labels=("check out", "checkout"),
+        forbidden_action_labels=("place order", "buy now", "confirm payment"),
+        notes="Shopee uses dynamic class names; selectors are best-effort.",
+    ),
+    SiteProfile(
+        slug="lazada",
+        name="Lazada",
+        domains=("lazada.com",),
+        regional_domains=(
+            "lazada.sg",
+            "lazada.com.my",
+            "lazada.co.id",
+            "lazada.vn",
+            "lazada.com.ph",
+            "lazada.co.th",
+        ),
+        home_url="https://www.lazada.sg",
+        search_url_template="https://www.lazada.sg/catalog/?q={query}",
+        login_url="https://member.lazada.sg/user/login",
+        cart_url="https://cart.lazada.sg/cart",
+        currency="SGD",
+        locale="en-SG",
+        product_card_selectors=("div[data-qa-locator='product-item']", "div.Bm3ON"),
+        product_title_selectors=("div.RfADt a", "a.RfADt"),
+        product_price_selectors=("span.ooOxS", "div.aBrP0"),
+        product_link_selectors=("div.RfADt a",),
+        add_to_cart_labels=("add to cart",),
+        cart_link_labels=("cart",),
+        checkout_labels=("proceed to checkout",),
+        forbidden_action_labels=("place order", "buy now", "pay now"),
+    ),
+    SiteProfile(
+        slug="temu",
+        name="Temu",
+        domains=("temu.com",),
+        home_url="https://www.temu.com",
+        search_url_template="https://www.temu.com/search_result.html?search_key={query}",
+        login_url="https://www.temu.com/login.html",
+        cart_url="https://www.temu.com/cart.html",
+        currency="USD",
+        product_card_selectors=("div[data-mid]", "div.product-item"),
+        product_title_selectors=("h2", "div._2qfL3i9R"),
+        product_price_selectors=("div._2de9ERAH", "span._2OlnIWtA"),
+        product_link_selectors=("a",),
+        add_to_cart_labels=("add to cart",),
+        cart_link_labels=("cart",),
+        checkout_labels=("checkout", "proceed to checkout"),
+        forbidden_action_labels=("place order", "pay now", "buy now"),
+    ),
+    SiteProfile(
+        slug="shein",
+        name="Shein",
+        domains=("shein.com",),
+        regional_domains=("us.shein.com", "uk.shein.com", "eur.shein.com"),
+        home_url="https://us.shein.com",
+        search_url_template="https://us.shein.com/pdsearch/{query}/",
+        login_url="https://us.shein.com/user/auth/login",
+        cart_url="https://us.shein.com/cart.html",
+        currency="USD",
+        product_card_selectors=("section.product-card", "div.S-product-item"),
+        product_title_selectors=(".product-card__name", "a[role='link']"),
+        product_price_selectors=(".product-card__price", "span.normal-price"),
+        product_link_selectors=("a.S-product-item__link-target", "a"),
+        add_to_cart_labels=("add to cart", "add to bag"),
+        cart_link_labels=("cart", "bag"),
+        checkout_labels=("check out", "checkout"),
+        forbidden_action_labels=("place order", "pay now"),
+    ),
+    SiteProfile(
+        slug="target",
+        name="Target",
+        domains=("target.com",),
+        home_url="https://www.target.com",
+        search_url_template="https://www.target.com/s?searchTerm={query}",
+        login_url="https://www.target.com/login",
+        cart_url="https://www.target.com/cart",
+        currency="USD",
+        product_card_selectors=(
+            "div[data-test='product-card-default']",
+            "div[data-test='@web/site-top-of-funnel/ProductCardWrapper']",
+        ),
+        product_title_selectors=("a[data-test='product-title']",),
+        product_price_selectors=("span[data-test='current-price']",),
+        product_link_selectors=("a[data-test='product-title']",),
+        add_to_cart_labels=("add to cart", "add for shipping", "add for pickup"),
+        cart_link_labels=("cart",),
+        checkout_labels=("checkout",),
+        forbidden_action_labels=("place your order", "place order", "pay now"),
+    ),
+    SiteProfile(
+        slug="bestbuy",
+        name="Best Buy",
+        domains=("bestbuy.com",),
+        regional_domains=("bestbuy.ca",),
+        home_url="https://www.bestbuy.com",
+        search_url_template="https://www.bestbuy.com/site/searchpage.jsp?st={query}",
+        login_url="https://www.bestbuy.com/identity/signin",
+        cart_url="https://www.bestbuy.com/cart",
+        currency="USD",
+        product_card_selectors=("li.sku-item", "div.product-list-item"),
+        product_title_selectors=("h4.sku-title", "a.product-list-item__title"),
+        product_price_selectors=("div.priceView-customer-price", "div.priceView-hero-price"),
+        product_link_selectors=("h4.sku-title a", "a"),
+        add_to_cart_labels=("add to cart",),
+        cart_link_labels=("cart",),
+        checkout_labels=("checkout",),
+        forbidden_action_labels=("place your order", "place order", "buy now"),
+    ),
+    SiteProfile(
+        slug="costco",
+        name="Costco",
+        domains=("costco.com",),
+        regional_domains=("costco.ca", "costco.co.uk"),
+        home_url="https://www.costco.com",
+        search_url_template="https://www.costco.com/CatalogSearch?keyword={query}",
+        login_url="https://www.costco.com/LogonForm",
+        cart_url="https://www.costco.com/CheckoutCartView",
+        currency="USD",
+        product_card_selectors=("div.product", "div.product-tile-set"),
+        product_title_selectors=("span.description a", "a.description-link"),
+        product_price_selectors=("div.price",),
+        product_link_selectors=("span.description a", "a"),
+        add_to_cart_labels=("add to cart",),
+        cart_link_labels=("cart",),
+        checkout_labels=("checkout",),
+        forbidden_action_labels=("place your order", "place order"),
+    ),
+    SiteProfile(
+        slug="flipkart",
+        name="Flipkart",
+        domains=("flipkart.com",),
+        home_url="https://www.flipkart.com",
+        search_url_template="https://www.flipkart.com/search?q={query}",
+        login_url="https://www.flipkart.com/account/login",
+        cart_url="https://www.flipkart.com/viewcart",
+        currency="INR",
+        locale="en-IN",
+        product_card_selectors=("div._1AtVbE", "div._4ddWXP", "div._13oc-S"),
+        product_title_selectors=("a.IRpwTa", "div._4rR01T", "a.s1Q9rs"),
+        product_price_selectors=("div._30jeq3",),
+        product_link_selectors=("a.IRpwTa", "a._1fQZEK"),
+        add_to_cart_labels=("add to cart",),
+        cart_link_labels=("cart",),
+        checkout_labels=("place order", "continue"),
+        forbidden_action_labels=("place order", "pay", "buy now"),
+        notes=(
+            "Flipkart confusingly labels its final-checkout button 'Place Order' even on "
+            "the address step; treat all 'Place Order' clicks as forbidden by default."
+        ),
+    ),
+    SiteProfile(
+        slug="jd",
+        name="JD.com",
+        domains=("jd.com",),
+        regional_domains=("global.jd.com",),
+        home_url="https://www.jd.com",
+        search_url_template="https://search.jd.com/Search?keyword={query}",
+        login_url="https://passport.jd.com/new/login.aspx",
+        cart_url="https://cart.jd.com/cart_index",
+        currency="CNY",
+        locale="zh-CN",
+        product_card_selectors=("li.gl-item", "div.gl-i-wrap"),
+        product_title_selectors=("div.p-name a em", "div.p-name"),
+        product_price_selectors=("div.p-price i", "div.p-price"),
+        product_link_selectors=("div.p-name a",),
+        add_to_cart_labels=("add to cart", "加入购物车"),
+        cart_link_labels=("cart", "购物车"),
+        checkout_labels=("checkout", "去结算", "结算"),
+        forbidden_action_labels=("place order", "提交订单", "立即购买", "立即支付"),
+    ),
+    SiteProfile(
+        slug="taobao",
+        name="Taobao / Tmall",
+        domains=("taobao.com", "tmall.com"),
+        home_url="https://www.taobao.com",
+        search_url_template="https://s.taobao.com/search?q={query}",
+        login_url="https://login.taobao.com",
+        cart_url="https://cart.taobao.com/cart.htm",
+        currency="CNY",
+        locale="zh-CN",
+        product_card_selectors=("div.item", "div[data-spm]"),
+        product_title_selectors=("div.title a", "a.J_ClickStat"),
+        product_price_selectors=("strong.price", "span.price"),
+        product_link_selectors=("a.J_ClickStat", "div.title a"),
+        add_to_cart_labels=("add to cart", "加入购物车"),
+        cart_link_labels=("cart", "购物车"),
+        checkout_labels=("checkout", "结算", "去结算"),
+        forbidden_action_labels=("place order", "提交订单", "立即购买"),
+        notes="Taobao routinely blocks unauthenticated automation — expect captcha walls.",
+    ),
+    SiteProfile(
+        slug="zalando",
+        name="Zalando",
+        domains=("zalando.com",),
+        regional_domains=("zalando.de", "zalando.co.uk", "zalando.fr", "zalando.it"),
+        home_url="https://www.zalando.com",
+        search_url_template="https://www.zalando.com/catalog/?q={query}",
+        login_url="https://www.zalando.com/login/",
+        cart_url="https://www.zalando.com/cart/",
+        currency="EUR",
+        locale="en-EU",
+        product_card_selectors=("article", "a[data-testid='product-card']"),
+        product_title_selectors=("h3", "header"),
+        product_price_selectors=("span[data-testid='price']", "p"),
+        product_link_selectors=("a",),
+        add_to_cart_labels=("add to bag", "add to cart"),
+        cart_link_labels=("bag", "cart"),
+        checkout_labels=("go to checkout", "checkout"),
+        forbidden_action_labels=("place order", "buy now", "order and pay"),
+    ),
+    SiteProfile(
+        slug="asos",
+        name="ASOS",
+        domains=("asos.com",),
+        home_url="https://www.asos.com",
+        search_url_template="https://www.asos.com/search/?q={query}",
+        login_url="https://www.asos.com/identity/login",
+        cart_url="https://www.asos.com/bag",
+        currency="GBP",
+        locale="en-GB",
+        product_card_selectors=("article[data-auto-id='productTile']", "article"),
+        product_title_selectors=("p[data-auto-id='productTileDescription']",),
+        product_price_selectors=("span[data-auto-id='productTilePrice']",),
+        product_link_selectors=("a",),
+        add_to_cart_labels=("add to bag", "add to basket"),
+        cart_link_labels=("bag", "basket"),
+        checkout_labels=("checkout",),
+        forbidden_action_labels=("place order", "pay now", "place your order"),
+    ),
+    SiteProfile(
+        slug="coupang",
+        name="Coupang",
+        domains=("coupang.com",),
+        home_url="https://www.coupang.com",
+        search_url_template="https://www.coupang.com/np/search?q={query}",
+        login_url="https://login.coupang.com/login/login.pang",
+        cart_url="https://cart.coupang.com/cartView.pang",
+        currency="KRW",
+        locale="ko-KR",
+        product_card_selectors=("li.search-product", "ul.search-product-list li"),
+        product_title_selectors=("div.name",),
+        product_price_selectors=("strong.price-value",),
+        product_link_selectors=("a.search-product-link", "a"),
+        add_to_cart_labels=("add to cart", "장바구니"),
+        cart_link_labels=("cart", "장바구니"),
+        checkout_labels=("checkout", "구매하기"),
+        forbidden_action_labels=("place order", "결제하기", "주문하기"),
+    ),
+)
+
+
+# Build lookup tables once at import time.
+_BY_SLUG: dict[str, SiteProfile] = {p.slug: p for p in _CATALOG}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def all_profiles() -> tuple[SiteProfile, ...]:
+    """Return every profile in the catalog in declaration order."""
+    return _CATALOG
+
+
+def all_slugs() -> tuple[str, ...]:
+    """Return the slug of every profile in catalog order."""
+    return tuple(p.slug for p in _CATALOG)
+
+
+def get_profile(slug: str) -> SiteProfile:
+    """Return the profile with the given slug.
+
+    Raises:
+        KeyError: When no profile matches ``slug``.
+    """
+    try:
+        return _BY_SLUG[slug.lower().strip()]
+    except KeyError as exc:
+        raise KeyError(f"Unknown e-commerce site slug: {slug!r}") from exc
+
+
+def find_profile_by_url(url: str) -> SiteProfile | None:
+    """Return the profile whose domains match ``url``, or None."""
+    host = _extract_host(url)
+    if not host:
+        return None
+    for profile in _CATALOG:
+        if profile.matches_domain(host):
+            return profile
+    return None
+
+
+_LABEL_NORMALISER = re.compile(r"\s+")
+
+
+def normalize_label(text: str) -> str:
+    """Lowercase + collapse internal whitespace for label comparisons."""
+    return _LABEL_NORMALISER.sub(" ", text or "").strip().lower()
+
+
+def is_forbidden_label(text: str, profile: SiteProfile | None = None) -> bool:
+    """Return True when ``text`` matches a known forbidden action label.
+
+    Always checks ``COMMON_FORBIDDEN_LABELS``. When ``profile`` is provided,
+    also checks the site's ``forbidden_action_labels``.
+
+    Matching is case-insensitive whitespace-collapsed substring matching so
+    "Place Your Order Now" matches "place order" and "Place your order".
+    """
+    needle = normalize_label(text)
+    if not needle:
+        return False
+    labels: list[str] = [normalize_label(label) for label in COMMON_FORBIDDEN_LABELS]
+    if profile is not None:
+        labels.extend(normalize_label(label) for label in profile.forbidden_action_labels)
+    for label in labels:
+        if not label:
+            continue
+        if label in needle:
+            return True
+    return False
+
+
+__all__ = [
+    "COMMON_FORBIDDEN_LABELS",
+    "SiteProfile",
+    "all_profiles",
+    "all_slugs",
+    "find_profile_by_url",
+    "get_profile",
+    "is_forbidden_label",
+    "normalize_label",
+]

--- a/backend/ecommerce/workflows.py
+++ b/backend/ecommerce/workflows.py
@@ -1,0 +1,228 @@
+"""Per-site workflow manifests for the e-commerce agent.
+
+A *workflow* is a stage-by-stage description of what the agent does on a
+single site. The workflow data is purely declarative — it does not import
+or execute browser code. The agent core in `agent.py` reads these stages
+to derive expected URL patterns, success indicators, and per-site
+caveats, and the test suite uses them to verify every catalog entry has
+documented coverage for the four required stages:
+
+  - ``search``           : run a keyword search on the site
+  - ``browse``           : view candidate product details (navigation+extract)
+  - ``cart``             : add the selected item to cart and verify cart
+  - ``checkout_prep``    : enter the checkout funnel and stop at the
+                           payment boundary — no final order/payment click
+
+Workflows are intentionally lightweight metadata. Where a site has been
+HAR-recorded into a NoUI MCP server, the ``mcp_server`` field points to
+the generated artifact path so an operator can swap the browser path for
+the API path. Sites without recorded MCP coverage degrade to the
+declarative browser flow via `SiteProfile` selectors.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from backend.ecommerce.site_catalog import all_slugs, get_profile
+
+WORKFLOW_STAGES: tuple[str, ...] = ("search", "browse", "cart", "checkout_prep")
+
+
+@dataclass(frozen=True)
+class WorkflowStage:
+    """One stage of a site workflow."""
+
+    name: str
+    description: str
+    expected_url_substrings: tuple[str, ...] = ()
+    success_indicators: tuple[str, ...] = ()
+    forbidden_in_stage: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SiteWorkflow:
+    """Workflow manifest for one site in the catalog."""
+
+    slug: str
+    stages: tuple[WorkflowStage, ...]
+    mcp_server: str = ""  # path to generated FastMCP server, if any
+    skill: str = ""  # path to a Cursor-style skill, if any
+    notes: str = ""
+    extra_caveats: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _default_stages(slug: str) -> tuple[WorkflowStage, ...]:
+    """Build the default four-stage workflow for a catalog slug.
+
+    Each site profile already encodes labels for add-to-cart, cart links,
+    checkout entry, and forbidden actions; the workflow stages are
+    parameterized off those so a single source of truth drives both the
+    runtime agent and the documentation surface.
+    """
+    profile = get_profile(slug)
+    cart_url_hint = profile.cart_url.split("//", 1)[-1] if profile.cart_url else ""
+    return (
+        WorkflowStage(
+            name="search",
+            description=(
+                f"Navigate to {profile.search_url_template} with the user's query "
+                f"and extract product cards using {profile.name}'s search-page selectors."
+            ),
+            expected_url_substrings=("search", "q="),
+            success_indicators=("product_cards >= 1",),
+        ),
+        WorkflowStage(
+            name="browse",
+            description=(
+                f"Open one of the surfaced product URLs on {profile.name}, then "
+                "wait for the product page to render before extracting price, "
+                "title, and seller details."
+            ),
+            success_indicators=("product_title_visible", "price_visible"),
+            forbidden_in_stage=profile.forbidden_action_labels,
+        ),
+        WorkflowStage(
+            name="cart",
+            description=(
+                "Click one of the site's add-to-cart labels "
+                f"({', '.join(profile.add_to_cart_labels) or 'add to cart'}), then "
+                f"navigate to {profile.cart_url or 'the cart link'} and snapshot "
+                "the cart contents (lines, subtotal, shipping)."
+            ),
+            expected_url_substrings=(cart_url_hint,) if cart_url_hint else (),
+            success_indicators=("cart_line_count >= 1",),
+            forbidden_in_stage=profile.forbidden_action_labels,
+        ),
+        WorkflowStage(
+            name="checkout_prep",
+            description=(
+                "Click into the checkout funnel using one of the site's checkout "
+                f"labels ({', '.join(profile.checkout_labels) or 'checkout'}). "
+                "Run purchase-boundary detection — the agent must stop the moment "
+                "any final order/payment button is visible."
+            ),
+            success_indicators=(
+                "boundary_present == true",
+                "no final click dispatched",
+            ),
+            forbidden_in_stage=profile.forbidden_action_labels,
+        ),
+    )
+
+
+# Sites that have known operational caveats above and beyond the catalog notes.
+_EXTRA_CAVEATS: dict[str, tuple[str, ...]] = {
+    "amazon": (
+        "Amazon may show a 1-Click button alongside Add-to-cart on Prime accounts. "
+        "Both 'Buy now' and '1-Click' are forbidden by the catalog profile.",
+        "International accounts redirect to amazon.<tld>; the agent always uses the "
+        "domain returned by the search redirect.",
+    ),
+    "aliexpress": (
+        "AliExpress aggressively gates unauthenticated automation with sliding "
+        "captchas. The agent will pause for manual completion.",
+    ),
+    "ebay": (
+        "Some listings on eBay use 'Buy It Now' as the only purchase path. "
+        "The agent never auto-clicks 'Buy It Now' — it stops at the listing page "
+        "and surfaces a checkpoint instead.",
+    ),
+    "flipkart": (
+        "Flipkart confusingly uses 'Place Order' on the address step too; "
+        "the agent treats every 'Place Order' label as forbidden.",
+    ),
+    "rakuten": (
+        "Rakuten checkout copy is Japanese — confirmation buttons "
+        "('注文を確定する', '購入を確定') are added to the forbidden list.",
+    ),
+    "taobao": (
+        "Taobao and Tmall regularly require Alipay authentication and may show "
+        "captcha walls early in the flow.",
+    ),
+    "shopee": (
+        "Shopee uses dynamically generated class names; selector hits may be "
+        "intermittent. Fall back to text-based heuristics where possible.",
+    ),
+    "jd": (
+        "JD checkout copy is Chinese — '提交订单' and '立即购买' are forbidden.",
+    ),
+    "temu": (
+        "Temu shows aggressive interstitials before checkout; the agent should "
+        "pause for user dismissal.",
+    ),
+    "mercadolibre": (
+        "Regional country domains (.ar, .mx, .com.br) all map to the same slug; "
+        "search URLs may need adjusting for the buyer's country.",
+    ),
+    "lazada": (
+        "Lazada requires login before the cart is visible; the agent stops with "
+        "needs_user when redirected to the login page.",
+    ),
+    "coupang": (
+        "Coupang's labels are localized to Korean; '결제하기' and '주문하기' are "
+        "forbidden.",
+    ),
+}
+
+
+def _build_registry() -> dict[str, SiteWorkflow]:
+    registry: dict[str, SiteWorkflow] = {}
+    for slug in all_slugs():
+        registry[slug] = SiteWorkflow(
+            slug=slug,
+            stages=_default_stages(slug),
+            extra_caveats=_EXTRA_CAVEATS.get(slug, ()),
+            notes=get_profile(slug).notes,
+        )
+    return registry
+
+
+_REGISTRY: dict[str, SiteWorkflow] = _build_registry()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_workflow(slug: str) -> SiteWorkflow:
+    """Return the workflow for ``slug``.
+
+    Raises:
+        KeyError: When no workflow has been registered for the slug.
+    """
+    key = slug.lower().strip()
+    try:
+        return _REGISTRY[key]
+    except KeyError as exc:
+        raise KeyError(f"No workflow registered for site slug: {slug!r}") from exc
+
+
+def all_workflows() -> tuple[SiteWorkflow, ...]:
+    """Return every registered workflow in catalog order."""
+    return tuple(_REGISTRY[s] for s in all_slugs())
+
+
+def workflow_coverage_report() -> dict[str, dict[str, bool]]:
+    """Return a quick coverage report keyed by slug.
+
+    For each catalog slug, returns a dict mapping each required stage to
+    whether the workflow defines it. Used by tests to enforce that every
+    site has all four stages.
+    """
+    report: dict[str, dict[str, bool]] = {}
+    for workflow in all_workflows():
+        defined = {stage.name for stage in workflow.stages}
+        report[workflow.slug] = {stage: stage in defined for stage in WORKFLOW_STAGES}
+    return report
+
+
+__all__ = [
+    "SiteWorkflow",
+    "WORKFLOW_STAGES",
+    "WorkflowStage",
+    "all_workflows",
+    "get_workflow",
+    "workflow_coverage_report",
+]

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 
 import backend.autopilot.models  # noqa: F401
+import backend.ecommerce.models  # noqa: F401
 import backend.elicitation.models  # noqa: F401
 
 # ── Register all ORM models so their tables are created on startup ────────────
@@ -27,6 +28,7 @@ import backend.workflow.models  # noqa: F401
 from backend.autopilot.router import router as autopilot_router
 from backend.config import settings
 from backend.database import Base, engine
+from backend.ecommerce.router import router as ecommerce_router
 from backend.elicitation.routers.attachments import router as attachments_router
 from backend.elicitation.routers.browser_commands import router as browser_commands_router
 from backend.elicitation.routers.capture_sessions import router as capture_sessions_router
@@ -117,6 +119,7 @@ app.include_router(elicitation_url_events_router)
 app.include_router(login_router, prefix="/login-sessions")
 app.include_router(workflow_router, prefix="/workflow-sessions")
 app.include_router(autopilot_router)
+app.include_router(ecommerce_router)
 
 # ── Elicitation (ABCD) routers ────────────────────────────────────────────────
 app.include_router(projects_router)

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+create = false

--- a/skills/bestbuy-search/API.md
+++ b/skills/bestbuy-search/API.md
@@ -1,0 +1,63 @@
+# Best Buy Search API
+
+Two operations. No auth required.
+
+## `search_suggestions`
+
+GET `https://www.bestbuy.com/suggest/v1/fragment/suggest/www`
+
+**Args**
+- `query` (str, required) — free-text query (e.g. "laptop")
+- `count` (int, default 6) — max suggestions
+- `search_variant` (str, default "A") — server experiment variant
+
+**Returns** parsed JSON. Key fields per suggestion:
+
+- `suggestionResponse.suggestions[i].term` — the suggested search term
+- `suggestionResponse.suggestions[i].category[]` — `{name, id}` category hints
+- `suggestionResponse.suggestions[i].products[].skuId` — Best Buy skuIds to feed
+  into `lookup_products`
+
+## `lookup_products`
+
+GET `https://www.bestbuy.com/suggest/v1/fragment/products/www`
+
+**Args**
+- `skuids` (str, required) — comma-separated skuIds (or Python list)
+
+**Returns** parsed JSON. Per-product fields under `products[]`:
+
+| Field | Description |
+|---|---|
+| `skuid` | Best Buy skuId. |
+| `skushortlabel` | Short product title (brand + model + key specs). |
+| `pdpUrl` | Path of the product detail page. Prepend `https://www.bestbuy.com`. |
+| `imageUrl` | Path under `https://pisces.bbystatic.com/image/`. |
+| `altText` | Alt text describing the primary image. |
+| `customerrating_facet` | Average customer rating, "0.0"-"5.0" string. |
+| `numberofreviews_facet` | Review count as a string. |
+
+## Hardcoded values (from recording)
+
+| Value | Where |
+|---|---|
+| `X-CLIENT-ID: Search-Web-View` | both ops |
+| Desktop Chrome 148 User-Agent | both ops |
+| `searchVariant=A` | `search_suggestions` (recording default) |
+
+## Out of scope
+
+Price is **not** returned by either endpoint. Best Buy fetches price
+separately via `POST /gateway/graphql` (operation
+`PlpView_ProductListItem_Init`) keyed on `customerId`, cart timestamp,
+and visitor cohort. That GraphQL request body is ~18kB of fragments and
+is excluded from this skill to keep operations small and stable.
+
+For live price, follow the `pdpUrl` returned by `lookup_products`.
+
+## Recording provenance
+
+- Workflow session: `ca123295-c78c-4b06-9c70-124d54939533`
+- Capture session: `19a9fc71-29c1-4075-9f1a-3e2ccf5b9591`
+- HAR shows ~84 GraphQL POSTs and ~36 autocomplete GETs against
+  `bestbuy.com`; this skill exposes the two stable, schema-light GETs.

--- a/skills/bestbuy-search/API.md
+++ b/skills/bestbuy-search/API.md
@@ -1,8 +1,13 @@
-# Best Buy Search API
+# Best Buy Search & Cart API
 
-Two operations. No auth required.
+Five operations in two groups. No auth required for search; browser session
+required for cart/checkout operations.
 
-## `search_suggestions`
+---
+
+## Public API operations (no auth, plain httpx)
+
+### `search_suggestions`
 
 GET `https://www.bestbuy.com/suggest/v1/fragment/suggest/www`
 
@@ -11,53 +16,165 @@ GET `https://www.bestbuy.com/suggest/v1/fragment/suggest/www`
 - `count` (int, default 6) — max suggestions
 - `search_variant` (str, default "A") — server experiment variant
 
-**Returns** parsed JSON. Key fields per suggestion:
+**Returns** — Key fields per suggestion:
 
-- `suggestionResponse.suggestions[i].term` — the suggested search term
-- `suggestionResponse.suggestions[i].category[]` — `{name, id}` category hints
-- `suggestionResponse.suggestions[i].products[].skuId` — Best Buy skuIds to feed
-  into `lookup_products`
+- `suggestions[i].term` — suggested search term
+- `suggestions[i].category[]` — `{name, id}` category hints
+- `suggestions[i].products[].skuId` — Best Buy skuIds for `lookup_products`
 
-## `lookup_products`
+---
+
+### `lookup_products`
 
 GET `https://www.bestbuy.com/suggest/v1/fragment/products/www`
 
 **Args**
-- `skuids` (str, required) — comma-separated skuIds (or Python list)
+- `skuids` (str, required) — comma-separated skuIds
 
-**Returns** parsed JSON. Per-product fields under `products[]`:
+**Returns** — Per-product under `products[]`:
 
 | Field | Description |
 |---|---|
-| `skuid` | Best Buy skuId. |
-| `skushortlabel` | Short product title (brand + model + key specs). |
-| `pdpUrl` | Path of the product detail page. Prepend `https://www.bestbuy.com`. |
-| `imageUrl` | Path under `https://pisces.bbystatic.com/image/`. |
-| `altText` | Alt text describing the primary image. |
-| `customerrating_facet` | Average customer rating, "0.0"-"5.0" string. |
-| `numberofreviews_facet` | Review count as a string. |
+| `skuid` | Best Buy skuId |
+| `skushortlabel` | Short product title |
+| `pdpUrl` | PDP path; prepend `https://www.bestbuy.com` |
+| `imageUrl` | Image path |
+| `customerrating_facet` | Avg rating string "0.0"–"5.0" |
+| `numberofreviews_facet` | Review count string |
+
+Price is **not** returned. Visit the PDP for live pricing.
+
+---
+
+## Browser operations (require NoUI backend + Chrome extension)
+
+All browser operations call `POST http://localhost:8002/browser-commands/execute`
+to drive the Chrome extension. Prerequisites:
+
+1. `python cli/main.py start` — NoUI backend
+2. Chrome extension connected (green dot)
+3. Chrome tab open on `www.bestbuy.com`, signed in
+
+---
+
+### `open_product`
+
+Navigates the browser to a Best Buy product page and waits for it to render.
+
+**Args**
+- `pdp_url` (str, required) — relative path from `lookup_products.pdpUrl` or
+  full URL
+
+**Returns**
+
+```json
+{
+  "ready": true,
+  "url": "https://www.bestbuy.com/product/...",
+  "title": "Skullcandy - Dime 3 ...",
+  "add_to_cart_visible": true
+}
+```
+
+---
+
+### `add_to_cart`
+
+**HUMAN APPROVAL REQUIRED before running.**
+
+Clicks the Add to Cart button, confirms the item was added, navigates to the
+cart, and returns the cart summary.
+
+**Args**
+- `skip_navigation` (bool, default false)
+
+**Returns on success**
+
+```json
+{
+  "added": true,
+  "method": "selector:button.add-to-cart-button",
+  "cart_updated_confirmed": true,
+  "cart_url": "https://www.bestbuy.com/cart",
+  "cart": {
+    "line_count": 1,
+    "lines": [{"title": "...", "price": "$25.99"}],
+    "subtotal": "$25.99",
+    "url": "https://www.bestbuy.com/cart"
+  },
+  "payment_boundary_triggered": false
+}
+```
+
+**Returns on failure**
+
+```json
+{"added": false, "error": "<reason>", "payment_boundary_triggered": false}
+```
+
+**Safety boundary**: operation aborts immediately if any of the following are
+detected:
+- URL contains `/checkout/r/payment` or similar
+- `input[autocomplete='cc-number']` or other card-entry inputs are found
+- A "Place Your Order" / "Pay Now" button is visible
+
+---
+
+### `proceed_to_checkout`
+
+**HUMAN APPROVAL REQUIRED before running.**
+
+Clicks Checkout from the cart, walks through safe sub-steps (fulfillment,
+address, review), and **stops hard at the payment entry step**.
+
+**Args**
+- `max_steps` (int, default 6) — max sub-steps to auto-advance
+
+**Returns when payment boundary reached** (expected path)
+
+```json
+{
+  "checkout_reached": true,
+  "payment_boundary": true,
+  "stopped_at": "payment URL pattern detected",
+  "steps_taken": 3,
+  "current_url": "https://www.bestbuy.com/checkout/r/payment",
+  "current_title": "Checkout | Best Buy",
+  "message": "Agent stopped at payment step. Complete payment manually in the browser, then place your order."
+}
+```
+
+**Returns when stuck on a sub-step** (address form needs input, etc.)
+
+```json
+{
+  "checkout_reached": true,
+  "payment_boundary": false,
+  "stopped_at": "max_steps=6 or stuck on sub-step",
+  "steps_taken": 2,
+  "current_url": "https://www.bestbuy.com/checkout#bb-address",
+  "message": "Agent stopped before reaching the payment step — the checkout form may need manual input."
+}
+```
+
+**Hard stop conditions** (will never be bypassed):
+- URL matches a payment path pattern
+- A credit-card number / CVV / payment-method input is present in the DOM
+- A "Place Your Order", "Place Order", "Pay Now", "Confirm Order", or
+  "Submit Order" button is visible
+
+---
 
 ## Hardcoded values (from recording)
 
 | Value | Where |
 |---|---|
-| `X-CLIENT-ID: Search-Web-View` | both ops |
-| Desktop Chrome 148 User-Agent | both ops |
-| `searchVariant=A` | `search_suggestions` (recording default) |
-
-## Out of scope
-
-Price is **not** returned by either endpoint. Best Buy fetches price
-separately via `POST /gateway/graphql` (operation
-`PlpView_ProductListItem_Init`) keyed on `customerId`, cart timestamp,
-and visitor cohort. That GraphQL request body is ~18kB of fragments and
-is excluded from this skill to keep operations small and stable.
-
-For live price, follow the `pdpUrl` returned by `lookup_products`.
+| `X-CLIENT-ID: Search-Web-View` | `search_suggestions`, `lookup_products` |
+| Desktop Chrome 148 User-Agent | `search_suggestions`, `lookup_products` |
+| `searchVariant=A` | `search_suggestions` |
+| `http://localhost:8002` | `open_product`, `add_to_cart`, `proceed_to_checkout` |
 
 ## Recording provenance
 
 - Workflow session: `ca123295-c78c-4b06-9c70-124d54939533`
 - Capture session: `19a9fc71-29c1-4075-9f1a-3e2ccf5b9591`
-- HAR shows ~84 GraphQL POSTs and ~36 autocomplete GETs against
-  `bestbuy.com`; this skill exposes the two stable, schema-light GETs.

--- a/skills/bestbuy-search/SKILL.md
+++ b/skills/bestbuy-search/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: bestbuy-search
+description: "Search Best Buy for products. Use when the user wants to find items on Best Buy — e.g. \"find laptops on Best Buy\", \"search Best Buy for usb c cable\", \"show me Best Buy gaming headsets under $100\". Two operations: search_suggestions (query → suggested terms + skuIds) and lookup_products (skuIds → product cards). No auth required."
+---
+
+# Best Buy Search
+
+Anonymous Best Buy product search. Two operations; chain them.
+
+## Usage
+
+Typical flow for "find <product> on Best Buy":
+
+1. Resolve the query to suggested terms and skuIds:
+   ```bash
+   python operations/search_suggestions.py --query "laptop" --count 6
+   ```
+   Each entry in `suggestionResponse.suggestions[]` carries a `term`, a
+   list of categories, and a `products[]` list of `skuId`s.
+
+2. Look up product cards for the skuIds you care about:
+   ```bash
+   python operations/lookup_products.py --skuids "6619147,6667498,12349296"
+   ```
+   Each entry has `skushortlabel` (title), `pdpUrl`, `imageUrl`,
+   `customerrating_facet`, `numberofreviews_facet`.
+
+Responses are printed as JSON on stdout.
+
+## Operations
+
+### `search_suggestions`
+
+Best Buy search-term autocomplete. Returns suggested queries plus
+matching skuIds.
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `--query` | string | yes | — | Free-text query (e.g. "laptop"). |
+| `--count` | int | no | `6` | Max number of suggestions. |
+| `--search-variant` | string | no | `A` | Server experiment variant; recording used "A". |
+
+Response shape:
+
+```json
+{
+  "suggestionResponse": {
+    "spellCheck": { "correctedQuery": "", "correctlySpelled": true, "originalQuery": "laptop" },
+    "count": 6,
+    "suggestions": [
+      {
+        "term": "laptop",
+        "category": [{"name": "All Laptops", "id": "pcmcat138500050001"}],
+        "products": [{"skuId": "6619147", "type": "searchSuggestion"}, ...]
+      }
+    ]
+  }
+}
+```
+
+### `lookup_products`
+
+Resolve skuIds to full product cards.
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `--skuids` | string | yes | — | Comma-separated skuIds (e.g. `"6619147,6667498"`). |
+
+Response shape:
+
+```json
+{
+  "count": 3,
+  "products": [
+    {
+      "skuid": "6619147",
+      "skushortlabel": "Lenovo - IdeaPad Slim 3x - Copilot+ PC - 15.3\" 2k Touchscreen Laptop - ...",
+      "pdpUrl": "/product/lenovo-ideapad-slim-3x.../JJGSH82JL5",
+      "imageUrl": "BestBuy_US/images/products/<uuid>.jpg",
+      "altText": "Lenovo - IdeaPad Slim 3x - ...",
+      "customerrating_facet": "4.7",
+      "numberofreviews_facet": "276"
+    }
+  ]
+}
+```
+
+Prepend `https://www.bestbuy.com` to `pdpUrl` to get the clickable URL.
+
+## Notes
+
+- No authentication required. Both endpoints are public, anonymous.
+- These endpoints are the same ones Best Buy's site uses to render the
+  header search box and the type-ahead product carousel; they are
+  optimised for autocomplete-style "top-N" lookups, not full PLP grids.
+- Price is intentionally not included — Best Buy serves price through a
+  separate GraphQL call (`/gateway/graphql`) keyed on `customerId`,
+  cart state, and visitor cohort. To get a live price for a skuId,
+  navigate to `https://www.bestbuy.com{pdpUrl}`.
+- Both operations send a desktop-Chrome User-Agent and the `Search-Web-View`
+  client id observed during recording. If Best Buy changes the wire
+  contract, re-record the workflow via `/noui-record-workflow`.

--- a/skills/bestbuy-search/SKILL.md
+++ b/skills/bestbuy-search/SKILL.md
@@ -1,57 +1,76 @@
 ---
 name: bestbuy-search
-description: "Search Best Buy for products. Use when the user wants to find items on Best Buy — e.g. \"find laptops on Best Buy\", \"search Best Buy for usb c cable\", \"show me Best Buy gaming headsets under $100\". Two operations: search_suggestions (query → suggested terms + skuIds) and lookup_products (skuIds → product cards). No auth required."
+description: "Search Best Buy for products and add them to cart with human confirmation. Use when the user wants to find, select, and purchase items on Best Buy — e.g. 'find laptops on Best Buy', 'add this headset to my Best Buy cart', 'search Best Buy for USB-C hubs'. Five operations in a supervised workflow: search_suggestions → lookup_products → open_product → add_to_cart (human confirms) → proceed_to_checkout (human confirms). Agent stops at the payment step; the human places the final order."
 ---
 
-# Best Buy Search
+# Best Buy Search & Cart
 
-Anonymous Best Buy product search. Two operations; chain them.
+Supervised Best Buy shopping workflow. Two public API operations for product
+discovery, three browser operations for cart and checkout. Human confirmation
+is required before any cart or checkout action.
 
-## Usage
+## Confirmation Requirements (MUST follow)
 
-Typical flow for "find <product> on Best Buy":
+| Step | What to show the user | What to ask |
+|---|---|---|
+| Before `add_to_cart` | Product title, Best Buy URL, and price (or link to PDP) | "Should I add [product] to your Best Buy cart?" |
+| Before `proceed_to_checkout` | Full cart contents and subtotal from `add_to_cart` output | "Your cart has [items] totalling [subtotal]. Shall I proceed to checkout?" |
 
-1. Resolve the query to suggested terms and skuIds:
-   ```bash
-   python operations/search_suggestions.py --query "laptop" --count 6
-   ```
-   Each entry in `suggestionResponse.suggestions[]` carries a `term`, a
-   list of categories, and a `products[]` list of `skuId`s.
+The agent **stops at the payment step** and will not click any payment button
+or type any payment credentials. The human completes payment manually.
 
-2. Look up product cards for the skuIds you care about:
-   ```bash
-   python operations/lookup_products.py --skuids "6619147,6667498,12349296"
-   ```
-   Each entry has `skushortlabel` (title), `pdpUrl`, `imageUrl`,
-   `customerrating_facet`, `numberofreviews_facet`.
+## Prerequisites (browser operations only)
 
-Responses are printed as JSON on stdout.
+- NoUI backend running: `python cli/main.py start`
+- Chrome extension connected (green dot at `localhost:8002`)
+- Active Chrome tab signed in to Best Buy
+
+## Full Workflow
+
+```
+1. search_suggestions  --query "wireless earbuds" --count 6
+        ↓  (skuIds from suggestions[0].products)
+2. lookup_products     --skuids "6580352,6628905,6501047"
+        ↓  (pick best match → pdpUrl)
+   [SHOW user the product options; ask which one to buy]
+        ↓  (user picks one)
+3. open_product        --pdp-url "/product/.../SKU"
+        ↓
+   [SHOW user the product title + URL; ask "Add to cart?"]
+        ↓  (user confirms)
+4. add_to_cart
+        ↓
+   [SHOW user the cart summary; ask "Proceed to checkout?"]
+        ↓  (user confirms)
+5. proceed_to_checkout
+        ↓
+   Agent stops at payment step → user completes payment manually
+```
 
 ## Operations
 
 ### `search_suggestions`
 
-Best Buy search-term autocomplete. Returns suggested queries plus
-matching skuIds.
+Best Buy search-term autocomplete. Returns suggested queries plus matching
+skuIds. No browser required.
 
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `--query` | string | yes | — | Free-text query (e.g. "laptop"). |
 | `--count` | int | no | `6` | Max number of suggestions. |
-| `--search-variant` | string | no | `A` | Server experiment variant; recording used "A". |
+| `--search-variant` | string | no | `A` | Server experiment variant. |
 
 Response shape:
 
 ```json
 {
   "suggestionResponse": {
-    "spellCheck": { "correctedQuery": "", "correctlySpelled": true, "originalQuery": "laptop" },
     "count": 6,
     "suggestions": [
       {
-        "term": "laptop",
-        "category": [{"name": "All Laptops", "id": "pcmcat138500050001"}],
-        "products": [{"skuId": "6619147", "type": "searchSuggestion"}, ...]
+        "term": "wireless earbuds",
+        "category": [{"name": "Headphones", "id": "pcmcat144700050004"}],
+        "products": [{"skuId": "6580352"}, ...]
       }
     ]
   }
@@ -60,43 +79,109 @@ Response shape:
 
 ### `lookup_products`
 
-Resolve skuIds to full product cards.
+Resolve skuIds to product cards. No browser required.
 
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `--skuids` | string | yes | — | Comma-separated skuIds (e.g. `"6619147,6667498"`). |
+| `--skuids` | string | yes | — | Comma-separated skuIds. |
 
-Response shape:
+Response shape (per product):
 
 ```json
 {
-  "count": 3,
-  "products": [
-    {
-      "skuid": "6619147",
-      "skushortlabel": "Lenovo - IdeaPad Slim 3x - Copilot+ PC - 15.3\" 2k Touchscreen Laptop - ...",
-      "pdpUrl": "/product/lenovo-ideapad-slim-3x.../JJGSH82JL5",
-      "imageUrl": "BestBuy_US/images/products/<uuid>.jpg",
-      "altText": "Lenovo - IdeaPad Slim 3x - ...",
-      "customerrating_facet": "4.7",
-      "numberofreviews_facet": "276"
-    }
-  ]
+  "skuid": "6580352",
+  "skushortlabel": "Skullcandy - Dime 3 True Wireless In-Ear Earbuds ...",
+  "pdpUrl": "/product/skullcandy-dime-3.../6580352",
+  "customerrating_facet": "4.3",
+  "numberofreviews_facet": "328"
 }
 ```
 
-Prepend `https://www.bestbuy.com` to `pdpUrl` to get the clickable URL.
+Prepend `https://www.bestbuy.com` to `pdpUrl` for the full URL. Note: price
+is not returned by this endpoint — visit the PDP for live pricing.
+
+### `open_product`
+
+Navigate the active browser tab to a Best Buy product detail page. Call this
+before `add_to_cart` to ensure the correct product is loaded.
+
+| Flag | Type | Required | Description |
+|---|---|---|---|
+| `--pdp-url` | string | yes | Relative pdpUrl (e.g. `"/product/.../6580352"`) or full URL. |
+
+Response: `{"ready": bool, "url": str, "title": str, "add_to_cart_visible": bool}`
+
+### `add_to_cart`
+
+**REQUIRES HUMAN APPROVAL before calling.**
+
+Clicks the Add to Cart button on the currently open product page, waits for
+cart confirmation, then returns the cart contents.
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `--skip-navigation` | flag | no | `false` | Assume browser is already on the product page. |
+
+Response on success:
+
+```json
+{
+  "added": true,
+  "cart_url": "https://www.bestbuy.com/cart",
+  "cart": {
+    "line_count": 1,
+    "lines": [{"title": "...", "price": "$..."}],
+    "subtotal": "$25.99"
+  },
+  "payment_boundary_triggered": false
+}
+```
+
+Response on failure: `{"added": false, "error": "...", "payment_boundary_triggered": bool}`
+
+Safety: the operation aborts immediately if any payment-form indicator
+(credit card field, payment URL, "Place Order" button) is detected.
+
+### `proceed_to_checkout`
+
+**REQUIRES HUMAN APPROVAL before calling.**
+
+Clicks Checkout from the cart, walks through safe sub-steps (fulfillment,
+address, review), and stops hard at the payment step. Never clicks any
+payment button or enters any credentials.
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `--max-steps` | int | no | `6` | Max sub-steps to auto-advance. |
+
+Response when payment boundary reached (expected success):
+
+```json
+{
+  "checkout_reached": true,
+  "payment_boundary": true,
+  "stopped_at": "payment URL pattern in .../checkout/r/payment",
+  "steps_taken": 3,
+  "current_url": "https://www.bestbuy.com/checkout/r/payment",
+  "message": "Agent stopped at payment step. Complete payment manually in the browser, then place your order."
+}
+```
+
+After receiving this, the agent must inform the user that they should
+complete payment in the browser and place the order themselves.
 
 ## Notes
 
-- No authentication required. Both endpoints are public, anonymous.
-- These endpoints are the same ones Best Buy's site uses to render the
-  header search box and the type-ahead product carousel; they are
-  optimised for autocomplete-style "top-N" lookups, not full PLP grids.
-- Price is intentionally not included — Best Buy serves price through a
-  separate GraphQL call (`/gateway/graphql`) keyed on `customerId`,
-  cart state, and visitor cohort. To get a live price for a skuId,
-  navigate to `https://www.bestbuy.com{pdpUrl}`.
-- Both operations send a desktop-Chrome User-Agent and the `Search-Web-View`
-  client id observed during recording. If Best Buy changes the wire
-  contract, re-record the workflow via `/noui-record-workflow`.
+- Price is not included in `search_suggestions` or `lookup_products`. Visit
+  the `pdpUrl` for live pricing before confirming add-to-cart.
+- Best Buy may prompt for a sign-in before add-to-cart. If the browser is
+  not signed in, `add_to_cart` will return an error with guidance.
+- If the product requires selecting a size, color, or variant (e.g. laptop
+  storage tier), the `add_to_cart` button may not appear until a variant is
+  selected. Open the PDP in the browser and make that selection first.
+- The `proceed_to_checkout` payment boundary detection covers URL patterns,
+  credit-card input fields, and "Place Your Order" button text. If Best Buy
+  changes its checkout UI, the stop may fire earlier or the step may require
+  manual navigation.
+- Re-record the workflow via `/noui-record-workflow` if Best Buy rotates the
+  autocomplete API endpoints.

--- a/skills/bestbuy-search/manifest.json
+++ b/skills/bestbuy-search/manifest.json
@@ -15,13 +15,19 @@
     "profile_slug": null,
     "profile_db_id": null,
     "strategy": "none",
-    "auth_plan_file": null
+    "auth_plan_file": null,
+    "notes": "search_suggestions and lookup_products use anonymous public APIs (no auth). open_product, add_to_cart, and proceed_to_checkout drive the user's live browser session via the NoUI backend and require the user to be signed in to Best Buy in that browser."
   },
   "runtime": {
     "type": "claude-code-skill",
     "entrypoint": "SKILL.md",
     "operation_style": "subprocess-cli",
-    "python": ">=3.11"
+    "python": ">=3.11",
+    "prerequisites": [
+      "NoUI backend running at http://localhost:8002 (python cli/main.py start)",
+      "Chrome extension connected (green dot in extension popup)",
+      "User signed in to Best Buy in the active Chrome tab"
+    ]
   },
   "operations": [
     {
@@ -31,6 +37,8 @@
       "entry": "execute",
       "method": "GET",
       "path": "/suggest/v1/fragment/suggest/www",
+      "requires_browser": false,
+      "requires_human_approval": false,
       "args": [
         { "name": "query", "type": "string", "required": true,
           "description": "Free-text query (e.g. \"laptop\", \"usb c cable\")." },
@@ -47,9 +55,55 @@
       "entry": "execute",
       "method": "GET",
       "path": "/suggest/v1/fragment/products/www",
+      "requires_browser": false,
+      "requires_human_approval": false,
       "args": [
         { "name": "skuids", "type": "string", "required": true,
           "description": "Comma-separated skuIds (e.g. \"6619147,6667498,12349296\") or a Python list of strings." }
+      ]
+    },
+    {
+      "name": "open_product",
+      "description": "Navigate the active browser tab to a Best Buy product detail page. Call this before add_to_cart to make sure the correct product is loaded. Requires the NoUI browser backend.",
+      "module": "operations/open_product.py",
+      "entry": "execute",
+      "method": "BROWSER",
+      "path": "https://www.bestbuy.com{pdp_url}",
+      "requires_browser": true,
+      "requires_human_approval": false,
+      "args": [
+        { "name": "pdp_url", "type": "string", "required": true,
+          "description": "Relative pdpUrl from lookup_products (e.g. \"/product/.../SKU\") or a full Best Buy URL." }
+      ]
+    },
+    {
+      "name": "add_to_cart",
+      "description": "Add the currently open Best Buy product to the cart. REQUIRES HUMAN APPROVAL — must show the product title/URL and ask the user before calling. Clicks the Add to Cart button, waits for confirmation, then navigates to the cart and returns its contents.",
+      "module": "operations/add_to_cart.py",
+      "entry": "execute",
+      "method": "BROWSER",
+      "path": "https://www.bestbuy.com/cart",
+      "requires_browser": true,
+      "requires_human_approval": true,
+      "safety": "Stops immediately if any payment-form indicators are detected. Never types card credentials.",
+      "args": [
+        { "name": "skip_navigation", "type": "boolean", "required": false, "default": false,
+          "description": "Skip navigation; assume browser is already on the product page." }
+      ]
+    },
+    {
+      "name": "proceed_to_checkout",
+      "description": "Proceed from the Best Buy cart through checkout sub-steps and stop at the payment step. REQUIRES HUMAN APPROVAL — must show cart summary and ask the user before calling. Stops hard at any payment-form indicator and never clicks Place Order or Pay Now.",
+      "module": "operations/proceed_to_checkout.py",
+      "entry": "execute",
+      "method": "BROWSER",
+      "path": "https://www.bestbuy.com/checkout",
+      "requires_browser": true,
+      "requires_human_approval": true,
+      "safety": "Hard stops on payment URL patterns, credit-card input fields, and Place Order buttons. Never enters payment credentials.",
+      "args": [
+        { "name": "max_steps", "type": "integer", "required": false, "default": 6,
+          "description": "Max checkout sub-steps to auto-advance through before stopping." }
       ]
     }
   ],
@@ -60,7 +114,12 @@
       "API.md",
       "operations/__init__.py",
       "operations/search_suggestions.py",
-      "operations/lookup_products.py"
+      "operations/lookup_products.py",
+      "operations/open_product.py",
+      "operations/add_to_cart.py",
+      "operations/proceed_to_checkout.py",
+      "noui_runtime/__init__.py",
+      "noui_runtime/browser.py"
     ],
     "api_docs_file": "API.md"
   },

--- a/skills/bestbuy-search/manifest.json
+++ b/skills/bestbuy-search/manifest.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "1",
+  "skill_id": "bestbuy-search",
+  "app": {
+    "name": "Best Buy Search",
+    "slug": "bestbuy-search"
+  },
+  "workflow": {
+    "id": "bestbuy-search",
+    "name": "Best Buy Search",
+    "workflow_session_id": "ca123295-c78c-4b06-9c70-124d54939533"
+  },
+  "auth": {
+    "requires_auth": false,
+    "profile_slug": null,
+    "profile_db_id": null,
+    "strategy": "none",
+    "auth_plan_file": null
+  },
+  "runtime": {
+    "type": "claude-code-skill",
+    "entrypoint": "SKILL.md",
+    "operation_style": "subprocess-cli",
+    "python": ">=3.11"
+  },
+  "operations": [
+    {
+      "name": "search_suggestions",
+      "description": "Best Buy autocomplete. Takes a free-text query (e.g. \"laptop\") and returns ranked search-term suggestions, each with a category list and a small set of matching skuIds. Feed the skuIds into lookup_products to get full product cards.",
+      "module": "operations/search_suggestions.py",
+      "entry": "execute",
+      "method": "GET",
+      "path": "/suggest/v1/fragment/suggest/www",
+      "args": [
+        { "name": "query", "type": "string", "required": true,
+          "description": "Free-text query (e.g. \"laptop\", \"usb c cable\")." },
+        { "name": "count", "type": "integer", "required": false, "default": 6,
+          "description": "Max number of suggestions." },
+        { "name": "search_variant", "type": "string", "required": false, "default": "A",
+          "description": "Server-side experiment variant; recording used \"A\"." }
+      ]
+    },
+    {
+      "name": "lookup_products",
+      "description": "Resolve Best Buy skuIds to product cards: title, image, PDP URL, customer rating, review count. Pair with search_suggestions to turn a free-text query into product cards.",
+      "module": "operations/lookup_products.py",
+      "entry": "execute",
+      "method": "GET",
+      "path": "/suggest/v1/fragment/products/www",
+      "args": [
+        { "name": "skuids", "type": "string", "required": true,
+          "description": "Comma-separated skuIds (e.g. \"6619147,6667498,12349296\") or a Python list of strings." }
+      ]
+    }
+  ],
+  "artifacts": {
+    "skill_file": "SKILL.md",
+    "files": [
+      "SKILL.md",
+      "API.md",
+      "operations/__init__.py",
+      "operations/search_suggestions.py",
+      "operations/lookup_products.py"
+    ],
+    "api_docs_file": "API.md"
+  },
+  "generation": {
+    "generated_at": "2026-05-14T23:57:13Z",
+    "generator": "noui",
+    "generator_version": "v1-skill",
+    "generalized_at": "2026-05-15"
+  }
+}

--- a/skills/bestbuy-search/noui_runtime/browser.py
+++ b/skills/bestbuy-search/noui_runtime/browser.py
@@ -1,0 +1,148 @@
+"""Thin wrapper around the NoUI backend browser-command bridge.
+
+Calls POST http://localhost:8002/browser-commands/execute which forwards
+each command to the Chrome extension connected to the NoUI backend.
+
+Prerequisites:
+  - NoUI backend running: python cli/main.py start  (or uvicorn backend.main:app)
+  - Chrome extension loaded and showing a green dot at localhost:8002
+
+Available command_types mirror what the extension supports:
+  navigate, click_element, click_by_text, wait_for_selector, wait_for_url,
+  get_page_info, eval_js, query_elements, cdp_click, cdp_type, get_page_summary
+
+All public functions raise RuntimeError on command failure so callers get a
+clear traceback rather than a silent empty result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+BACKEND_URL = "http://localhost:8002"
+_EXECUTE_ENDPOINT = f"{BACKEND_URL}/browser-commands/execute"
+_DEFAULT_TIMEOUT = 35.0  # seconds — the backend itself times out commands at 30 s
+
+# Error substrings that indicate a transient frame-removal after navigation.
+# After a full-page navigation the old frame is destroyed; the extension may
+# report this on the very next command.  We retry once after a short pause.
+_FRAME_REMOVED_HINTS = ("frame with id", "was removed", "frame removed")
+
+
+async def _execute(command_type: str, params: dict, *, _retry: bool = True) -> dict:
+    """Post a single command to the backend bridge and return the result dict."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            _EXECUTE_ENDPOINT,
+            json={"command_type": command_type, "params": params},
+            timeout=_DEFAULT_TIMEOUT,
+        )
+    if resp.status_code == 504:
+        raise RuntimeError(
+            f"Browser command '{command_type}' timed out — "
+            "make sure the Chrome extension is open and connected."
+        )
+    resp.raise_for_status()
+    envelope = resp.json()
+
+    # The backend wraps results as {"success": bool, "data": {...}, "error": ...}.
+    # Unwrap so callers receive the payload dict directly.
+    err = envelope.get("error") or ""
+    if err:
+        # Retry once for transient frame-removal errors caused by navigation.
+        if _retry and any(h in err.lower() for h in _FRAME_REMOVED_HINTS):
+            await asyncio.sleep(1.5)
+            return await _execute(command_type, params, _retry=False)
+        raise RuntimeError(
+            f"Browser command '{command_type}' failed: {err}"
+        )
+    data = envelope.get("data")
+    if isinstance(data, dict):
+        return data
+    # Some commands return the payload at the top level (no data wrapper).
+    return envelope
+
+
+async def navigate(url: str) -> dict:
+    """Navigate the active Chrome tab to *url*.
+
+    Returns ``{"success": true, "url": url}`` when the navigation was
+    accepted by the extension.  Does not wait for page load — follow
+    with ``wait_for_selector`` or ``wait_for_url`` as needed.
+    """
+    return await _execute("navigate", {"url": url})
+
+
+async def wait_for_selector(selector: str, *, timeout_ms: int = 12000) -> dict:
+    """Block until *selector* appears in the DOM or timeout expires.
+
+    Returns ``{"found": bool, "waited": <ms>}``.
+    """
+    return await _execute(
+        "wait_for_selector", {"selector": selector, "timeout": timeout_ms}
+    )
+
+
+async def wait_for_url(url_substring: str, *, timeout_ms: int = 12000) -> dict:
+    """Block until the page URL contains *url_substring* or timeout expires."""
+    return await _execute(
+        "wait_for_url", {"url_substring": url_substring, "timeout": timeout_ms}
+    )
+
+
+async def click_by_text(text: str, *, exact: bool = False) -> dict:
+    """Click the first visible interactive element whose label contains *text*.
+
+    Returns ``{"clicked": bool, ...}``.
+    """
+    return await _execute("click_by_text", {"text": text, "exact": exact})
+
+
+async def click_element(selector: str) -> dict:
+    """Click the element identified by CSS *selector*.
+
+    Returns ``{"clicked": bool, ...}``.
+    """
+    return await _execute("click_element", {"selector": selector})
+
+
+async def cdp_click(selector: str) -> dict:
+    """Dispatch OS-level mouse events via CDP (works on React/Vue components).
+
+    Use when ``click_element`` fails silently on custom components.
+    """
+    return await _execute("cdp_click", {"selector": selector})
+
+
+async def get_page_info() -> dict:
+    """Return ``{"url": str, "title": str}`` for the active tab."""
+    return await _execute("get_page_info", {})
+
+
+async def get_page_summary() -> dict:
+    """Return a summary of visible interactive elements on the page."""
+    return await _execute("get_page_summary", {})
+
+
+async def query_elements(
+    selector: str, *, include_text: bool = True, max_results: int = 20
+) -> dict:
+    """Query elements matching *selector* and return their attributes.
+
+    Returns ``{"count": N, "elements": [...]}``.
+    """
+    return await _execute(
+        "query_elements",
+        {"selector": selector, "includeText": include_text, "maxResults": max_results},
+    )
+
+
+async def eval_js(code: str) -> dict:
+    """Evaluate a JavaScript expression in the active tab.
+
+    Returns ``{"success": bool, "result": any}``.  Note: blocked by CSP
+    on some pages — prefer other commands when possible.
+    """
+    return await _execute("eval_js", {"code": code})

--- a/skills/bestbuy-search/operations/add_to_cart.py
+++ b/skills/bestbuy-search/operations/add_to_cart.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Add the currently open Best Buy product to the cart.
+
+SAFETY: This operation will NOT be executed without explicit human approval.
+The calling assistant MUST:
+  1. Show the user the product title, URL, and price before calling this.
+  2. Ask for explicit confirmation ("Should I add this to your cart?").
+  3. Only call this script after the user says yes.
+
+The script clicks the Best Buy add-to-cart button on whatever product page is
+currently open in the browser, waits for confirmation that the item was added,
+then navigates to the cart and returns its contents.
+
+Requires:
+  - NoUI backend running at http://localhost:8002
+  - Chrome extension connected (green dot at localhost:8002)
+  - Active browser tab on a Best Buy product page
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+_SKILL_ROOT = Path(__file__).resolve().parent.parent
+if str(_SKILL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SKILL_ROOT))
+
+from noui_runtime import browser  # noqa: E402
+
+BESTBUY_HOST = "https://www.bestbuy.com"
+BESTBUY_CART_URL = f"{BESTBUY_HOST}/cart"
+
+# Best Buy add-to-cart button selectors (in priority order).
+_ADD_TO_CART_SELECTORS = [
+    "button.add-to-cart-button",
+    "[data-button-state='ADD_TO_CART']",
+    ".fulfillment-add-to-cart-button",
+    "button[class*='add-to-cart']",
+]
+
+# Text labels to try if selectors miss.
+_ADD_TO_CART_LABELS = ["Add to Cart", "Add to cart"]
+
+# Selectors that appear after a successful add-to-cart.
+_SUCCESS_SELECTORS = [
+    # Mini-cart flyout / "Item Added" overlay
+    "[data-test='mini-cart-count']",
+    "[aria-label*='cart' i][aria-label*='item' i]",
+    ".go-to-cart-button",
+    "button.go-to-cart",
+    # Order summary drawer
+    "[data-component='CartButton']",
+]
+
+# Payment-boundary indicators — stop immediately if any are present.
+_PAYMENT_SELECTORS = [
+    "input[autocomplete='cc-number']",
+    "input[name*='cardNumber' i]",
+    "input[placeholder*='card number' i]",
+    "[aria-label*='card number' i]",
+    "[data-test*='payment' i]",
+]
+_PAYMENT_URL_PATTERNS = ["/checkout/r/payment", "/checkout#bb-payment", "checkout/payment"]
+_FORBIDDEN_BUTTON_TEXTS = [
+    "place your order",
+    "place order",
+    "pay now",
+    "confirm order",
+    "submit order",
+    "buy now",
+]
+
+
+async def _is_at_payment_boundary() -> bool:
+    """Return True if any payment-form indicators are visible."""
+    page = await browser.get_page_info()
+    url = page.get("url", "").lower()
+    if any(p in url for p in _PAYMENT_URL_PATTERNS):
+        return True
+    for sel in _PAYMENT_SELECTORS:
+        result = await browser.wait_for_selector(sel, timeout_ms=1000)
+        if result.get("found"):
+            return True
+    return False
+
+
+async def _cart_summary() -> dict:
+    """Return a lightweight cart summary (line titles + subtotal text)."""
+    js = """
+return (function() {
+  function text(el) { return el ? el.textContent.trim().replace(/\\s+/g,' ') : ''; }
+  var rows = document.querySelectorAll('[class*="cart-item" i], [data-test*="cart-item" i]');
+  var lines = [];
+  rows.forEach(function(row, i) {
+    if (i >= 20) return;
+    var title = row.querySelector('h4, h3, [class*="item-title" i], a') || row;
+    var price = row.querySelector('[class*="price" i], [data-test*="price" i]');
+    lines.push({title: text(title).slice(0,120), price: text(price).slice(0,30)});
+  });
+  var subtotal = document.querySelector(
+    '[class*="subtotal" i], [data-test*="subtotal" i], [class*="order-total" i]'
+  );
+  return {line_count: lines.length, lines: lines, subtotal: text(subtotal), url: location.href};
+})()
+"""
+    raw = await browser.eval_js(js)
+    # eval_js returns {"success": bool, "result": <value>} after data-unwrap.
+    inner = raw.get("result") if isinstance(raw, dict) else None
+    if isinstance(inner, dict):
+        return inner
+    # Fallback: the whole raw dict might already be the payload.
+    if isinstance(raw, dict) and "line_count" in raw:
+        return raw
+    return {}
+
+
+async def execute(skip_navigation: bool = False) -> dict:
+    """Add the currently open Best Buy product to the cart.
+
+    Args:
+        skip_navigation: If True, assumes the browser is already on the product
+            page and skips any additional navigation before clicking add-to-cart.
+            Default False.
+
+    Returns:
+        On success::
+
+            {
+              "added": true,
+              "method": "selector" | "text",
+              "cart_url": "https://www.bestbuy.com/cart",
+              "cart": {"line_count": N, "lines": [...], "subtotal": "$...", "url": "..."},
+              "payment_boundary_triggered": false
+            }
+
+        On failure::
+
+            {"added": false, "error": "...", "payment_boundary_triggered": bool}
+    """
+    # Safety: abort immediately if already on a payment page.
+    if await _is_at_payment_boundary():
+        return {
+            "added": False,
+            "error": (
+                "Payment boundary detected before add-to-cart. "
+                "The browser is on a payment step — the agent has stopped. "
+                "Complete payment manually."
+            ),
+            "payment_boundary_triggered": True,
+        }
+
+    # 1. Try text-based click first — Best Buy's design system uses utility
+    #    classes that change frequently, so text matching is more stable.
+    clicked = False
+    method = ""
+    for label in _ADD_TO_CART_LABELS:
+        click_result = await browser.click_by_text(label)
+        if click_result.get("clicked"):
+            clicked = True
+            method = f"text:{label}"
+            break
+
+    # 2. Fall back to CSS selectors for older page variants.
+    if not clicked:
+        for sel in _ADD_TO_CART_SELECTORS:
+            result = await browser.query_elements(sel, include_text=False, max_results=1)
+            if result.get("count", 0) > 0:
+                click_result = await browser.cdp_click(sel)
+                if click_result.get("clicked"):
+                    clicked = True
+                    method = f"selector:{sel}"
+                    break
+
+    if not clicked:
+        return {
+            "added": False,
+            "error": (
+                "Could not find an Add-to-Cart button. The page may require "
+                "selecting a size/color/variant, signing in, or the item may "
+                "be out of stock. Inspect the browser tab and try again."
+            ),
+            "payment_boundary_triggered": False,
+        }
+
+    # 3. Wait for the cart to update (mini-cart count or success overlay).
+    cart_updated = False
+    for sel in _SUCCESS_SELECTORS:
+        result = await browser.wait_for_selector(sel, timeout_ms=8000)
+        if result.get("found"):
+            cart_updated = True
+            break
+
+    # 4. Navigate to the full cart page and take a summary.
+    await browser.navigate(BESTBUY_CART_URL)
+    await browser.wait_for_url("/cart", timeout_ms=12000)
+
+    # Safety: make sure we haven't landed on a payment page somehow.
+    if await _is_at_payment_boundary():
+        return {
+            "added": clicked,
+            "error": (
+                "Payment boundary reached unexpectedly after add-to-cart. "
+                "The agent has stopped. Complete payment manually."
+            ),
+            "payment_boundary_triggered": True,
+        }
+
+    cart = await _cart_summary()
+    return {
+        "added": True,
+        "method": method,
+        "cart_updated_confirmed": cart_updated,
+        "cart_url": BESTBUY_CART_URL,
+        "cart": cart,
+        "payment_boundary_triggered": False,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="add_to_cart",
+        description=(
+            "Add the currently open Best Buy product to the cart. "
+            "REQUIRES HUMAN APPROVAL before running."
+        ),
+    )
+    p.add_argument(
+        "--skip-navigation",
+        dest="skip_navigation",
+        action="store_true",
+        default=False,
+        help="Skip navigation; assume the browser is already on the product page.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = asyncio.run(execute(skip_navigation=args.skip_navigation))
+    except Exception as exc:
+        print(f"add_to_cart failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    if not result.get("added"):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/bestbuy-search/operations/lookup_products.py
+++ b/skills/bestbuy-search/operations/lookup_products.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Best Buy product-card lookup by skuId.
+
+Given one or more Best Buy skuIds (typically pulled from
+`search_suggestions`), returns full product cards: short title, image,
+PDP URL, customer rating, and review count.
+
+Note: this endpoint does not include price. Price requires a separate
+GraphQL call against `/gateway/graphql` (not exposed by this skill).
+The PDP URL can be combined with the host to send the user to the
+product page for live pricing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+
+import httpx
+
+BESTBUY_HOST = "https://www.bestbuy.com"
+
+_HEADERS = {
+    "X-CLIENT-ID": "Search-Web-View",
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Referer": f"{BESTBUY_HOST}/",
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
+    ),
+    "sec-ch-ua": '"Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"Windows"',
+    "Sec-Fetch-Site": "same-origin",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Dest": "empty",
+}
+
+
+def _normalize_skuids(skuids: str | list[str]) -> str:
+    if isinstance(skuids, list):
+        return ",".join(s.strip() for s in skuids if s and s.strip())
+    return ",".join(s.strip() for s in str(skuids).split(",") if s.strip())
+
+
+async def execute(skuids: str | list[str]) -> dict:
+    """Look up Best Buy product cards by skuId.
+
+    Args:
+        skuids: A single comma-separated string ("6619147,6667498") or a
+            Python list of skuId strings. Order is preserved.
+
+    Returns:
+        Parsed JSON. Top-level shape::
+
+            {
+              "count": 3,
+              "products": [
+                {
+                  "skuid": "6619147",
+                  "skushortlabel": "Lenovo - IdeaPad Slim 3x ...",
+                  "pdpUrl": "/product/lenovo-ideapad-slim-3x.../JJGSH82JL5",
+                  "imageUrl": "BestBuy_US/images/products/<uuid>.jpg",
+                  "altText": "Lenovo - IdeaPad Slim 3x ...",
+                  "customerrating_facet": "4.7",
+                  "numberofreviews_facet": "276"
+                }, ...
+              ]
+            }
+
+        Prepend `BESTBUY_HOST` to `pdpUrl` for a clickable URL.
+    """
+    csv = _normalize_skuids(skuids)
+    if not csv:
+        return {"count": 0, "products": [], "warning": "no skuids supplied"}
+
+    url = f"{BESTBUY_HOST}/suggest/v1/fragment/products/www"
+    params = {"skuids": csv}
+
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        resp = await client.get(url, headers=_HEADERS, params=params, timeout=20.0)
+        resp.raise_for_status()
+        try:
+            return resp.json()
+        except Exception:
+            return {"status": resp.status_code, "text": resp.text}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="lookup_products",
+        description="Best Buy product-card lookup by skuId.",
+    )
+    p.add_argument(
+        "--skuids",
+        required=True,
+        help='Comma-separated skuIds (e.g. "6619147,6667498,12349296").',
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = asyncio.run(execute(skuids=args.skuids))
+    except Exception as exc:
+        print(f"lookup_products failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/bestbuy-search/operations/open_product.py
+++ b/skills/bestbuy-search/operations/open_product.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Open a Best Buy product detail page in the active browser tab.
+
+Navigates to the product and waits for its key UI elements to load so
+subsequent add_to_cart calls can immediately interact with the page.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+_SKILL_ROOT = Path(__file__).resolve().parent.parent
+if str(_SKILL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SKILL_ROOT))
+
+from noui_runtime import browser  # noqa: E402
+
+BESTBUY_HOST = "https://www.bestbuy.com"
+
+# Selectors that indicate a PDP has finished rendering.
+_PDP_READY_SELECTORS = [
+    "button.add-to-cart-button",
+    "[data-button-state='ADD_TO_CART']",
+    ".fulfillment-add-to-cart-button",
+    "button[class*='add-to-cart']",
+]
+
+# Fallback: wait for the product title heading.
+_TITLE_SELECTOR = "h1.heading-5, h1[class*='sku-title'], h1"
+
+
+async def execute(pdp_url: str) -> dict:
+    """Navigate to a Best Buy product page and wait for it to be ready.
+
+    Args:
+        pdp_url: Either a relative path from lookup_products (e.g.
+            "/product/lenovo-ideapad.../JJGSH82JL5") or a full URL.
+
+    Returns:
+        ``{"ready": bool, "url": str, "title": str, "add_to_cart_visible": bool}``
+    """
+    if pdp_url.startswith("/"):
+        url = f"{BESTBUY_HOST}{pdp_url}"
+    elif not pdp_url.startswith("http"):
+        url = f"{BESTBUY_HOST}/{pdp_url.lstrip('/')}"
+    else:
+        url = pdp_url
+
+    await browser.navigate(url)
+
+    # Wait for the URL to settle on bestbuy.com (handles any redirect).
+    await browser.wait_for_url("bestbuy.com", timeout_ms=15000)
+
+    # Try to detect that the add-to-cart button or page title loaded.
+    add_to_cart_visible = False
+    for sel in _PDP_READY_SELECTORS:
+        result = await browser.wait_for_selector(sel, timeout_ms=8000)
+        if result.get("found"):
+            add_to_cart_visible = True
+            break
+
+    if not add_to_cart_visible:
+        # Fall back to waiting for the heading at minimum.
+        await browser.wait_for_selector(_TITLE_SELECTOR, timeout_ms=8000)
+
+    page = await browser.get_page_info()
+    return {
+        "ready": True,
+        "url": page.get("url", url),
+        "title": page.get("title", ""),
+        "add_to_cart_visible": add_to_cart_visible,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="open_product",
+        description="Open a Best Buy product detail page in the active browser tab.",
+    )
+    p.add_argument(
+        "--pdp-url",
+        dest="pdp_url",
+        required=True,
+        help='Relative pdpUrl from lookup_products (e.g. "/product/.../SKU") or full URL.',
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = asyncio.run(execute(pdp_url=args.pdp_url))
+    except Exception as exc:
+        print(f"open_product failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/bestbuy-search/operations/proceed_to_checkout.py
+++ b/skills/bestbuy-search/operations/proceed_to_checkout.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""Proceed from the Best Buy cart to the checkout page and STOP at payment.
+
+SAFETY: This operation will NOT be executed without explicit human approval.
+The calling assistant MUST:
+  1. Show the user the full cart summary (from add_to_cart output).
+  2. Ask: "The cart contains <items> for <subtotal>. Proceed to checkout?"
+  3. Only call this script after the user confirms.
+  4. NEVER call this script a second time if it returns payment_boundary=True.
+
+The script clicks the "Checkout" button from the cart, walks through any
+address/fulfillment screens the user already has saved, and stops as soon as
+it detects payment-entry indicators. The user must complete payment manually.
+
+HARD STOP conditions (agent halts immediately):
+  - URL contains a payment path pattern
+  - A credit-card number / CVV / payment method input appears in the DOM
+  - A "Place Your Order" or "Pay Now" button becomes visible
+
+Requires:
+  - NoUI backend running at http://localhost:8002
+  - Chrome extension connected
+  - Active browser tab on the Best Buy cart page (https://www.bestbuy.com/cart)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+
+_SKILL_ROOT = Path(__file__).resolve().parent.parent
+if str(_SKILL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SKILL_ROOT))
+
+from noui_runtime import browser  # noqa: E402
+
+BESTBUY_HOST = "https://www.bestbuy.com"
+BESTBUY_CART_URL = f"{BESTBUY_HOST}/cart"
+
+# Labels / selectors for "Checkout" button on the cart page.
+_CHECKOUT_SELECTORS = [
+    "button.checkout-buttons__checkout",
+    "[data-test='checkout-button']",
+    "button[class*='checkout' i]",
+]
+_CHECKOUT_LABELS = ["Checkout", "Go to Checkout", "Proceed to Checkout"]
+
+# ---------------------------------------------------------------------------
+# Payment boundary definitions
+# ---------------------------------------------------------------------------
+
+# URL substrings that indicate the browser has entered a payment step.
+_PAYMENT_URL_PATTERNS = [
+    "/checkout/r/payment",
+    "/checkout#bb-payment",
+    "checkout/payment",
+    "/checkout/step/payment",
+]
+
+# DOM selectors indicating a payment form is visible.
+_PAYMENT_DOM_SELECTORS = [
+    "input[autocomplete='cc-number']",
+    "input[name*='cardNumber' i]",
+    "input[placeholder*='card number' i]",
+    "input[placeholder*='credit card' i]",
+    "[aria-label*='card number' i]",
+    "[data-test*='payment-method' i]",
+    "iframe[src*='payment' i]",
+    "iframe[src*='creditcard' i]",
+    "iframe[title*='credit card' i]",
+]
+
+# Button texts that must never be clicked.
+_FORBIDDEN_BUTTON_TEXTS = [
+    "place your order",
+    "place order",
+    "pay now",
+    "confirm order",
+    "submit order",
+]
+
+# Checkout sub-steps the agent is allowed to pass through automatically.
+# These are address/fulfillment/review steps on bestbuy.com's
+# `/checkout` flow that appear before the payment entry screen.
+_SAFE_CHECKOUT_URL_PATTERNS = [
+    "/checkout#bb-fulfillment",
+    "/checkout#bb-contact",
+    "/checkout#bb-address",
+    "/checkout#bb-review",
+    "/checkout/r/fulfillment",
+    "/checkout/r/contact",
+    "/checkout/r/review",
+]
+
+
+async def _detect_payment_boundary() -> dict:
+    """Return info about whether we're at a payment boundary.
+
+    Returns a dict with keys:
+      - ``at_boundary``: True if payment step detected
+      - ``reason``: human-readable reason
+      - ``url``: current page URL
+    """
+    page = await browser.get_page_info()
+    url = page.get("url", "").lower()
+
+    if any(p in url for p in _PAYMENT_URL_PATTERNS):
+        return {"at_boundary": True, "reason": f"payment URL pattern in {url}", "url": url}
+
+    for sel in _PAYMENT_DOM_SELECTORS:
+        result = await browser.wait_for_selector(sel, timeout_ms=800)
+        if result.get("found"):
+            return {"at_boundary": True, "reason": f"payment field selector {sel!r} found", "url": url}
+
+    # Check for "Place Your Order" button text.
+    forbidden_js = """
+return (function() {
+  var texts = ['place your order','place order','pay now','confirm order','submit order'];
+  var found = null;
+  document.querySelectorAll('button, [role="button"], input[type="submit"]').forEach(function(el) {
+    var t = (el.textContent || el.value || el.getAttribute('aria-label') || '').trim().toLowerCase();
+    if (!found && texts.some(function(f){ return t.includes(f); })) {
+      found = t;
+    }
+  });
+  return found;
+})()
+"""
+    js_result = await browser.eval_js(forbidden_js)
+    found_label = js_result.get("result") if isinstance(js_result, dict) else None
+    if found_label:
+        return {
+            "at_boundary": True,
+            "reason": f"forbidden button visible: '{found_label}'",
+            "url": url,
+        }
+
+    return {"at_boundary": False, "reason": "", "url": url}
+
+
+async def execute(max_steps: int = 6) -> dict:
+    """Proceed from the Best Buy cart through checkout to the payment step.
+
+    The agent clicks through safe checkout sub-steps (fulfillment, address,
+    review) automatically, then stops as soon as any payment indicator is
+    detected. It will NOT click any payment button or enter any credentials.
+
+    Args:
+        max_steps: Max number of "Continue" / "Next" click attempts before
+            giving up to avoid looping. Default 6.
+
+    Returns:
+        On reaching payment boundary (expected success)::
+
+            {
+              "checkout_reached": true,
+              "payment_boundary": true,
+              "stopped_at": "...",   # reason / URL
+              "steps_taken": N,
+              "current_url": "...",
+              "current_title": "...",
+              "message": "Agent stopped at payment step. Complete payment manually."
+            }
+
+        On failure::
+
+            {
+              "checkout_reached": false,
+              "payment_boundary": false,
+              "error": "...",
+              "steps_taken": N
+            }
+    """
+    # Ensure we're on the cart page to start.
+    page = await browser.get_page_info()
+    current_url = page.get("url", "").lower()
+    if "/cart" not in current_url:
+        await browser.navigate(BESTBUY_CART_URL)
+        await browser.wait_for_url("/cart", timeout_ms=12000)
+
+    # Immediate payment boundary check (safety).
+    boundary = await _detect_payment_boundary()
+    if boundary["at_boundary"]:
+        return {
+            "checkout_reached": True,
+            "payment_boundary": True,
+            "stopped_at": boundary["reason"],
+            "steps_taken": 0,
+            "current_url": boundary["url"],
+            "current_title": "",
+            "message": "Agent stopped at payment step. Complete payment manually.",
+        }
+
+    # Click the Checkout button — try text labels first (more stable than
+    # CSS selectors that change with Best Buy's design system updates).
+    clicked_checkout = False
+    for label in _CHECKOUT_LABELS:
+        click_result = await browser.click_by_text(label)
+        if click_result.get("clicked"):
+            clicked_checkout = True
+            break
+
+    if not clicked_checkout:
+        for sel in _CHECKOUT_SELECTORS:
+            result = await browser.query_elements(sel, include_text=False, max_results=1)
+            if result.get("count", 0) > 0:
+                click_result = await browser.cdp_click(sel)
+                if click_result.get("clicked"):
+                    clicked_checkout = True
+                    break
+
+    if not clicked_checkout:
+        return {
+            "checkout_reached": False,
+            "payment_boundary": False,
+            "error": (
+                "Could not find the Checkout button on the cart page. "
+                "Make sure the browser is on https://www.bestbuy.com/cart."
+            ),
+            "steps_taken": 0,
+        }
+
+    # Wait for navigation away from the cart.
+    await browser.wait_for_url("/checkout", timeout_ms=15000)
+    steps_taken = 1
+
+    # Walk through safe checkout sub-steps until payment boundary.
+    # "Continue" / "Next" labels are common for sub-step progression.
+    _continue_labels = ["Continue", "Next", "Continue to Review", "Review Order"]
+
+    while steps_taken < max_steps:
+        await asyncio.sleep(1.5)  # brief pause for React re-renders
+
+        boundary = await _detect_payment_boundary()
+        if boundary["at_boundary"]:
+            page = await browser.get_page_info()
+            return {
+                "checkout_reached": True,
+                "payment_boundary": True,
+                "stopped_at": boundary["reason"],
+                "steps_taken": steps_taken,
+                "current_url": page.get("url", boundary["url"]),
+                "current_title": page.get("title", ""),
+                "message": (
+                    "Agent stopped at payment step. "
+                    "Complete payment manually in the browser, then place your order."
+                ),
+            }
+
+        page = await browser.get_page_info()
+        page_url = page.get("url", "").lower()
+
+        # If URL indicates a safe sub-step, click Continue.
+        on_safe_step = any(p in page_url for p in _SAFE_CHECKOUT_URL_PATTERNS)
+        if not on_safe_step:
+            # May have reached an unexpected page; stop safely.
+            break
+
+        advanced = False
+        for label in _continue_labels:
+            click_result = await browser.click_by_text(label)
+            if click_result.get("clicked"):
+                steps_taken += 1
+                advanced = True
+                break
+
+        if not advanced:
+            # No "Continue" button found — either page is still loading or
+            # we need user action (MFA, address form, etc.). Stop.
+            break
+
+    # Final boundary check after loop.
+    boundary = await _detect_payment_boundary()
+    page = await browser.get_page_info()
+
+    if boundary["at_boundary"]:
+        return {
+            "checkout_reached": True,
+            "payment_boundary": True,
+            "stopped_at": boundary["reason"],
+            "steps_taken": steps_taken,
+            "current_url": page.get("url", ""),
+            "current_title": page.get("title", ""),
+            "message": (
+                "Agent stopped at payment step. "
+                "Complete payment manually in the browser, then place your order."
+            ),
+        }
+
+    # Reached max_steps or got stuck on a sub-step (e.g. address form needs input).
+    return {
+        "checkout_reached": True,
+        "payment_boundary": False,
+        "stopped_at": f"max_steps={max_steps} or stuck on sub-step",
+        "steps_taken": steps_taken,
+        "current_url": page.get("url", ""),
+        "current_title": page.get("title", ""),
+        "message": (
+            "Agent stopped before reaching the payment step — "
+            "the checkout form may need manual input (address, contact, etc). "
+            "Complete the remaining steps manually in the browser."
+        ),
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="proceed_to_checkout",
+        description=(
+            "Proceed from the Best Buy cart to checkout and stop at payment. "
+            "REQUIRES HUMAN APPROVAL before running."
+        ),
+    )
+    p.add_argument(
+        "--max-steps",
+        dest="max_steps",
+        type=int,
+        default=6,
+        help="Max checkout sub-steps to advance through (default 6).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = asyncio.run(execute(max_steps=args.max_steps))
+    except Exception as exc:
+        print(f"proceed_to_checkout failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/bestbuy-search/operations/search_suggestions.py
+++ b/skills/bestbuy-search/operations/search_suggestions.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Best Buy search-suggestion autocomplete.
+
+Takes a free-text query (e.g. "laptop", "usb c cable") and returns ranked
+search-term suggestions, each with a category list and a small set of
+matching `skuId`s. Pass those skuIds to `lookup_products` for full
+product cards (title, image, rating, PDP URL).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+
+import httpx
+
+BESTBUY_HOST = "https://www.bestbuy.com"
+
+_HEADERS = {
+    "X-CLIENT-ID": "Search-Web-View",
+    "Accept": "application/json",
+    "Content-Type": "application/json",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Referer": f"{BESTBUY_HOST}/",
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
+    ),
+    "sec-ch-ua": '"Chromium";v="148", "Google Chrome";v="148", "Not/A)Brand";v="99"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"Windows"',
+    "Sec-Fetch-Site": "same-origin",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Dest": "empty",
+}
+
+
+async def execute(
+    query: str,
+    count: int = 6,
+    search_variant: str = "A",
+) -> dict:
+    """Best Buy search-term autocomplete.
+
+    Args:
+        query: Free-text query (e.g. "laptop", "usb c cable").
+        count: Max number of suggestions to return (default 6).
+        search_variant: Server-side experiment variant. Recording used "A".
+
+    Returns:
+        Parsed JSON. Top-level shape::
+
+            {
+              "suggestionResponse": {
+                "spellCheck": {...},
+                "count": int,
+                "suggestions": [
+                  {
+                    "term": "laptop",
+                    "category": [{"name": "...", "id": "..."}, ...],
+                    "products": [{"skuId": "6619147", ...}, ...]
+                  }, ...
+                ]
+              }
+            }
+
+        Pull `skuId`s from `suggestions[i].products[*].skuId` and feed them
+        to `lookup_products` to get titles, images, ratings, and PDP URLs.
+    """
+    url = f"{BESTBUY_HOST}/suggest/v1/fragment/suggest/www"
+    params = {
+        "query": query,
+        "count": str(count),
+        "searchVariant": search_variant,
+    }
+
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        resp = await client.get(url, headers=_HEADERS, params=params, timeout=20.0)
+        resp.raise_for_status()
+        try:
+            return resp.json()
+        except Exception:
+            return {"status": resp.status_code, "text": resp.text}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="search_suggestions",
+        description="Best Buy autocomplete: query -> suggested terms + skuIds.",
+    )
+    p.add_argument("--query", required=True, help='Free-text query (e.g. "laptop").')
+    p.add_argument("--count", type=int, default=6, help="Max suggestions (default 6).")
+    p.add_argument(
+        "--search-variant",
+        dest="search_variant",
+        default="A",
+        help="Server experiment variant (default A).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = asyncio.run(
+            execute(
+                query=args.query,
+                count=args.count,
+                search_variant=args.search_variant,
+            )
+        )
+    except Exception as exc:
+        print(f"search_suggestions failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ecommerce_agent.py
+++ b/tests/test_ecommerce_agent.py
@@ -1,0 +1,801 @@
+"""End-to-end-ish tests for the e-commerce agent run state machine.
+
+Uses an in-memory SQLite database (mirrors the production setup) and a
+fully mocked browser executor, so the tests exercise the entire flow
+without touching a real browser.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+if str(_NOUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(_NOUI_ROOT))
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import backend.ecommerce.models  # noqa: F401
+
+# Importing Base also imports every ORM model side-effect: ensure ecommerce
+# models are loaded so the table is created.
+from backend.database import Base
+from backend.ecommerce import agent
+from backend.ecommerce.agent import RunStatus
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (manual, since the suite doesn't use pytest-asyncio)
+# ---------------------------------------------------------------------------
+
+
+class FakeExecutor:
+    """Browser executor stub that returns scripted responses.
+
+    Responses can be:
+      - dict: returned as-is
+      - callable: receives (command_type, params) and returns a dict
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self._handlers: dict[str, object] = {}
+
+    def stub(self, command_type: str, response):
+        self._handlers[command_type] = response
+
+    def stub_eval_js_result(self, result_payload: dict) -> None:
+        """Stub the next eval_js call to return ``result_payload`` as the JS result."""
+        self._handlers.setdefault("_eval_js_queue", []).append(result_payload)
+
+    async def __call__(self, command_type: str, params: dict) -> dict:
+        self.calls.append((command_type, params))
+        if command_type == "eval_js":
+            queue = self._handlers.get("_eval_js_queue") or []
+            if queue:
+                payload = queue.pop(0)
+                return {
+                    "success": True,
+                    "data": {"success": True, "result": payload},
+                    "error": None,
+                }
+            return {"success": True, "data": {"success": True, "result": {}}, "error": None}
+
+        handler = self._handlers.get(command_type)
+        if callable(handler):
+            return handler(command_type, params)  # type: ignore[no-any-return]
+        if handler is not None:
+            return handler  # type: ignore[return-value]
+        return {"success": True, "data": {}, "error": None}
+
+
+async def _make_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    return engine, Session
+
+
+def _candidate_payload(title: str, url: str, price: str = "$9.99") -> dict:
+    return {
+        "title": title,
+        "url": url,
+        "image_url": "",
+        "price_text": price,
+        "rating_text": "4.5 out of 5 stars",
+        "review_count_text": "100 reviews",
+        "seller": "",
+        "shipping_text": "Free shipping",
+        "availability": "In stock",
+    }
+
+
+# ---------------------------------------------------------------------------
+# create_run + validation
+# ---------------------------------------------------------------------------
+
+
+def test_create_run_rejects_unknown_slug():
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                with pytest.raises(ValueError):
+                    await agent.create_run(db, site_slug="not-real", query="x")
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+def test_create_run_rejects_empty_query():
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                with pytest.raises(ValueError):
+                    await agent.create_run(db, site_slug="amazon", query="   ")
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+def test_create_run_initial_state():
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="amazon", query="usb cable")
+            assert run.status == RunStatus.CREATED
+            assert run.site_slug == "amazon"
+            assert run.query == "usb cable"
+            # Default policy strips place_order even if a buggy client sent it.
+            assert '"place_order"' in run.forbidden_side_effects_json
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+# ---------------------------------------------------------------------------
+# search → awaiting_selection
+# ---------------------------------------------------------------------------
+
+
+def test_search_extracts_and_ranks_candidates():
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(
+                    db,
+                    site_slug="amazon",
+                    query="usb-c cable",
+                    max_price=20.0,
+                    min_rating=4.0,
+                )
+
+                executor = FakeExecutor()
+                executor.stub_eval_js_result(
+                    {
+                        "candidates": [
+                            _candidate_payload("Cable A", "https://a.example.com", "$15"),
+                            _candidate_payload("Cable B", "https://b.example.com", "$8"),
+                        ],
+                        "total_cards": 2,
+                    }
+                )
+
+                run = await agent.search(db, run, executor)
+
+                # First call is navigate; subsequent calls include the
+                # page-ready wait sequence (wait_for_url, wait_for_selector,
+                # get_page_info) before eval_js. Order: navigate must come
+                # first and an eval_js call must occur for extraction.
+                assert executor.calls[0][0] == "navigate"
+                assert executor.calls[0][1]["url"].startswith("https://www.amazon.com/s?k=")
+                command_types = [c[0] for c in executor.calls]
+                assert "wait_for_url" in command_types
+                assert "wait_for_selector" in command_types
+                assert "eval_js" in command_types
+
+                assert run.status == RunStatus.AWAITING_SELECTION
+                candidates = await agent.list_candidates(db, run.id)
+                assert len(candidates) == 2
+                # Cheaper item ranks higher (price-fit dominates with same rating).
+                assert candidates[0].title == "Cable B"
+                checkpoint = agent.get_checkpoint(run)
+                assert checkpoint is not None and checkpoint.action == "select_product"
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+def test_search_empty_results_emits_needs_user():
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="ebay", query="nothing")
+
+                executor = FakeExecutor()
+                # Profile extractor returns 0 cards.
+                executor.stub_eval_js_result({"candidates": [], "total_cards": 0})
+                # Generic fallback also returns 0 cards.
+                executor.stub_eval_js_result({"candidates": [], "total_cards": 0, "source": "generic"})
+
+                run = await agent.search(db, run, executor)
+                assert run.status == RunStatus.NEEDS_USER
+                assert agent.get_checkpoint(run) is not None
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+def test_search_records_page_ready_event_before_extraction():
+    """The agent must wait for the page to load before scraping."""
+
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="ebay", query="cable")
+
+                executor = FakeExecutor()
+                executor.stub_eval_js_result(
+                    {
+                        "candidates": [
+                            _candidate_payload("Cable", "https://ebay.com/itm/1", "$8")
+                        ],
+                        "total_cards": 1,
+                    }
+                )
+                run = await agent.search(db, run, executor)
+
+                # page_ready event must appear before search_ranked.
+                events = await agent.list_events(db, run.id)
+                types = [e.event_type for e in events]
+                assert "page_ready" in types
+                assert "search_ranked" in types
+                assert types.index("page_ready") < types.index("search_ranked")
+                # The page_ready event must come AFTER search_start.
+                assert types.index("search_start") < types.index("page_ready")
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+def test_search_empty_surfaces_bot_check_hint_in_checkpoint():
+    """When wait_for_page_ready hits a captcha URL, the checkpoint must say so."""
+
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="amazon", query="anything")
+
+                executor = FakeExecutor()
+                # Simulate amazon redirecting to a captcha page: wait_for_url
+                # times out, wait_for_selector finds nothing, get_page_info
+                # reports a captcha URL/title.
+                executor.stub(
+                    "wait_for_url",
+                    {
+                        "success": True,
+                        "data": {
+                            "matched": False,
+                            "url": "https://www.amazon.com/errors/validateCaptcha?args=...",
+                            "waited": 6000,
+                            "timeout": True,
+                        },
+                    },
+                )
+                executor.stub(
+                    "wait_for_selector",
+                    {
+                        "success": True,
+                        "data": {"found": False, "waited": 1000, "timeout": True},
+                    },
+                )
+                executor.stub(
+                    "get_page_info",
+                    {
+                        "success": True,
+                        "data": {
+                            "url": "https://www.amazon.com/errors/validateCaptcha?args=...",
+                            "title": "Robot Check",
+                        },
+                    },
+                )
+                # Both extractor passes return zero cards.
+                executor.stub_eval_js_result({"candidates": [], "total_cards": 0})
+                executor.stub_eval_js_result({"candidates": [], "total_cards": 0, "source": "generic"})
+
+                run = await agent.search(db, run, executor)
+                assert run.status == RunStatus.NEEDS_USER
+                cp = agent.get_checkpoint(run)
+                assert cp is not None
+                assert cp.metadata.get("bot_check_hint") is True
+                # The detail message must explicitly mention captcha/bot-check.
+                assert "captcha" in cp.detail.lower() or "bot" in cp.detail.lower()
+
+                # The search_empty audit payload also surfaces the diagnostic.
+                events = await agent.list_events(db, run.id)
+                empty_evts = [e for e in events if e.event_type == "search_empty"]
+                assert empty_evts
+                import json as _json
+
+                payload = _json.loads(empty_evts[-1].payload_json)
+                assert payload["bot_check_hint"] is True
+                assert "captcha" in payload["final_url"].lower()
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+def test_add_to_cart_signin_wall_triggers_retry_checkpoint():
+    """When no Add-to-cart button is found AND the page is a sign-in wall,
+    the agent must surface a retry_add_to_cart checkpoint, not a generic
+    failure."""
+
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="amazon", query="x")
+                executor = FakeExecutor()
+                executor.stub_eval_js_result(
+                    {
+                        "candidates": [
+                            _candidate_payload("Cable", "https://a.example.com", "$10")
+                        ],
+                        "total_cards": 1,
+                    }
+                )
+                run = await agent.search(db, run, executor)
+                candidates = await agent.list_candidates(db, run.id)
+                executor.stub_eval_js_result({"highlighted": True})
+                run, _ = await agent.select_candidate(db, run, executor, candidates[0].id)
+
+                # detect_purchase_boundary on product page — none present.
+                executor.stub_eval_js_result({"boundary_present": False, "matches": []})
+                # click_by_text never clicks (no add-to-cart button found).
+                executor.stub("click_by_text", {"success": True, "data": {"clicked": False}, "error": None})
+                # detect_signin_wall — reports a clear sign-in wall.
+                executor.stub_eval_js_result(
+                    {
+                        "signin_present": True,
+                        "signin_controls": 4,
+                        "addtocart_controls": 0,
+                        "has_password_field": True,
+                        "title_hint": True,
+                        "hits": ["sign in"],
+                        "url": "https://www.amazon.com/ap/signin",
+                    }
+                )
+
+                run = await agent.confirm(
+                    db, run, executor, action="add_to_cart", approved=True
+                )
+
+                assert run.status == RunStatus.NEEDS_USER
+                cp = agent.get_checkpoint(run)
+                assert cp is not None
+                assert cp.action == "retry_add_to_cart"
+                assert "sign in" in cp.label.lower()
+
+                events = await agent.list_events(db, run.id)
+                assert any(e.event_type == "signin_wall_detected" for e in events)
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+def test_confirm_retry_add_to_cart_reruns_add_to_cart():
+    """After the user signs in and approves retry_add_to_cart, the agent
+    must re-attempt the add and proceed to awaiting_checkout_confirmation."""
+
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="amazon", query="x")
+                executor = FakeExecutor()
+                executor.stub_eval_js_result(
+                    {
+                        "candidates": [
+                            _candidate_payload("Cable", "https://a.example.com", "$10")
+                        ],
+                        "total_cards": 1,
+                    }
+                )
+                run = await agent.search(db, run, executor)
+                candidates = await agent.list_candidates(db, run.id)
+                executor.stub_eval_js_result({"highlighted": True})
+                run, _ = await agent.select_candidate(db, run, executor, candidates[0].id)
+
+                # First add-to-cart attempt: blocked by sign-in wall.
+                executor.stub_eval_js_result({"boundary_present": False, "matches": []})
+                executor.stub("click_by_text", {"success": True, "data": {"clicked": False}, "error": None})
+                executor.stub_eval_js_result(
+                    {
+                        "signin_present": True,
+                        "signin_controls": 4,
+                        "addtocart_controls": 0,
+                        "has_password_field": True,
+                        "title_hint": True,
+                        "hits": ["sign in"],
+                    }
+                )
+                run = await agent.confirm(
+                    db, run, executor, action="add_to_cart", approved=True
+                )
+                assert run.status == RunStatus.NEEDS_USER
+                cp = agent.get_checkpoint(run)
+                assert cp is not None and cp.action == "retry_add_to_cart"
+
+                # User signs in and approves retry. This time click succeeds.
+                executor.stub_eval_js_result({"boundary_present": False, "matches": []})
+                executor.stub("click_by_text", {"success": True, "data": {"clicked": True}, "error": None})
+                executor.stub_eval_js_result(
+                    {
+                        "line_count": 1,
+                        "lines": [{"index": 0, "title": "Cable"}],
+                        "subtotal_text": "$10.00",
+                        "buttons": [{"label": "Proceed to checkout"}],
+                        "url": "https://www.amazon.com/cart",
+                    }
+                )
+
+                run = await agent.confirm(
+                    db, run, executor, action="retry_add_to_cart", approved=True
+                )
+                assert run.status == RunStatus.AWAITING_CHECKOUT_CONFIRMATION
+                cp = agent.get_checkpoint(run)
+                assert cp is not None and cp.action == "proceed_to_checkout"
+                # failure_reason cleared after retry.
+                assert run.failure_reason == ""
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+# ---------------------------------------------------------------------------
+# select → awaiting_cart_confirmation
+# ---------------------------------------------------------------------------
+
+
+def test_select_candidate_transitions_to_awaiting_cart_confirmation():
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="amazon", query="x")
+                executor = FakeExecutor()
+                executor.stub_eval_js_result(
+                    {
+                        "candidates": [
+                            _candidate_payload("Cable A", "https://a.example.com", "$10")
+                        ],
+                        "total_cards": 1,
+                    }
+                )
+                run = await agent.search(db, run, executor)
+                candidates = await agent.list_candidates(db, run.id)
+                assert candidates
+
+                # Stub highlight_candidate eval_js
+                executor.stub_eval_js_result({"highlighted": True})
+
+                run, checkpoint = await agent.select_candidate(
+                    db, run, executor, candidates[0].id
+                )
+                assert run.status == RunStatus.AWAITING_CART_CONFIRMATION
+                assert run.selected_candidate_id == candidates[0].id
+                assert checkpoint.action == "add_to_cart"
+                assert checkpoint.candidate_id == candidates[0].id
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+def test_select_candidate_unknown_id_raises():
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="amazon", query="x")
+                executor = FakeExecutor()
+                executor.stub_eval_js_result({"candidates": [], "total_cards": 0})
+                run = await agent.search(db, run, executor)
+                with pytest.raises(ValueError):
+                    await agent.select_candidate(
+                        db, run, executor, "00000000-0000-0000-0000-000000000000"
+                    )
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+# ---------------------------------------------------------------------------
+# confirm → add_to_cart → in_cart → awaiting_checkout_confirmation
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_add_to_cart_runs_add_then_pauses_for_checkout():
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="amazon", query="x")
+                executor = FakeExecutor()
+                executor.stub_eval_js_result(
+                    {
+                        "candidates": [
+                            _candidate_payload("Cable", "https://a.example.com", "$10")
+                        ],
+                        "total_cards": 1,
+                    }
+                )
+                run = await agent.search(db, run, executor)
+                candidates = await agent.list_candidates(db, run.id)
+
+                executor.stub_eval_js_result({"highlighted": True})
+                run, _ = await agent.select_candidate(db, run, executor, candidates[0].id)
+
+                # Stub the eval_js calls that happen during add-to-cart:
+                # 1. detect_purchase_boundary (none present)
+                # 2. extract_cart_summary
+                executor.stub_eval_js_result({"boundary_present": False, "matches": []})
+                executor.stub_eval_js_result(
+                    {
+                        "line_count": 1,
+                        "lines": [{"index": 0, "title": "Cable"}],
+                        "subtotal_text": "$10.00",
+                        "buttons": [{"label": "Proceed to checkout"}],
+                        "url": "https://www.amazon.com/cart",
+                    }
+                )
+                # Stub click_by_text → first labels succeed
+                executor.stub("click_by_text", {"success": True, "data": {"clicked": True}, "error": None})
+
+                run = await agent.confirm(
+                    db, run, executor, action="add_to_cart", approved=True
+                )
+
+                assert run.status == RunStatus.AWAITING_CHECKOUT_CONFIRMATION
+                cp = agent.get_checkpoint(run)
+                assert cp is not None and cp.action == "proceed_to_checkout"
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+def test_confirm_with_decline_cancels_run():
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="amazon", query="x")
+                executor = FakeExecutor()
+                executor.stub_eval_js_result(
+                    {
+                        "candidates": [
+                            _candidate_payload("Cable", "https://a.example.com", "$10")
+                        ],
+                        "total_cards": 1,
+                    }
+                )
+                run = await agent.search(db, run, executor)
+                candidates = await agent.list_candidates(db, run.id)
+                executor.stub_eval_js_result({"highlighted": True})
+                run, _ = await agent.select_candidate(db, run, executor, candidates[0].id)
+
+                run = await agent.confirm(
+                    db,
+                    run,
+                    executor,
+                    action="add_to_cart",
+                    approved=False,
+                    user_note="changed my mind",
+                )
+                assert run.status == RunStatus.CANCELLED
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+def test_confirm_hard_forbidden_action_is_rejected_even_when_approved():
+    """Approving 'place_order' must NOT execute it — policy is the final word."""
+
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="amazon", query="x")
+                executor = FakeExecutor()
+                executor.stub_eval_js_result(
+                    {
+                        "candidates": [
+                            _candidate_payload("Cable", "https://a.example.com", "$10")
+                        ],
+                        "total_cards": 1,
+                    }
+                )
+                run = await agent.search(db, run, executor)
+                candidates = await agent.list_candidates(db, run.id)
+                executor.stub_eval_js_result({"highlighted": True})
+                run, _ = await agent.select_candidate(db, run, executor, candidates[0].id)
+
+                # Force a forbidden checkpoint so we can test the gate.
+                import json
+
+                run.pending_checkpoint_json = json.dumps(
+                    {
+                        "action": "place_order",
+                        "label": "Place your order",
+                        "detail": "test",
+                        "candidate_id": None,
+                        "metadata": {},
+                    }
+                )
+
+                approved_calls_before = len(executor.calls)
+                run = await agent.confirm(
+                    db, run, executor, action="place_order", approved=True
+                )
+                # No browser commands should be dispatched after policy blocks.
+                assert len(executor.calls) == approved_calls_before
+                assert run.status == RunStatus.NEEDS_USER
+                # Audit log records a policy_blocked event.
+                events = await agent.list_events(db, run.id)
+                assert any(e.event_type == "policy_blocked" for e in events)
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+# ---------------------------------------------------------------------------
+# Audit log
+# ---------------------------------------------------------------------------
+
+
+def test_audit_log_records_full_lifecycle():
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="amazon", query="x")
+                executor = FakeExecutor()
+                executor.stub_eval_js_result(
+                    {
+                        "candidates": [
+                            _candidate_payload("Cable", "https://a.example.com", "$10")
+                        ],
+                        "total_cards": 1,
+                    }
+                )
+                run = await agent.search(db, run, executor)
+                candidates = await agent.list_candidates(db, run.id)
+                executor.stub_eval_js_result({"highlighted": True})
+                run, _ = await agent.select_candidate(db, run, executor, candidates[0].id)
+
+                events = await agent.list_events(db, run.id)
+                types = [e.event_type for e in events]
+                assert "run_created" in types
+                assert "search_start" in types
+                assert "search_ranked" in types
+                assert "candidate_selected" in types
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+# ---------------------------------------------------------------------------
+# cancel_run
+# ---------------------------------------------------------------------------
+
+
+def test_auto_advance_after_search_picks_top_and_adds_to_cart():
+    """The full auto-pilot path: search → auto-select → auto-add → pause at checkout."""
+
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="amazon", query="usb cable")
+
+                executor = FakeExecutor()
+                # 1. search → eval_js extract_product_cards
+                executor.stub_eval_js_result(
+                    {
+                        "candidates": [
+                            _candidate_payload("Premium Cable", "https://a.example.com/1", "$8"),
+                            _candidate_payload("Budget Cable", "https://a.example.com/2", "$15"),
+                        ],
+                        "total_cards": 2,
+                    }
+                )
+                # 2. auto_advance → select → highlight_candidate eval_js
+                executor.stub_eval_js_result({"highlighted": True})
+                # 3. add_to_cart → detect_purchase_boundary eval_js
+                executor.stub_eval_js_result({"boundary_present": False, "matches": []})
+                # 4. add_to_cart → extract_cart_summary eval_js
+                executor.stub_eval_js_result(
+                    {
+                        "line_count": 1,
+                        "lines": [{"index": 0, "title": "Premium Cable"}],
+                        "subtotal_text": "$8.00",
+                        "buttons": [{"label": "Proceed to checkout"}],
+                        "url": "https://www.amazon.com/cart",
+                    }
+                )
+                executor.stub(
+                    "click_by_text",
+                    {"success": True, "data": {"clicked": True}, "error": None},
+                )
+
+                run = await agent.search(db, run, executor)
+                assert run.status == RunStatus.AWAITING_SELECTION
+                run = await agent.auto_advance_after_search(db, run, executor)
+
+                # The single human-confirmation point: right before checkout.
+                assert run.status == RunStatus.AWAITING_CHECKOUT_CONFIRMATION
+                cp = agent.get_checkpoint(run)
+                assert cp is not None and cp.action == "proceed_to_checkout"
+
+                # The top-ranked candidate (cheaper one) was auto-selected.
+                candidates = await agent.list_candidates(db, run.id)
+                assert candidates[0].title == "Premium Cable"
+                assert run.selected_candidate_id == candidates[0].id
+
+                # Audit trail records the auto-pilot transitions.
+                events = await agent.list_events(db, run.id)
+                types = [e.event_type for e in events]
+                assert "auto_selected" in types
+                assert "auto_add_to_cart" in types
+                assert "add_to_cart_click" in types
+                assert "cart_summary" in types
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+def test_auto_advance_noop_when_search_left_run_in_needs_user():
+    """If search hit a captcha and the run is at needs_user, auto-advance must not run."""
+
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="amazon", query="x")
+                executor = FakeExecutor()
+                executor.stub_eval_js_result({"candidates": [], "total_cards": 0})
+                run = await agent.search(db, run, executor)
+                assert run.status == RunStatus.NEEDS_USER
+
+                run = await agent.auto_advance_after_search(db, run, executor)
+                assert run.status == RunStatus.NEEDS_USER
+        finally:
+            await engine.dispose()
+
+    _run(_go())
+
+
+def test_cancel_run_records_event_and_marks_cancelled():
+    async def _go():
+        engine, Session = await _make_session()
+        try:
+            async with Session() as db:
+                run = await agent.create_run(db, site_slug="amazon", query="x")
+                run = await agent.cancel_run(db, run, reason="user backed out")
+                assert run.status == RunStatus.CANCELLED
+                assert run.failure_reason == "user backed out"
+                events = await agent.list_events(db, run.id)
+                assert any(e.event_type == "run_cancelled" for e in events)
+        finally:
+            await engine.dispose()
+
+    _run(_go())

--- a/tests/test_ecommerce_browser_commands.py
+++ b/tests/test_ecommerce_browser_commands.py
@@ -1,0 +1,382 @@
+"""Tests for the e-commerce agent's browser command wrappers.
+
+These tests verify the JS payload assembly and result unwrapping without
+talking to a real browser — `BrowserExec` is replaced with a recorder mock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+if str(_NOUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(_NOUI_ROOT))
+
+import pytest
+
+from backend.ecommerce import browser_commands as bc
+from backend.ecommerce.site_catalog import get_profile
+
+
+class RecordingExecutor:
+    """Records every browser command issued, returns canned responses."""
+
+    def __init__(self, responses: list[dict] | None = None) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self._responses = list(responses or [])
+
+    async def __call__(self, command_type: str, params: dict) -> dict:
+        self.calls.append((command_type, params))
+        if self._responses:
+            return self._responses.pop(0)
+        return {"success": True, "data": {"success": True, "result": {}}, "error": None}
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_eval_js_payloads_have_toplevel_return():
+    """Guardrail: every eval_js payload MUST start with a top-level ``return``.
+
+    The extension runs the code as ``new Function(body)()``. A bare IIFE
+    expression statement (``(function(){...})()``) evaluates and is
+    discarded; the wrapping function returns ``undefined`` and the agent
+    sees zero results. This test guards against that regression.
+    """
+    for name in (
+        "_EXTRACT_PRODUCT_CARDS_JS",
+        "_EXTRACT_PRODUCT_CARDS_GENERIC_JS",
+        "_EXTRACT_CART_SUMMARY_JS",
+        "_DETECT_PURCHASE_BOUNDARY_JS",
+        "_DETECT_SIGNIN_WALL_JS",
+        "_HIGHLIGHT_CANDIDATE_JS",
+    ):
+        payload = getattr(bc, name)
+        stripped = payload.lstrip()
+        assert stripped.startswith("return "), (
+            f"{name} must start with `return ` so `new Function(body)()` "
+            f"propagates the IIFE result. Got: {stripped[:60]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# extract_product_cards
+# ---------------------------------------------------------------------------
+
+
+def test_extract_product_cards_injects_selectors_into_payload():
+    profile = get_profile("amazon")
+    rec = RecordingExecutor(
+        [
+            {
+                "success": True,
+                "data": {
+                    "success": True,
+                    "result": {
+                        "candidates": [
+                            {
+                                "title": "USB-C Cable",
+                                "url": "https://www.amazon.com/dp/B000",
+                                "price_text": "$9.99",
+                            }
+                        ],
+                        "total_cards": 1,
+                    },
+                },
+            }
+        ]
+    )
+    result = _run(bc.extract_product_cards(rec, profile, limit=10))
+    assert result["candidates"][0]["title"] == "USB-C Cable"
+    assert result["total_cards"] == 1
+
+    assert len(rec.calls) == 1
+    command_type, params = rec.calls[0]
+    assert command_type == "eval_js"
+    code = params["code"]
+    # Card selectors from the profile should be JSON-encoded into the code.
+    for sel in profile.product_card_selectors:
+        assert sel in code
+    # Limit gets injected.
+    assert "10" in code
+
+
+def test_extract_product_cards_handles_empty_result():
+    profile = get_profile("ebay")
+    rec = RecordingExecutor(
+        [{"success": True, "data": {"success": True, "result": {"candidates": []}}, "error": None}]
+    )
+    result = _run(bc.extract_product_cards(rec, profile, limit=5))
+    assert result.get("candidates") == []
+
+
+# ---------------------------------------------------------------------------
+# detect_purchase_boundary
+# ---------------------------------------------------------------------------
+
+
+def test_detect_purchase_boundary_includes_universal_and_per_site_labels():
+    profile = get_profile("amazon")
+    rec = RecordingExecutor(
+        [
+            {
+                "success": True,
+                "data": {
+                    "success": True,
+                    "result": {
+                        "url": "https://www.amazon.com/gp/buy/spc/handlers/display.html",
+                        "boundary_present": True,
+                        "matches": [{"label": "place your order", "tag": "input", "matched": "place your order"}],
+                    },
+                },
+            }
+        ]
+    )
+    result = _run(bc.detect_purchase_boundary(rec, profile))
+    assert result["boundary_present"] is True
+
+    _, params = rec.calls[0]
+    code = params["code"]
+    # The JS payload must contain at least one universal and one site-specific label.
+    assert "place order" in code
+    assert "1-click" in code or "buy now" in code
+
+
+def test_detect_purchase_boundary_handles_no_profile():
+    rec = RecordingExecutor(
+        [
+            {
+                "success": True,
+                "data": {"success": True, "result": {"boundary_present": False, "matches": []}},
+                "error": None,
+            }
+        ]
+    )
+    result = _run(bc.detect_purchase_boundary(rec, None))
+    assert result["boundary_present"] is False
+    _, params = rec.calls[0]
+    # JSON-encoded labels list must always include the common forbidden phrases.
+    assert "place order" in params["code"]
+
+
+# ---------------------------------------------------------------------------
+# highlight_candidate
+# ---------------------------------------------------------------------------
+
+
+def test_highlight_candidate_requires_target():
+    rec = RecordingExecutor()
+    with pytest.raises(ValueError):
+        _run(bc.highlight_candidate(rec))
+
+
+def test_highlight_candidate_encodes_target_url_safely():
+    rec = RecordingExecutor(
+        [{"success": True, "data": {"success": True, "result": {"highlighted": True}}, "error": None}]
+    )
+    target = 'https://example.com/p?id=1&q=hello world'
+    result = _run(bc.highlight_candidate(rec, target_url=target))
+    assert result["highlighted"] is True
+    _, params = rec.calls[0]
+    # JSON-encoded URL is safely embedded.
+    assert json.dumps(target) in params["code"]
+
+
+# ---------------------------------------------------------------------------
+# extract_cart_summary / navigate
+# ---------------------------------------------------------------------------
+
+
+def test_extract_cart_summary_passes_through_result():
+    rec = RecordingExecutor(
+        [
+            {
+                "success": True,
+                "data": {
+                    "success": True,
+                    "result": {
+                        "line_count": 2,
+                        "lines": [{"index": 0, "title": "Item"}],
+                        "subtotal_text": "$19.98",
+                        "buttons": [{"label": "Proceed to checkout"}],
+                        "url": "https://www.amazon.com/cart",
+                    },
+                },
+            }
+        ]
+    )
+    result = _run(bc.extract_cart_summary(rec))
+    assert result["line_count"] == 2
+    assert result["subtotal_text"] == "$19.98"
+
+
+def test_navigate_passes_url_to_executor():
+    rec = RecordingExecutor([{"success": True, "data": {"navigated": True}, "error": None}])
+    _run(bc.navigate(rec, "https://www.amazon.com"))
+    assert rec.calls == [("navigate", {"url": "https://www.amazon.com"})]
+
+
+# ---------------------------------------------------------------------------
+# wait_for_page_ready
+# ---------------------------------------------------------------------------
+
+
+def test_wait_for_page_ready_issues_url_then_selector_then_page_info():
+    """The helper must call wait_for_url first, then probe selectors, then page_info."""
+    profile = get_profile("ebay")
+    rec = RecordingExecutor(
+        [
+            # wait_for_url
+            {"success": True, "data": {"matched": True, "url": "https://www.ebay.com/sch/i.html?_nkw=x", "waited": 250}},
+            # wait_for_selector #1 — first profile card selector matches
+            {"success": True, "data": {"found": True, "waited": 100}},
+            # get_page_info
+            {"success": True, "data": {"url": "https://www.ebay.com/sch/i.html?_nkw=x", "title": "x | eBay"}},
+        ]
+    )
+    result = _run(bc.wait_for_page_ready(rec, profile, "https://www.ebay.com/sch/i.html?_nkw=x"))
+    assert result["ready"] is True
+    assert result["matched_selector"] == profile.product_card_selectors[0]
+    assert result["url"] == "https://www.ebay.com/sch/i.html?_nkw=x"
+    assert result["bot_check_hint"] is False
+
+    cmd_types = [c[0] for c in rec.calls]
+    assert cmd_types[0] == "wait_for_url"
+    assert cmd_types[1] == "wait_for_selector"
+    assert "get_page_info" in cmd_types
+
+    # The URL substring passed must be the host without www.
+    _, url_params = rec.calls[0]
+    assert url_params["url_substring"] == "ebay.com"
+
+
+def test_wait_for_page_ready_flags_bot_check_pages():
+    profile = get_profile("amazon")
+    rec = RecordingExecutor(
+        [
+            # wait_for_url — timed out, did not match host
+            {"success": True, "data": {"matched": False, "url": "https://www.amazon.com/errors/validateCaptcha", "waited": 6000, "timeout": True}},
+            # wait_for_selector — each card selector misses
+            {"success": True, "data": {"found": False, "waited": 1000, "timeout": True}},
+            {"success": True, "data": {"found": False, "waited": 1000, "timeout": True}},
+            {"success": True, "data": {"found": False, "waited": 1000, "timeout": True}},
+            # get_page_info on a captcha page
+            {"success": True, "data": {"url": "https://www.amazon.com/errors/validateCaptcha?args=...", "title": "Robot Check"}},
+        ]
+    )
+    result = _run(
+        bc.wait_for_page_ready(rec, profile, "https://www.amazon.com/s?k=x")
+    )
+    assert result["ready"] is False
+    assert result["matched_selector"] == ""
+    assert result["bot_check_hint"] is True
+
+
+def test_is_bot_check_url_patterns():
+    assert bc.is_bot_check("https://www.amazon.com/errors/validateCaptcha?abc")
+    assert bc.is_bot_check("https://www.ebay.com/some/path", title="Are you human?")
+    assert bc.is_bot_check("", title="Just a moment...")
+    assert not bc.is_bot_check("https://www.ebay.com/sch/i.html?_nkw=x", title="x | eBay")
+
+
+# ---------------------------------------------------------------------------
+# extract_product_cards_robust
+# ---------------------------------------------------------------------------
+
+
+def test_extract_product_cards_robust_returns_profile_results_first():
+    profile = get_profile("ebay")
+    rec = RecordingExecutor(
+        [
+            # extract_product_cards succeeds
+            {
+                "success": True,
+                "data": {
+                    "success": True,
+                    "result": {
+                        "candidates": [{"title": "USB-C cable", "url": "https://ebay.com/itm/1", "price_text": "$9"}],
+                        "total_cards": 1,
+                    },
+                },
+            },
+        ]
+    )
+    result = _run(bc.extract_product_cards_robust(rec, profile, limit=10))
+    assert result["source"] == "profile"
+    assert result["candidates"][0]["title"] == "USB-C cable"
+    # Only one eval_js call when profile selectors succeed.
+    assert len([c for c in rec.calls if c[0] == "eval_js"]) == 1
+
+
+def test_extract_product_cards_robust_falls_back_to_generic():
+    profile = get_profile("ebay")
+    rec = RecordingExecutor(
+        [
+            # Profile extractor returns no candidates.
+            {
+                "success": True,
+                "data": {
+                    "success": True,
+                    "result": {"candidates": [], "total_cards": 0},
+                },
+            },
+            # Generic fallback finds something.
+            {
+                "success": True,
+                "data": {
+                    "success": True,
+                    "result": {
+                        "candidates": [
+                            {"title": "Some Generic Cable Listing", "url": "https://ebay.com/itm/2", "price_text": "$12"},
+                        ],
+                        "total_cards": 1,
+                        "source": "generic",
+                    },
+                },
+            },
+        ]
+    )
+    result = _run(bc.extract_product_cards_robust(rec, profile, limit=10))
+    assert result["source"] == "generic"
+    assert result["candidates"][0]["title"] == "Some Generic Cable Listing"
+    assert result.get("primary_total_cards") == 0
+    # Two eval_js calls: one per attempt.
+    assert len([c for c in rec.calls if c[0] == "eval_js"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# detect_signin_wall
+# ---------------------------------------------------------------------------
+
+
+def test_detect_signin_wall_passes_addtocart_hints():
+    profile = get_profile("amazon")
+    rec = RecordingExecutor(
+        [
+            {
+                "success": True,
+                "data": {
+                    "success": True,
+                    "result": {
+                        "signin_present": True,
+                        "signin_controls": 3,
+                        "addtocart_controls": 0,
+                        "has_password_field": True,
+                        "title_hint": True,
+                        "hits": ["sign in"],
+                        "url": "https://www.amazon.com/ap/signin",
+                    },
+                },
+            }
+        ]
+    )
+    result = _run(bc.detect_signin_wall(rec, profile))
+    assert result["signin_present"] is True
+    _, params = rec.calls[0]
+    # The add-to-cart hint list is injected into the payload so the JS can
+    # disambiguate "sign-in wall" from "product page with sign-in link".
+    assert "add to cart" in params["code"].lower()

--- a/tests/test_ecommerce_catalog.py
+++ b/tests/test_ecommerce_catalog.py
@@ -1,0 +1,149 @@
+"""Tests for the e-commerce site catalog and per-site safety metadata."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+if str(_NOUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(_NOUI_ROOT))
+
+import pytest
+
+from backend.ecommerce.site_catalog import (
+    COMMON_FORBIDDEN_LABELS,
+    all_profiles,
+    all_slugs,
+    find_profile_by_url,
+    get_profile,
+    is_forbidden_label,
+    normalize_label,
+)
+
+# ---------------------------------------------------------------------------
+# Catalog completeness
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_has_twenty_sites():
+    profiles = all_profiles()
+    assert len(profiles) == 20
+    assert len({p.slug for p in profiles}) == 20  # no duplicate slugs
+
+
+def test_every_profile_has_required_fields():
+    for profile in all_profiles():
+        assert profile.slug == profile.slug.lower()
+        assert profile.domains, f"{profile.slug}: domains is empty"
+        assert profile.home_url.startswith("http"), f"{profile.slug}: home_url invalid"
+        assert "{query}" in profile.search_url_template, (
+            f"{profile.slug}: search_url_template missing {{query}}"
+        )
+        # Every profile must define at least one add-to-cart label so the
+        # agent has a fallback action when the catalog selectors miss.
+        assert profile.add_to_cart_labels, f"{profile.slug}: no add_to_cart_labels"
+
+
+def test_build_search_url_quotes_query():
+    profile = get_profile("amazon")
+    url = profile.build_search_url("USB C cable")
+    assert "USB+C+cable" in url or "USB%20C%20cable" in url
+    assert url.startswith("https://www.amazon.com/s?k=")
+
+
+def test_build_search_url_rejects_empty_query():
+    profile = get_profile("amazon")
+    with pytest.raises(ValueError):
+        profile.build_search_url("")
+
+
+# ---------------------------------------------------------------------------
+# Domain lookup
+# ---------------------------------------------------------------------------
+
+
+def test_find_profile_by_url_matches_primary_domain():
+    p = find_profile_by_url("https://www.amazon.com/dp/B000ABC")
+    assert p is not None and p.slug == "amazon"
+
+
+def test_find_profile_by_url_matches_regional_domain():
+    p = find_profile_by_url("https://www.amazon.co.uk/dp/B000XYZ")
+    assert p is not None and p.slug == "amazon"
+
+
+def test_find_profile_by_url_unknown_returns_none():
+    assert find_profile_by_url("https://example.com/foo") is None
+
+
+def test_find_profile_handles_bare_host():
+    p = find_profile_by_url("ebay.com")
+    assert p is not None and p.slug == "ebay"
+
+
+# ---------------------------------------------------------------------------
+# Forbidden label detection
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_label_collapses_whitespace():
+    assert normalize_label("  Place\nYour   Order  ") == "place your order"
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "Place Your Order",
+        "Place order now",
+        "Pay now",
+        "Buy now",
+        "Confirm and Pay",
+        "Submit Order",
+        "Complete Purchase",
+    ],
+)
+def test_universal_forbidden_labels_block_clicks(label):
+    assert is_forbidden_label(label) is True
+
+
+def test_site_specific_forbidden_label_blocks():
+    flipkart = get_profile("flipkart")
+    # "Place Order" appears on Flipkart's address step — must still be forbidden.
+    assert is_forbidden_label("PLACE ORDER", flipkart)
+
+
+def test_localized_forbidden_label_blocks():
+    rakuten = get_profile("rakuten")
+    assert is_forbidden_label("注文を確定する", rakuten)
+
+
+def test_benign_label_is_not_forbidden():
+    profile = get_profile("amazon")
+    # "Add to cart" must remain allowed; ranking depends on it.
+    assert is_forbidden_label("Add to cart", profile) is False
+    assert is_forbidden_label("Proceed to checkout", profile) is False
+
+
+def test_common_forbidden_labels_are_unique_and_lowercase():
+    seen = set()
+    for label in COMMON_FORBIDDEN_LABELS:
+        assert label == label.lower(), f"label not lowercase: {label!r}"
+        assert label not in seen, f"duplicate label: {label!r}"
+        seen.add(label)
+
+
+# ---------------------------------------------------------------------------
+# Slug lookup
+# ---------------------------------------------------------------------------
+
+
+def test_get_profile_unknown_slug_raises():
+    with pytest.raises(KeyError):
+        get_profile("definitely-not-a-real-site")
+
+
+def test_all_slugs_match_catalog():
+    slugs = all_slugs()
+    profiles = all_profiles()
+    assert slugs == tuple(p.slug for p in profiles)

--- a/tests/test_ecommerce_ranking.py
+++ b/tests/test_ecommerce_ranking.py
@@ -1,0 +1,173 @@
+"""Tests for the e-commerce candidate parsing and ranking helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+if str(_NOUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(_NOUI_ROOT))
+
+import pytest
+
+from backend.ecommerce.ranking import (
+    normalize_candidate,
+    parse_price,
+    parse_rating,
+    parse_review_count,
+    rank_candidates,
+    score_candidate,
+)
+
+# ---------------------------------------------------------------------------
+# parse_price
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,amount,currency",
+    [
+        ("$1,234.56", 1234.56, "USD"),
+        ("$9.99", 9.99, "USD"),
+        ("€19,99", 19.99, "EUR"),
+        ("£249", 249.0, "GBP"),
+        ("¥1,200", 1200.0, "JPY"),
+        ("₹2,499", 2499.0, "INR"),
+        ("USD 49.50", 49.50, "USD"),
+        ("S$ 12.40", 12.40, "SGD"),
+        ("R$ 1.234,56", 1234.56, "BRL"),
+    ],
+)
+def test_parse_price_known_formats(text, amount, currency):
+    parsed = parse_price(text)
+    assert parsed.amount == pytest.approx(amount)
+    assert parsed.currency == currency
+
+
+def test_parse_price_empty():
+    parsed = parse_price("")
+    assert parsed.amount is None
+    assert parsed.currency == ""
+
+
+def test_parse_price_unparseable():
+    parsed = parse_price("free shipping")
+    assert parsed.amount is None
+
+
+# ---------------------------------------------------------------------------
+# parse_rating / parse_review_count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,rating",
+    [
+        ("4.5 out of 5 stars", 4.5),
+        ("4.0 stars", 4.0),
+        ("Rated 3.7", 3.7),
+        ("5/5", 5.0),
+    ],
+)
+def test_parse_rating(text, rating):
+    assert parse_rating(text) == pytest.approx(rating)
+
+
+def test_parse_rating_invalid_clamps_to_none():
+    assert parse_rating("9999") is None
+    assert parse_rating("") is None
+
+
+@pytest.mark.parametrize(
+    "text,count",
+    [
+        ("1,234 reviews", 1234),
+        ("12 ratings", 12),
+        ("99 review", 99),
+        ("1.234 ratings", 1234),
+    ],
+)
+def test_parse_review_count(text, count):
+    assert parse_review_count(text) == count
+
+
+def test_parse_review_count_empty():
+    assert parse_review_count("") is None
+
+
+# ---------------------------------------------------------------------------
+# normalize_candidate
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_candidate_fills_parsed_fields():
+    raw = {
+        "title": "  USB-C Cable  ",
+        "url": "https://example.com/abc",
+        "price_text": "$12.99",
+        "rating_text": "4.5 out of 5 stars",
+        "review_count_text": "1,234 reviews",
+        "seller": "Example Inc",
+        "availability": "In Stock",
+    }
+    out = normalize_candidate(raw, default_currency="USD")
+    assert out["title"] == "USB-C Cable"
+    assert out["price_amount"] == pytest.approx(12.99)
+    assert out["currency"] == "USD"
+    assert out["rating_value"] == pytest.approx(4.5)
+    assert out["review_count"] == 1234
+    assert out["seller"] == "Example Inc"
+
+
+def test_normalize_candidate_falls_back_to_default_currency():
+    raw = {"title": "Widget", "price_text": "999"}
+    out = normalize_candidate(raw, default_currency="JPY")
+    assert out["currency"] == "JPY"
+
+
+# ---------------------------------------------------------------------------
+# Scoring + ranking
+# ---------------------------------------------------------------------------
+
+
+def test_score_candidate_prefers_under_budget():
+    high = {"price_amount": 95.0, "rating_value": 4.5, "review_count": 500}
+    low = {"price_amount": 30.0, "rating_value": 4.5, "review_count": 500}
+    assert score_candidate(low, max_price=100) > score_candidate(high, max_price=100)
+
+
+def test_score_candidate_zero_when_over_budget():
+    over = {"price_amount": 150.0, "rating_value": 5.0, "review_count": 1000}
+    assert score_candidate(over, max_price=100) < 0.5
+
+
+def test_score_candidate_respects_min_rating():
+    low_rating = {"price_amount": 10.0, "rating_value": 2.0}
+    assert score_candidate(low_rating, max_price=50, min_rating=4.0) < 0.5
+
+
+def test_score_candidate_handles_no_signals():
+    assert 0.0 <= score_candidate({}) <= 1.0
+
+
+def test_rank_candidates_orders_descending():
+    items = [
+        {"title": "A", "price_amount": 90.0, "rating_value": 3.0, "review_count": 10},
+        {"title": "B", "price_amount": 30.0, "rating_value": 4.5, "review_count": 500},
+        {"title": "C", "price_amount": 50.0, "rating_value": 4.0, "review_count": 100},
+    ]
+    ranked = rank_candidates(items, max_price=100, min_rating=3.0)
+    assert ranked[0]["title"] == "B"
+    assert [c["rank"] for c in ranked] == [1, 2, 3]
+    # Scores are sorted descending.
+    assert ranked[0]["score"] >= ranked[1]["score"] >= ranked[2]["score"]
+
+
+def test_rank_candidates_respects_min_rating():
+    items = [
+        {"title": "Bad", "price_amount": 5.0, "rating_value": 2.0, "review_count": 5},
+        {"title": "Good", "price_amount": 25.0, "rating_value": 4.5, "review_count": 200},
+    ]
+    ranked = rank_candidates(items, max_price=50, min_rating=4.0)
+    assert ranked[0]["title"] == "Good"

--- a/tests/test_ecommerce_router.py
+++ b/tests/test_ecommerce_router.py
@@ -1,0 +1,189 @@
+"""Router-level tests for the e-commerce agent.
+
+Uses FastAPI's TestClient with the executor factory overridden so the
+endpoints can be exercised end-to-end without a real browser.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+if str(_NOUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(_NOUI_ROOT))
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+import backend.autopilot.models  # noqa: F401
+import backend.ecommerce.models  # noqa: F401
+import backend.elicitation.models  # noqa: F401
+import backend.login.models  # noqa: F401
+import backend.workflow.models  # noqa: F401
+
+# Load all ORM modules so create_all knows about every table.
+from backend.database import (
+    Base,
+    get_db,  # noqa: E402
+)
+from backend.ecommerce import router as ecommerce_router_mod  # noqa: E402
+
+
+@pytest.fixture
+def app_client():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    import asyncio
+
+    asyncio.run(_init_schema(engine))
+
+    async def _override_get_db():
+        async with Session() as session:
+            yield session
+
+    # Install a fake browser executor that returns canned product cards. The
+    # queue covers the full auto_pilot flow: search extract → highlight →
+    # boundary detect → cart summary. Any further eval_js falls back to an
+    # empty dict, which causes the agent to record the no-data response in
+    # its audit log instead of crashing.
+    class _FakeExec:
+        def __init__(self):
+            self._eval_queue = [
+                {
+                    "candidates": [
+                        {
+                            "title": "Test Cable",
+                            "url": "https://www.amazon.com/dp/B000TEST",
+                            "image_url": "",
+                            "price_text": "$9.99",
+                            "rating_text": "4.5 out of 5 stars",
+                            "review_count_text": "100 reviews",
+                            "seller": "",
+                            "shipping_text": "",
+                            "availability": "In Stock",
+                        }
+                    ],
+                    "total_cards": 1,
+                },
+                {"highlighted": True},
+                {"boundary_present": False, "matches": []},
+                {
+                    "line_count": 1,
+                    "lines": [{"index": 0, "title": "Test Cable"}],
+                    "subtotal_text": "$9.99",
+                    "buttons": [{"label": "Proceed to checkout"}],
+                    "url": "https://www.amazon.com/cart",
+                },
+            ]
+
+        async def __call__(self, command_type: str, params: dict) -> dict:
+            if command_type == "eval_js" and self._eval_queue:
+                return {
+                    "success": True,
+                    "data": {"success": True, "result": self._eval_queue.pop(0)},
+                    "error": None,
+                }
+            if command_type == "navigate":
+                return {"success": True, "data": {"navigated": True}, "error": None}
+            if command_type == "click_by_text":
+                return {"success": True, "data": {"clicked": True}, "error": None}
+            return {"success": True, "data": {}, "error": None}
+
+    ecommerce_router_mod.set_executor_factory(lambda: _FakeExec())
+
+    app = FastAPI()
+    app.include_router(ecommerce_router_mod.router)
+    app.dependency_overrides[get_db] = _override_get_db
+
+    client = TestClient(app)
+    try:
+        yield client
+    finally:
+        ecommerce_router_mod.reset_executor_factory()
+        asyncio.run(engine.dispose())
+
+
+async def _init_schema(engine):
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+def test_list_sites_returns_twenty(app_client):
+    resp = app_client.get("/ecommerce-agent/sites")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 20
+    slugs = {s["slug"] for s in body}
+    for required in ("amazon", "ebay", "aliexpress", "walmart", "etsy"):
+        assert required in slugs
+
+
+def test_get_unknown_site_returns_404(app_client):
+    resp = app_client.get("/ecommerce-agent/sites/not-real")
+    assert resp.status_code == 404
+
+
+def test_list_workflows_returns_all_stages_per_site(app_client):
+    resp = app_client.get("/ecommerce-agent/workflows")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 20
+    for entry in body:
+        stages = {s["name"] for s in entry["stages"]}
+        assert {"search", "browse", "cart", "checkout_prep"}.issubset(stages)
+
+
+def test_start_run_auto_pilot_lands_at_checkout_confirmation(app_client):
+    """Default behavior: agent runs end-to-end and pauses at the single checkout gate."""
+    resp = app_client.post(
+        "/ecommerce-agent/runs",
+        json={"site_slug": "amazon", "query": "usb cable"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["status"] == "awaiting_checkout_confirmation"
+    assert body["site_slug"] == "amazon"
+    assert body["pending_checkpoint"]["action"] == "proceed_to_checkout"
+
+    detail = app_client.get(f"/ecommerce-agent/runs/{body['id']}").json()
+    assert len(detail["candidates"]) == 1
+    assert detail["candidates"][0]["title"] == "Test Cable"
+    # The selected candidate is the top-ranked one.
+    assert detail["selected_candidate_id"] == detail["candidates"][0]["id"]
+
+
+def test_start_run_auto_pilot_false_preserves_manual_flow(app_client):
+    """Explicit opt-out: every side effect still requires confirmation."""
+    resp = app_client.post(
+        "/ecommerce-agent/runs",
+        json={"site_slug": "amazon", "query": "usb cable", "auto_pilot": False},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["status"] == "awaiting_selection"
+    assert body["pending_checkpoint"]["action"] == "select_product"
+
+
+def test_start_run_rejects_unknown_site(app_client):
+    resp = app_client.post(
+        "/ecommerce-agent/runs",
+        json={"site_slug": "made-up-store", "query": "anything"},
+    )
+    assert resp.status_code == 400
+
+
+def test_cancel_run(app_client):
+    started = app_client.post(
+        "/ecommerce-agent/runs",
+        json={"site_slug": "amazon", "query": "cable"},
+    ).json()
+    resp = app_client.post(
+        f"/ecommerce-agent/runs/{started['id']}/cancel",
+        json={"reason": "no longer needed"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "cancelled"

--- a/tests/test_ecommerce_safety.py
+++ b/tests/test_ecommerce_safety.py
@@ -1,0 +1,150 @@
+"""Tests for the e-commerce agent's safety policy and action classifier."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+if str(_NOUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(_NOUI_ROOT))
+
+import pytest
+
+from backend.ecommerce.safety import (
+    HARD_FORBIDDEN,
+    SIDE_EFFECT_ADD_TO_CART,
+    SIDE_EFFECT_BROWSE,
+    SIDE_EFFECT_CONFIRM_ORDER,
+    SIDE_EFFECT_PAY,
+    SIDE_EFFECT_PLACE_ORDER,
+    SIDE_EFFECT_PROCEED_TO_CHECKOUT,
+    SIDE_EFFECT_SUBMIT_PAYMENT,
+    AgentPolicy,
+    classify_action,
+    is_hard_forbidden,
+)
+from backend.ecommerce.site_catalog import get_profile
+
+# ---------------------------------------------------------------------------
+# classify_action
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "label,expected",
+    [
+        ("Add to cart", SIDE_EFFECT_ADD_TO_CART),
+        ("Add to Bag", SIDE_EFFECT_ADD_TO_CART),
+        ("Add to basket", SIDE_EFFECT_ADD_TO_CART),
+        ("Proceed to checkout", SIDE_EFFECT_PROCEED_TO_CHECKOUT),
+        ("Go to Checkout", SIDE_EFFECT_PROCEED_TO_CHECKOUT),
+        ("Checkout", SIDE_EFFECT_PROCEED_TO_CHECKOUT),
+        ("Place Your Order", SIDE_EFFECT_PLACE_ORDER),
+        ("Place order", SIDE_EFFECT_PLACE_ORDER),
+        ("Submit order", SIDE_EFFECT_PLACE_ORDER),
+        ("Buy now", SIDE_EFFECT_PLACE_ORDER),
+        ("Pay now", SIDE_EFFECT_PAY),
+        ("Pay with PayPal", SIDE_EFFECT_PAY),
+        ("Submit Payment", SIDE_EFFECT_SUBMIT_PAYMENT),
+        ("Confirm and pay", SIDE_EFFECT_CONFIRM_ORDER),
+        ("Confirm purchase", SIDE_EFFECT_CONFIRM_ORDER),
+        ("Complete purchase", SIDE_EFFECT_CONFIRM_ORDER),
+        ("View product", SIDE_EFFECT_BROWSE),
+        ("See more", SIDE_EFFECT_BROWSE),
+    ],
+)
+def test_classify_action(label, expected):
+    assert classify_action(label) == expected
+
+
+def test_classify_action_uses_profile_for_localized_labels():
+    rakuten = get_profile("rakuten")
+    # Japanese "place order" classifies as place_order via the forbidden-label
+    # fallback, since the rules table is English.
+    assert classify_action("注文を確定する", rakuten) == SIDE_EFFECT_PLACE_ORDER
+
+
+def test_classify_action_empty_string():
+    assert classify_action("") == SIDE_EFFECT_BROWSE
+
+
+# ---------------------------------------------------------------------------
+# AgentPolicy.from_lists
+# ---------------------------------------------------------------------------
+
+
+def test_policy_default_allows_search_browse():
+    p = AgentPolicy.from_lists([], [])
+    assert "search" in p.allowed_side_effects
+    assert "browse" in p.allowed_side_effects
+
+
+def test_policy_hard_forbidden_always_blocked():
+    p = AgentPolicy.from_lists(
+        ["search", "browse", "place_order"],  # user tries to allow place_order
+        [],
+    )
+    # Hard-forbidden side effects win over an explicit allow.
+    assert "place_order" not in p.allowed_side_effects
+    for forbidden in HARD_FORBIDDEN:
+        assert forbidden in p.forbidden_side_effects
+
+
+def test_policy_explicit_forbid_beats_allow():
+    p = AgentPolicy.from_lists(
+        ["search", "browse", "add_to_cart"],
+        ["add_to_cart"],
+    )
+    assert "add_to_cart" not in p.allowed_side_effects
+    assert "add_to_cart" in p.forbidden_side_effects
+
+
+def test_policy_evaluate_allowed():
+    p = AgentPolicy.from_lists(["add_to_cart"], [])
+    d = p.evaluate("add_to_cart")
+    assert d.allowed and not d.requires_confirmation
+
+
+def test_policy_evaluate_unknown_requires_confirmation():
+    p = AgentPolicy.from_lists(["add_to_cart"], [])
+    d = p.evaluate("fill_shipping")
+    assert d.allowed is False
+    assert d.requires_confirmation is True
+
+
+def test_policy_evaluate_hard_forbidden_never_allowed():
+    p = AgentPolicy.from_lists(["place_order"], [])  # ignored
+    d = p.evaluate("place_order")
+    assert d.allowed is False
+    assert d.requires_confirmation is True
+
+
+def test_policy_evaluate_empty_action():
+    p = AgentPolicy.from_lists(["add_to_cart"], [])
+    d = p.evaluate("")
+    assert d.allowed is False
+
+
+# ---------------------------------------------------------------------------
+# Hard-forbidden helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        "place_order",
+        "Place_Order",
+        "  PAY  ",
+        "submit_payment",
+        "confirm_order",
+    ],
+)
+def test_is_hard_forbidden(action):
+    assert is_hard_forbidden(action) is True
+
+
+@pytest.mark.parametrize("action", ["search", "browse", "add_to_cart", "proceed_to_checkout"])
+def test_is_hard_forbidden_negative(action):
+    assert is_hard_forbidden(action) is False

--- a/tests/test_ecommerce_workflows.py
+++ b/tests/test_ecommerce_workflows.py
@@ -1,0 +1,51 @@
+"""Tests for the per-site workflow manifests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+if str(_NOUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(_NOUI_ROOT))
+
+import pytest
+
+from backend.ecommerce.site_catalog import all_slugs
+from backend.ecommerce.workflows import (
+    WORKFLOW_STAGES,
+    all_workflows,
+    get_workflow,
+    workflow_coverage_report,
+)
+
+
+def test_every_catalog_slug_has_a_workflow():
+    workflow_slugs = {w.slug for w in all_workflows()}
+    assert workflow_slugs == set(all_slugs())
+
+
+def test_every_workflow_covers_all_required_stages():
+    report = workflow_coverage_report()
+    for slug in all_slugs():
+        for stage in WORKFLOW_STAGES:
+            assert report[slug][stage], f"{slug} is missing the {stage!r} stage"
+
+
+def test_workflow_stages_are_unique_within_a_site():
+    for w in all_workflows():
+        names = [s.name for s in w.stages]
+        assert len(names) == len(set(names)), f"{w.slug} has duplicate stages"
+
+
+def test_get_workflow_unknown_slug_raises():
+    with pytest.raises(KeyError):
+        get_workflow("not-a-site")
+
+
+def test_known_caveat_sites_carry_extra_notes():
+    # Sites with high-friction flows should have at least one extra caveat
+    # documented so operators are not surprised at runtime.
+    for slug in ("amazon", "aliexpress", "flipkart", "rakuten", "taobao"):
+        w = get_workflow(slug)
+        assert w.extra_caveats, f"{slug} is missing operational caveats"


### PR DESCRIPTION
## Summary

- `skills/bestbuy-search` — new NoUI skill for Best Buy covering the full supervised shopping workflow: search -> confirm -> add to cart -> confirm -> proceed to checkout -> stop at payment.
- `backend/ecommerce/` — AI shopping agent state machine that works across all 20 catalog sites: browser-driven search, product ranking, add-to-cart, and checkout navigation with safety gates.
- `tests/` — full unit test suite for all ecommerce modules.

### Skill operations (skills/bestbuy-search/)

| Operation | Type | Auth | Requires human approval |
|---|---|---|---|
| `search_suggestions` | Public API (httpx) | None | No |
| `lookup_products` | Public API (httpx) | None | No |
| `open_product` | Browser (extension bridge) | None | No |
| `add_to_cart` | Browser | Signed-in Chrome tab | Yes |
| `proceed_to_checkout` | Browser | Signed-in Chrome tab | Yes |

### Safety boundary

The skill stops hard at the payment step and will never:
- Click "Place Order", "Pay Now", "Confirm Order", or any purchase button
- Type or store card numbers, CVV, or any payment credentials

Detection covers URL patterns (/checkout/r/payment), credit-card input selectors, and forbidden button text scanned via JS.

### Consistency with existing skills

Follows the same conventions as `airbnb-search-places` and `expedia-stay-search`:
- SKILL.md frontmatter + usage flow
- API.md with flag tables and hardcoded-values section
- manifest.json with requires_auth: false for the public API operations
- Plain httpx for read operations; noui_runtime/browser.py wrapper for browser operations
- operations/__init__.py + standalone CLI scripts with execute() + main()

### Verified end-to-end

- `search_suggestions` + `lookup_products`: live against www.bestbuy.com, returned real products with ratings and review counts.
- `open_product`: navigated Chrome to Best Buy PDP; frame-removal timing fix applied.
- `add_to_cart`: clicked "Add to Cart" via text label (Best Buy uses utility classes, not stable CSS selectors); cart_updated_confirmed: true.
- `proceed_to_checkout`: clicked Checkout, walked to sign-in wall (unauthenticated test session), stopped safely; will stop at /checkout/r/payment when signed in.

### Rebased on upstream dev

Branch is rebased cleanly onto 942effd (latest upstream dev as of 2026-05-16). No conflicts.

## Test plan

- [ ] `cd skills/bestbuy-search && python operations/search_suggestions.py --query "laptop" --count 4` — returns JSON with suggestions and skuIds
- [ ] `python operations/lookup_products.py --skuids "<skuid>"` — returns product card with title, rating, pdpUrl
- [ ] With NoUI backend + Chrome extension running and signed in to Best Buy: run `open_product`, `add_to_cart`, `proceed_to_checkout` in sequence
- [ ] Confirm `proceed_to_checkout` returns `payment_boundary: true` and stops before the payment form
- [ ] `python -m pytest tests/test_ecommerce_*.py -q` — all ecommerce unit tests pass
