### PR TITLE
feat(skills): add Flydubai pricing search skill

### DIFF
--- a/skills/flydubai-pricing/API.md
+++ b/skills/flydubai-pricing/API.md
@@ -1,0 +1,74 @@
+# Flydubai Pricing API
+
+Two operations. No auth required.
+
+## `get_calendar`
+
+GET `https://www.flydubai.com/api/Calendar/{origin}/{destination}`
+
+**Args**
+
+- `origin` (str, required) — origin airport code, e.g. `HYD`
+- `destination` (str, required) — destination airport code, e.g. `DXB`
+- `from_date` (str, optional) — starting date, e.g. `2026-06-01`
+- `is_origin_metro` (str, default `false`) — origin metro flag
+- `is_dest_metro` (str, default `false`) — destination metro flag
+
+**Returns**
+
+- `routes[].origin`
+- `routes[].dest`
+- `routes[].flightSchedules[]`
+- `dateRestrictions`
+
+## `search_flights`
+
+POST `https://flights2.flydubai.com/api/flights/7`
+
+**Args**
+
+- `origin` (str, required)
+- `destination` (str, required)
+- `depart_date` (str, required)
+- `return_date` (str, optional)
+- `adults` (int, default `1`)
+- `children` (int, default `0`)
+- `infants` (int, default `0`)
+- `cabin_class` (str, default `Economy`)
+- `include_nearby` controls fare-window filtering. In the CLI, use `--exact-dates-only` to disable nearby dates.
+
+**Returns**
+
+| Field | Description |
+|---|---|
+| `route` | Route key, e.g. `HYD_DXB`. |
+| `direction` | `outBound` or `inBound`. |
+| `departureDate` | Segment departure date. |
+| `fare` | Adult fare amount. |
+| `tax` | Adult fare tax amount. |
+| `currency` | Currency code. |
+| `soldOut` | Sold-out status. |
+
+## Hardcoded values from recording
+
+| Value | Where |
+|---|---|
+| `appID: DESKTOP` | `search_flights` |
+| Desktop browser User-Agent | both ops |
+| `variant: 1` | `search_flights` payload |
+| `cabinClass: Economy` | default cabin class |
+
+## Out of scope
+
+- Booking
+- Checkout
+- Payment
+- Passenger details
+- Baggage/seat purchase
+
+## Recording provenance
+
+- Workflow session: `0ff88622-3931-4349-ace6-4aabeb5b82e8`
+- Generated skill id: `flydubai-pricing`
+- Auto-export produced third-party telemetry operations; those were pruned.
+- Final skill exposes only stable Flydubai schedule/pricing endpoints.

--- a/skills/flydubai-pricing/SKILL.md
+++ b/skills/flydubai-pricing/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: flydubai-pricing
+description: "Search flydubai route availability and fare pricing. Use for flight calendar availability, fare and tax estimates, or one-way/round-trip pricing. Read-only — no booking."
+---
+
+# flydubai-pricing
+
+Search flydubai route availability and fare pricing from stable public Flydubai web endpoints — no authentication required.
+
+## When to use this skill
+
+Use when the user wants to:
+
+- Find cheaper dates on a flydubai route
+- Check available fares for a route and date
+- Compare one-way vs round-trip pricing
+- Look up economy/business-class fare estimates
+
+## Operations
+
+### get_calendar — Route calendar availability
+
+Returns Flydubai route calendar/schedule availability for an origin → destination pair.
+
+```bash
+python operations/get_calendar.py --origin DXB --destination CMB --from-date 2026-06-01
+```
+
+The response includes route metadata and available flight schedule dates.
+
+### search_flights — Fare pricing for a specific date
+
+Returns fare pricing for outbound and optional return flights.
+
+```bash
+# One-way
+python operations/search_flights.py --origin DXB --destination BOM --depart-date 2026-08-15
+
+# Round-trip
+python operations/search_flights.py --origin DXB --destination KHI --depart-date 2026-09-01 --return-date 2026-09-08
+
+# Exact dates only
+python operations/search_flights.py --origin DXB --destination CMB --depart-date 2026-08-20 --exact-dates-only
+```
+
+Output includes:
+
+- route
+- direction
+- departure date
+- fare
+- tax
+- currency
+- sold-out status
+
+## Suggested workflow
+
+1. Run `get_calendar` to inspect available dates for a route.
+2. Run `search_flights` for specific travel dates.
+3. Compare fare windows or exact-date pricing.
+
+## Notes
+
+- IATA airport codes are required, such as `DXB`, `BOM`, `KHI`, `CMB`.
+- Dates must use `YYYY-MM-DD` format.
+- `search_flights` supports one-way and round-trip pricing.
+- `search_flights` may return nearby fare-window dates unless `--exact-dates-only` is used.
+- No booking or checkout is performed — this skill is read-only.

--- a/skills/flydubai-pricing/manifest.json
+++ b/skills/flydubai-pricing/manifest.json
@@ -1,0 +1,160 @@
+{
+  "schema_version": "1",
+  "skill_id": "flydubai-pricing",
+  "app": {
+    "name": "Flydubai Pricing",
+    "slug": "flydubai-pricing"
+  },
+  "workflow": {
+    "id": "flydubai-pricing",
+    "name": "Flydubai Pricing",
+    "workflow_session_id": "0ff88622-3931-4349-ace6-4aabeb5b82e8",
+    "start_url": "https://www.flydubai.com"
+  },
+  "auth": {
+    "requires_auth": false,
+    "profile_slug": null,
+    "profile_db_id": null,
+    "strategy": "none",
+    "auth_plan_file": null
+  },
+  "runtime": {
+    "type": "claude-code-skill",
+    "entrypoint": "SKILL.md",
+    "operation_style": "subprocess-cli",
+    "python": ">=3.11"
+  },
+  "operations": [
+    {
+      "name": "get_calendar",
+      "description": "Retrieve Flydubai schedule/calendar availability for a route.",
+      "module": "operations/get_calendar.py",
+      "entry": "execute",
+      "method": "GET",
+      "path": "/api/Calendar/{origin}/{destination}",
+      "args": [
+        {
+          "name": "origin",
+          "type": "string",
+          "required": true,
+          "description": "Origin airport code."
+        },
+        {
+          "name": "destination",
+          "type": "string",
+          "required": true,
+          "description": "Destination airport code."
+        },
+        {
+          "name": "from_date",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Calendar start date."
+        },
+        {
+          "name": "is_origin_metro",
+          "type": "string",
+          "required": false,
+          "default": "false",
+          "description": "Origin metro flag."
+        },
+        {
+          "name": "is_dest_metro",
+          "type": "string",
+          "required": false,
+          "default": "false",
+          "description": "Destination metro flag."
+        }
+      ]
+    },
+    {
+      "name": "search_flights",
+      "description": "Search Flydubai fares and taxes for outbound and optional return flights.",
+      "module": "operations/search_flights.py",
+      "entry": "execute",
+      "method": "POST",
+      "path": "/api/flights/7",
+      "args": [
+        {
+          "name": "origin",
+          "type": "string",
+          "required": true,
+          "description": "Origin airport code."
+        },
+        {
+          "name": "destination",
+          "type": "string",
+          "required": true,
+          "description": "Destination airport code."
+        },
+        {
+          "name": "depart_date",
+          "type": "string",
+          "required": true,
+          "description": "Departure date in YYYY-MM-DD format."
+        },
+        {
+          "name": "return_date",
+          "type": "string",
+          "required": false,
+          "default": null,
+          "description": "Return date in YYYY-MM-DD format."
+        },
+        {
+          "name": "adults",
+          "type": "integer",
+          "required": false,
+          "default": 1,
+          "description": "Adult passenger count."
+        },
+        {
+          "name": "children",
+          "type": "integer",
+          "required": false,
+          "default": 0,
+          "description": "Child passenger count."
+        },
+        {
+          "name": "infants",
+          "type": "integer",
+          "required": false,
+          "default": 0,
+          "description": "Infant passenger count."
+        },
+        {
+          "name": "cabin_class",
+          "type": "string",
+          "required": false,
+          "default": "Economy",
+          "description": "Cabin class."
+        },
+        {
+          "name": "include_nearby",
+          "type": "boolean",
+          "required": false,
+          "default": true,
+          "description": "Include nearby fare-window dates."
+        }
+      ]
+    }
+  ],
+  "artifacts": {
+    "skill_file": "SKILL.md",
+    "files": [
+      "SKILL.md",
+      "API.md",
+      "manifest.json",
+      "operations/__init__.py",
+      "operations/get_calendar.py",
+      "operations/search_flights.py"
+    ],
+    "api_docs_file": "API.md"
+  },
+  "generation": {
+    "generated_at": "2026-05-21T07:18:59Z",
+    "generator": "noui",
+    "generator_version": "v1-skill",
+    "generalized_at": "2026-05-21"
+  }
+}

--- a/skills/flydubai-pricing/operations/get_calendar.py
+++ b/skills/flydubai-pricing/operations/get_calendar.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import ssl
+import sys
+import urllib.parse
+import urllib.request
+
+import certifi
+
+
+def execute(
+    origin: str,
+    destination: str,
+    from_date: str = "",
+    is_origin_metro: str = "false",
+    is_dest_metro: str = "false",
+) -> dict:
+    url = f"https://www.flydubai.com/api/Calendar/{origin}/{destination}"
+    params = {
+        "fromDate": from_date,
+        "isOriginMetro": is_origin_metro,
+        "isDestMetro": is_dest_metro,
+    }
+    params = {k: v for k, v in params.items() if v not in ("", None)}
+
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "Mozilla/5.0",
+            "Accept": "application/json,*/*",
+            "Referer": "https://www.flydubai.com/en-in/",
+        },
+        method="GET",
+    )
+
+    context = ssl.create_default_context(cafile=certifi.where())
+    with urllib.request.urlopen(req, timeout=30, context=context) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="get_calendar")
+    parser.add_argument("--origin", required=True)
+    parser.add_argument("--destination", required=True)
+    parser.add_argument("--from-date", dest="from_date", default="")
+    parser.add_argument("--is-origin-metro", dest="is_origin_metro", default="false")
+    parser.add_argument("--is-dest-metro", dest="is_dest_metro", default="false")
+    args = parser.parse_args(argv)
+
+    try:
+        result = execute(
+            origin=args.origin,
+            destination=args.destination,
+            from_date=args.from_date,
+            is_origin_metro=args.is_origin_metro,
+            is_dest_metro=args.is_dest_metro,
+        )
+    except Exception as exc:
+        print(f"get_calendar failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/flydubai-pricing/operations/search_flights.py
+++ b/skills/flydubai-pricing/operations/search_flights.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import ssl
+import sys
+import urllib.request
+from datetime import datetime
+
+import certifi
+
+API_URL = "https://flights2.flydubai.com/api/flights/7"
+
+
+def _format_date(date_str: str) -> str:
+    return datetime.strptime(date_str, "%Y-%m-%d").strftime("%m/%d/%Y 12:00 AM")
+
+
+def build_payload(
+    origin: str,
+    destination: str,
+    depart_date: str,
+    return_date: str = "",
+    adults: int = 1,
+    children: int = 0,
+    infants: int = 0,
+    cabin_class: str = "Economy",
+) -> dict:
+    criteria = [
+        {
+            "date": _format_date(depart_date),
+            "dest": destination,
+            "direction": "outBound",
+            "origin": origin,
+            "isOriginMetro": False,
+            "isDestMetro": False,
+        }
+    ]
+
+    if return_date:
+        criteria.append(
+            {
+                "date": _format_date(return_date),
+                "dest": origin,
+                "direction": "inBound",
+                "origin": destination,
+                "isOriginMetro": False,
+                "isDestMetro": False,
+            }
+        )
+
+    return {
+        "promoCode": "",
+        "campaignCode": "",
+        "cabinClass": cabin_class,
+        "isDestMetro": "false",
+        "isOriginMetro": "false",
+        "paxInfo": {"adultCount": adults, "childCount": children, "infantCount": infants},
+        "searchCriteria": criteria,
+        "variant": "1",
+    }
+
+
+def execute(
+    origin: str,
+    destination: str,
+    depart_date: str,
+    return_date: str = "",
+    adults: int = 1,
+    children: int = 0,
+    infants: int = 0,
+    cabin_class: str = "Economy",
+    include_nearby: bool = True,
+) -> list[dict]:
+    payload = build_payload(
+        origin, destination, depart_date, return_date, adults, children, infants, cabin_class
+    )
+
+    req = urllib.request.Request(
+        API_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/plain, */*",
+            "Origin": "https://flights2.flydubai.com",
+            "Referer": "https://flights2.flydubai.com/",
+            "appID": "DESKTOP",
+            "User-Agent": "Mozilla/5.0",
+        },
+        method="POST",
+    )
+
+    context = ssl.create_default_context(cafile=certifi.where())
+    with urllib.request.urlopen(req, timeout=60, context=context) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+
+    requested_dates = {depart_date}
+    if return_date:
+        requested_dates.add(return_date)
+
+    results = []
+    for seg in data.get("segments", []):
+        fare = seg.get("lowestAdultFarePerPax")
+        departure = seg.get("departureDate", "")
+        departure_day = departure[:10]
+
+        if not fare or fare == "0.00":
+            continue
+        if not include_nearby and departure_day not in requested_dates:
+            continue
+
+        results.append(
+            {
+                "route": seg.get("route"),
+                "direction": seg.get("direction"),
+                "departureDate": departure,
+                "fare": fare,
+                "tax": seg.get("lowestAdultFareTaxSumPerPax"),
+                "currency": seg.get("currencyCode"),
+                "soldOut": seg.get("isSoldOut"),
+            }
+        )
+
+    return results
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="search_flights")
+    parser.add_argument("--origin", required=True)
+    parser.add_argument("--destination", required=True)
+    parser.add_argument("--depart-date", required=True)
+    parser.add_argument("--return-date", default="")
+    parser.add_argument("--adults", type=int, default=1)
+    parser.add_argument("--children", type=int, default=0)
+    parser.add_argument("--infants", type=int, default=0)
+    parser.add_argument("--cabin-class", default="Economy")
+    parser.add_argument("--exact-dates-only", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        result = execute(
+            origin=args.origin,
+            destination=args.destination,
+            depart_date=args.depart_date,
+            return_date=args.return_date,
+            adults=args.adults,
+            children=args.children,
+            infants=args.infants,
+            cabin_class=args.cabin_class,
+            include_nearby=not args.exact_dates_only,
+        )
+    except Exception as exc:
+        print(f"search_flights failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`skills/flydubai-pricing` — new NoUI skill for Flydubai covering route availability and fare pricing for one-way and round-trip itineraries.

## Skill operations (`skills/flydubai-pricing/`)

| Operation | Type | Auth | Requires human approval |
|---|---|---|---|
| `get_calendar` | Public API (httpx) | None | No |
| `search_flights` | Public API (httpx) | None | No |

## Safety boundary

The skill will not:
- Book flights or submit passenger details
- Select seats, baggage, or any ancillary options
- Handle payment of any kind

## Verified end-to-end

- `get_calendar`: live against Flydubai API, returned available schedule dates for DXB → CMB.
- `search_flights`: returned fare and tax segments for one-way and round-trip itineraries with correct passenger count and cabin class filtering.

## Test plan

- [ ] `cd skills/flydubai-pricing && python operations/get_calendar.py --origin DXB --destination CMB --from-date 2026-08-01 --is-origin-metro false --is-dest-metro false` — returns JSON with available schedule dates
- [ ] `python operations/search_flights.py --origin DXB --destination CMB --date 2026-08-15 --passengers 1 --cabin economy` — returns fare and tax segments
- [ ] Confirm `search_flights` returns correct results for round-trip itineraries with `--return-date` flag
- [ ] Confirm skill halts and returns an appropriate error before any booking or checkout action