### PR TITLE
feat(skills): migrate expedia-stay-search from CDP to execute endpoints

### DIFF
--- a/skills/expedia-stay-search/API.md
+++ b/skills/expedia-stay-search/API.md
@@ -10,17 +10,17 @@
 
 | Operation | Transport | Path | Auth |
 |---|---|---|---|
-| `search_hotels` | CDP + DOM scrape | `/Hotel-Search` | cookies: `EG_SESSIONTOKEN` |
+| `search_hotels` | execute/fetch + execute/browser (HAR) | `/Hotel-Search` | agent token + browser session cookies |
 
 ## `search_hotels`
 
-Search Expedia for hotels in a destination, on given check-in / check-out dates, for a given number of guests and rooms. Returns up to 25 listings extracted from the first page of rendered results.
+Search Expedia for hotels in a destination, on given check-in / check-out dates, for a given number of guests and rooms. Returns up to 25 listings extracted from the first page of results.
 
-- **Transport:** CDP (connects to `localhost:9222`) — bypasses Akamai TLS fingerprint checks.
+- **Transport:** Tabby `POST /execute/fetch` (typeahead) + `POST /execute/browser` (navigate, HAR capture) — bypasses Akamai TLS fingerprint checks via the real browser session.
 - **Base URL:** `https://www.expedia.com`
 - **Path:** `/Hotel-Search`
 - **Recorded response status:** `200`
-- **Auth:** Tabby-provisioned session cookies (`EG_SESSIONTOKEN`, `JSESSION`, etc.) via the `expedia` profile.
+- **Auth:** Agent bearer token (`TABBY_CLIENT_ID` / `TABBY_CLIENT_SECRET` → `/auth/agent-token`). Browser session cookies are injected automatically by the execute endpoints.
 
 ### Parameters
 
@@ -31,6 +31,7 @@ Search Expedia for hotels in a destination, on given check-in / check-out dates,
 | `check_out` | string | yes | query | Check-out date in `YYYY-MM-DD` format. |
 | `guests` | integer | no | query | Number of adult guests (default: `2`). |
 | `rooms` | integer | no | query | Number of rooms (default: `1`). |
+| `profile_slug` | string | no | env/flag | Tabby profile slug (default: `$PROFILE_SLUG` or `expedia`). |
 
 ### CLI Invocation
 
@@ -45,15 +46,18 @@ python operations/search_hotels.py \
 
 ### Runtime Behavior
 
-1. Connects to Tabby's CDP endpoint and finds an open Expedia browser tab.
-2. Resolves the destination string to a `regionId` via `/api/v4/typeahead/<query>`.
-3. Navigates the browser tab to `/Hotel-Search?...` with resolved params.
-4. Waits 7 seconds for the SPA to render.
-5. Evaluates a JS extractor in the page to scrape up to 25 listings from the rendered DOM.
-6. Returns `{search_url, destination, region_id, check_in, check_out, guests, rooms, listings_count, listings}`.
+1. Obtains an agent bearer token via `POST /auth/agent-token` (client credentials exchange).
+2. Resolves the destination string to a `regionId` via `POST /execute/fetch` → `GET /api/v4/typeahead/<query>` (fetch runs inside the browser session).
+3. Starts HAR capture via `POST /execute/browser` → `har_start`.
+4. Navigates the browser to `/Hotel-Search?...` via `POST /execute/browser` → `navigate`.
+5. Waits for `[data-stid="lodging-card-responsive"]` to appear via `POST /execute/browser` → `wait_for_selector`.
+6. Stops HAR capture and retrieves all captured network entries via `POST /execute/browser` → `har_stop`.
+7. Parses captured API responses to extract hotel listings (name, price, rating, reviews, URL).
+8. Falls back to `get_page_summary` heading extraction if no structured API response is found in the HAR.
+9. Returns `{search_url, destination, region_id, check_in, check_out, guests, rooms, listings_count, listings}`.
 
 ### Static Request Notes
 
 - Query parameters: `destination`, `regionId`, `d1`/`startDate`, `d2`/`endDate`, `adults`, `rooms`, `sort=RECOMMENDED`
 - Body parameters: none
-- Static request headers: none (cookies attached by the browser automatically)
+- Request headers: `Authorization: Bearer <agent_token>` (to Tabby API only; browser cookies are injected by the execute endpoints)

--- a/skills/expedia-stay-search/SKILL.md
+++ b/skills/expedia-stay-search/SKILL.md
@@ -7,15 +7,16 @@ description: Use this skill when the user wants to search for hotels on Expedia 
 
 Search Expedia for available hotels by destination and dates using an authenticated Tabby browser session. Returns a Hotel-Search URL and extracted listings (name, nightly price, total price, rating, reviews, refundable flag, link).
 
-This skill drives the real Expedia site inside a Tabby-managed browser via the `execute/fetch` endpoint instead of a Python HTTP client. That is intentional: Expedia sits behind Akamai, which blocks non-browser TLS fingerprints. Do not try to port the operations to `httpx` or `requests` — you will get 429 Too Many Requests.
+This skill uses Tabby's `POST /execute/fetch` and `POST /execute/browser` endpoints to drive the real Expedia site inside a Tabby-managed browser. That is intentional: Expedia sits behind Akamai, which blocks non-browser TLS fingerprints. Do not try to port the operations to `httpx` or `requests` — you will get 429 Too Many Requests.
 
 ## Prerequisites
 
 Before invoking any operation:
 
 1. **Tabby is running with the `expedia` profile.** Verify with `.venv/bin/python cli/main.py tabby session ensure --profile expedia` from the `noui/` directory. If that command fails, the user needs to re-run `/noui-record-login` for the `expedia` profile first — do not try to proceed without a live session.
-2. **`PROFILE_SLUG=expedia` is exported** in the shell that runs the operation. This is the slug, not the DB UUID. The runtime reads it (or the `--profile-slug` flag) to fetch live credentials from Tabby.
-3. **The Expedia profile is ACTIVE.** Check with the Tabby admin endpoint if in doubt — a STAGING profile returns empty credentials and the operation fails with "Tabby returned empty credentials for profile 'expedia'".
+2. **`PROFILE_SLUG=expedia` is exported** in the shell that runs the operation. This is the slug, not the DB UUID. The runtime reads it (or the `--profile-slug` flag) to identify the Tabby session.
+3. **Agent credentials are configured.** `TABBY_CLIENT_ID` and `TABBY_CLIENT_SECRET` must be set in the environment or `.env` file. These are used to obtain a bearer token for the Tabby API.
+4. **The Expedia profile is ACTIVE.** Check with the Tabby admin endpoint if in doubt — a STAGING profile returns 409 from the execute endpoints.
 
 ## Operations
 
@@ -79,12 +80,14 @@ Prints a JSON object to stdout on success. Exits non-zero on failure with a diag
 ## Troubleshooting
 
 - **`No healthy Tabby session for profile "expedia"`** — no healthy session found. Run `tabby session ensure --profile expedia` and retry.
-- **`Expedia API returned 429: ...`** — Akamai is rate-limiting even through the browser. This is rare via the execute endpoint; if it happens repeatedly the Tabby session may need to rotate IPs or the profile needs re-recording.
-- **Empty `listings`, non-zero `listings_count`** — Expedia changed its DOM. The DOM-scrape selectors in `search_hotels.py` (`[data-stid="lodging-card-responsive"]`) need updating. Report to the NoUI maintainers; do not guess at selectors.
-- **`auth_plan.json missing profile_slug`** — this skill was mis-installed. The `auth_plan.json` file sitting next to `noui_runtime/` must have `profile_slug: "expedia"`. Reinstall the skill.
+- **`Tabby execute/fetch failed (429)`** — Akamai is rate-limiting even through the browser. This is rare via the execute endpoint; if it happens repeatedly the Tabby session may need to rotate IPs or the profile needs re-recording.
+- **Empty `listings`** — HAR capture did not find structured search results in the API responses, and the page summary fallback found no hotel headings. Expedia may have changed its API response shape. Check the HAR entries manually.
+- **`TABBY_CLIENT_ID and TABBY_CLIENT_SECRET must be set`** — agent credentials are missing. Create an agent client in the Tabby admin UI and set the env vars.
 
 ## Notes
 
-- This skill performs **DOM scraping** after navigation, not pure API calls. Results reflect what Expedia renders to a logged-in user, which may include personalized pricing.
-- There is a ~7-second wait for the SPA to render results; a single invocation can take 10–15 seconds end-to-end.
-- This skill is the reference sample for the NoUI skills-generation pipeline. Generated skills from real recordings will share the same layout (`SKILL.md`, `operations/`, `noui_runtime/auth.py`, `manifest.json`, `auth_plan.json`) but will vary in operation count and complexity.
+- This skill uses **HAR capture** during page navigation to intercept Expedia's API responses, then extracts hotel listings from the structured JSON data. Falls back to `get_page_summary` heading extraction if no structured API response is found.
+- The `execute/fetch` endpoint runs `fetch()` inside the real browser — cookies and TLS fingerprint are preserved automatically.
+- The `execute/browser` endpoint runs Playwright commands on the session page — no direct CDP WebSocket connection needed.
+- A single invocation can take 10–20 seconds (typeahead + navigation + SPA render).
+- This skill is the reference sample for the NoUI skills-generation pipeline. Generated skills from real recordings will share the same layout (`SKILL.md`, `operations/`, `noui_runtime/`, `manifest.json`, `auth_plan.json`) but will vary in operation count and complexity.

--- a/skills/expedia-stay-search/manifest.json
+++ b/skills/expedia-stay-search/manifest.json
@@ -14,13 +14,14 @@
     "requires_auth": true,
     "profile_slug": "expedia",
     "profile_db_id": "c2555a7e-7eb1-4945-bf8d-f5727c897831",
-    "strategy": "tabby_credentials",
+    "strategy": "tabby_execute",
     "auth_plan_file": "auth_plan.json"
   },
   "runtime": {
     "type": "claude-code-skill",
     "entrypoint": "SKILL.md",
     "operation_style": "subprocess-cli",
+    "transport": "execute",
     "python": ">=3.11"
   },
   "operations": [
@@ -34,7 +35,8 @@
         {"name": "check_in", "type": "string", "required": true},
         {"name": "check_out", "type": "string", "required": true},
         {"name": "guests", "type": "integer", "required": false, "default": 2},
-        {"name": "rooms", "type": "integer", "required": false, "default": 1}
+        {"name": "rooms", "type": "integer", "required": false, "default": 1},
+        {"name": "profile_slug", "type": "string", "required": false, "default": "expedia"}
       ]
     }
   ],
@@ -46,6 +48,7 @@
       "auth_plan.json",
       "API.md",
       "operations/search_hotels.py",
+      "noui_runtime/execute.py",
       "noui_runtime/auth.py",
       "noui_runtime/__init__.py",
       "operations/__init__.py"

--- a/skills/expedia-stay-search/noui_runtime/execute.py
+++ b/skills/expedia-stay-search/noui_runtime/execute.py
@@ -124,9 +124,7 @@ async def execute_fetch(
             "Run `tabby session ensure --profile <slug>` or check the admin UI."
         )
     if resp.status_code >= 400:
-        raise RuntimeError(
-            f"Tabby execute/fetch failed ({resp.status_code}): {resp.text[:500]}"
-        )
+        raise RuntimeError(f"Tabby execute/fetch failed ({resp.status_code}): {resp.text[:500]}")
 
     data = resp.json()
     status = data.get("status", 0)
@@ -175,9 +173,7 @@ async def execute_browser(
             "Run `tabby session ensure --profile <slug>` or check the admin UI."
         )
     if resp.status_code >= 400:
-        raise RuntimeError(
-            f"Tabby execute/browser failed ({resp.status_code}): {resp.text[:500]}"
-        )
+        raise RuntimeError(f"Tabby execute/browser failed ({resp.status_code}): {resp.text[:500]}")
 
     data = resp.json()
     if not data.get("success", False):

--- a/skills/expedia-stay-search/noui_runtime/execute.py
+++ b/skills/expedia-stay-search/noui_runtime/execute.py
@@ -1,0 +1,186 @@
+"""NoUI runtime execute adapter — fetch and browser commands via Tabby HTTP API.
+
+Calls Tabby's POST /execute/fetch and POST /execute/browser endpoints instead of
+connecting to the browser via CDP WebSocket. Cookies and TLS fingerprint come from
+the real authenticated browser session.
+
+Requires:
+  - A running Tabby session for the target profile.
+  - TABBY_API_HOST / TABBY_API_URL env var (or .env) pointing to the Tabby API.
+  - Agent credentials (TABBY_CLIENT_ID / TABBY_CLIENT_SECRET) for token exchange.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+def _find_env_file() -> str | None:
+    if os.environ.get("NOUI_ENV_FILE"):
+        return os.environ["NOUI_ENV_FILE"]
+    here = Path(__file__).resolve().parent
+    for _ in range(7):
+        candidate = here / ".env"
+        if candidate.exists():
+            return str(candidate)
+        here = here.parent
+    for fallback in (
+        Path.home() / ".config" / "noui" / ".env",
+        Path.home() / ".noui" / ".env",
+    ):
+        if fallback.exists():
+            return str(fallback)
+    return None
+
+
+def _load_env() -> None:
+    env_file = _find_env_file()
+    if not env_file:
+        return
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(env_file, override=False)
+    except ImportError:
+        pass
+
+
+_load_env()
+
+
+def _tabby_api_host() -> str:
+    return (
+        os.environ.get("TABBY_API_HOST")
+        or os.environ.get("TABBY_API_URL")
+        or "http://localhost:8000"
+    )
+
+
+async def _get_agent_token() -> str:
+    client_id = os.environ.get("TABBY_CLIENT_ID", "")
+    client_secret = os.environ.get("TABBY_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "TABBY_CLIENT_ID and TABBY_CLIENT_SECRET must be set. "
+            "Create an agent client in the Tabby admin UI."
+        )
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{_tabby_api_host()}/auth/agent-token",
+            json={
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    return data["access_token"]
+
+
+async def execute_fetch(
+    profile_id: str,
+    url: str,
+    *,
+    method: str = "GET",
+    body: Any = None,
+    headers: dict[str, str] | None = None,
+    timeout_ms: int = 30_000,
+) -> Any:
+    """Run fetch() inside the authenticated Tabby browser session.
+
+    Returns parsed JSON body on 2xx; raises RuntimeError otherwise.
+    """
+    token = await _get_agent_token()
+
+    request_body: dict[str, Any] = {
+        "profile_id": profile_id,
+        "url": url,
+        "method": method.upper(),
+        "timeout_ms": timeout_ms,
+    }
+    if headers:
+        request_body["headers"] = headers
+    if body is not None:
+        request_body["body"] = json.dumps(body) if not isinstance(body, str) else body
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{_tabby_api_host()}/execute/fetch",
+            json=request_body,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=timeout_ms / 1000 + 5,
+        )
+
+    if resp.status_code == 409:
+        raise RuntimeError(
+            f'No healthy Tabby session for profile "{profile_id}". '
+            "Run `tabby session ensure --profile <slug>` or check the admin UI."
+        )
+    if resp.status_code >= 400:
+        raise RuntimeError(
+            f"Tabby execute/fetch failed ({resp.status_code}): {resp.text[:500]}"
+        )
+
+    data = resp.json()
+    status = data.get("status", 0)
+    raw_body = data.get("body", "")
+
+    if not (200 <= status < 300):
+        raise RuntimeError(f"{method.upper()} {url} -> {status}: {(raw_body or '')[:500]}")
+
+    try:
+        return json.loads(raw_body) if raw_body else {}
+    except (ValueError, TypeError):
+        return {"status": status, "text": raw_body}
+
+
+async def execute_browser(
+    profile_id: str,
+    command: str,
+    params: dict[str, Any] | None = None,
+    *,
+    timeout_ms: int = 30_000,
+) -> Any:
+    """Run a browser command inside the authenticated Tabby browser session.
+
+    Returns the command result on success; raises RuntimeError on failure.
+    """
+    token = await _get_agent_token()
+
+    request_body: dict[str, Any] = {
+        "profile_id": profile_id,
+        "command": command,
+        "params": params or {},
+        "timeout_ms": timeout_ms,
+    }
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{_tabby_api_host()}/execute/browser",
+            json=request_body,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=timeout_ms / 1000 + 5,
+        )
+
+    if resp.status_code == 409:
+        raise RuntimeError(
+            f'No healthy Tabby session for profile "{profile_id}". '
+            "Run `tabby session ensure --profile <slug>` or check the admin UI."
+        )
+    if resp.status_code >= 400:
+        raise RuntimeError(
+            f"Tabby execute/browser failed ({resp.status_code}): {resp.text[:500]}"
+        )
+
+    data = resp.json()
+    if not data.get("success", False):
+        raise RuntimeError(f"Browser command '{command}' failed: {data.get('error', 'unknown')}")
+
+    return data.get("data")

--- a/skills/expedia-stay-search/operations/search_hotels.py
+++ b/skills/expedia-stay-search/operations/search_hotels.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """Operation: search_hotels
 
-Searches for hotels on Expedia by executing API calls from inside
-the authenticated Tabby browser session via CDP (Chrome DevTools Protocol).
+Searches for hotels on Expedia via Tabby's execute endpoints.
 
-This bypasses Akamai bot detection by making requests from the real browser
-context rather than from a Python HTTP client.
+Uses POST /execute/fetch for API calls (typeahead) and POST /execute/browser
+for page navigation + HAR capture of search results. Replaces the previous
+CDP WebSocket approach.
 
 Skill-variant entry point:
-    python operations/search_hotels.py --destination Paris --check-in 2026-05-01 \\
+    python operations/search_hotels.py --destination Paris --check-in 2026-05-01 \
         --check-out 2026-05-04 --guests 2 --rooms 1
 
 Prints JSON to stdout on success; exits non-zero with a diagnostic on stderr.
@@ -19,107 +19,15 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
 import sys
 import urllib.parse
+from pathlib import Path
+from typing import Any
 
-import httpx
-import websockets
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-CDP_LIST_URL = "http://localhost:9222/json"
-
-_JS_EXTRACT_LISTINGS = r"""
-(() => {
-    const cards = document.querySelectorAll('[data-stid="lodging-card-responsive"]');
-    const results = [];
-    for (const card of [...cards].slice(0, 25)) {
-        const text = card.innerText || '';
-
-        const headings = card.querySelectorAll('h3');
-        let name = '';
-        for (const h of headings) {
-            const t = h.textContent.trim();
-            if (!t.startsWith('Photo gallery')) { name = t; break; }
-        }
-        if (!name && headings.length) {
-            name = (headings[0].textContent || '').trim().replace(/^Photo gallery for /, '');
-        }
-
-        const prices = text.match(/\$[\d,]+/g) || [];
-        const mainPrice = prices[0] || '';
-
-        const nightlyMatch = text.match(/\$([\d,]+)\s*night/i);
-        const nightly = nightlyMatch ? '$' + nightlyMatch[1] : mainPrice;
-
-        const totalMatch = text.match(/\$([\d,]+)\s+total/i);
-        const total = totalMatch ? '$' + totalMatch[1] : '';
-
-        const ratingMatch = text.match(/([\d.]+)\s+out of 10/);
-        const rating = ratingMatch ? ratingMatch[1] + '/10' : '';
-        const ratingWord = text.match(/out of 10\n(\w+)/);
-        const ratingLabel = ratingWord ? ratingWord[1] : '';
-
-        const reviewMatch = text.match(/([\d,]+)\s+reviews/);
-        const reviews = reviewMatch ? reviewMatch[1] : '';
-
-        const link = (card.querySelector('a[href*="Hotel-Information"]') || card.querySelector('a') || {}).href || '';
-        const refundable = text.includes('Fully refundable');
-
-        if (name) {
-            results.push({
-                name, price_per_night: nightly, price_total: total,
-                rating, rating_label: ratingLabel, reviews_count: reviews,
-                refundable, url: link,
-            });
-        }
-    }
-    return JSON.stringify({total_on_page: cards.length, results});
-})()
-"""
-
-
-async def _find_expedia_page() -> str | None:
-    async with httpx.AsyncClient() as client:
-        resp = await client.get(CDP_LIST_URL, timeout=5)
-        targets = resp.json()
-    for t in targets:
-        if t.get("type") == "page" and "expedia.com" in t.get("url", ""):
-            return t["webSocketDebuggerUrl"]
-    return None
-
-
-async def _cdp_eval(ws_url: str, expression: str) -> dict:
-    async with websockets.connect(ws_url) as ws:
-        await ws.send(
-            json.dumps(
-                {
-                    "id": 1,
-                    "method": "Runtime.evaluate",
-                    "params": {
-                        "expression": expression,
-                        "awaitPromise": True,
-                        "returnByValue": True,
-                    },
-                }
-            )
-        )
-        resp = json.loads(await ws.recv())
-
-    result = resp.get("result", {}).get("result", {})
-    if result.get("type") != "string":
-        raise RuntimeError(f"CDP eval failed: {json.dumps(result)[:300]}")
-    return json.loads(result["value"])
-
-
-async def _cdp_fetch(ws_url: str, url: str) -> dict:
-    js = f"""
-    fetch({json.dumps(url)}, {{ credentials: 'include' }})
-      .then(r => r.text().then(t => JSON.stringify({{status: r.status, body: t}})))
-    """
-    data = await _cdp_eval(ws_url, js)
-    if data["status"] != 200:
-        raise RuntimeError(f"Expedia API returned {data['status']}: {data['body'][:300]}")
-    return json.loads(data["body"])
-
+from noui_runtime.execute import execute_browser, execute_fetch
 
 _TYPEAHEAD_PARAMS = {
     "locale": "en_US",
@@ -131,12 +39,12 @@ _TYPEAHEAD_PARAMS = {
 }
 
 
-async def _resolve_destination(ws_url: str, destination: str) -> dict:
+async def _resolve_destination(profile_id: str, destination: str) -> dict:
     query = urllib.parse.quote(destination)
     params = urllib.parse.urlencode(_TYPEAHEAD_PARAMS)
     url = f"https://www.expedia.com/api/v4/typeahead/{query}?{params}"
 
-    data = await _cdp_fetch(ws_url, url)
+    data = await execute_fetch(profile_id, url)
 
     results = data.get("sr", data) if isinstance(data, dict) else data
     if not results or not isinstance(results, list):
@@ -159,8 +67,173 @@ async def _resolve_destination(ws_url: str, destination: str) -> dict:
     }
 
 
+def _extract_listings_from_har(har_data: dict) -> list[dict]:
+    """Extract hotel listings from HAR-captured API responses.
+
+    Searches for JSON responses containing property/listing arrays returned
+    by Expedia's SPA during the Hotel-Search page load.
+    """
+    entries = har_data.get("har", {}).get("log", {}).get("entries", [])
+    for entry in entries:
+        resp = entry.get("response", {})
+        content = resp.get("content", {})
+        if resp.get("status") != 200:
+            continue
+        body_text = content.get("text", "")
+        if not body_text or len(body_text) < 500:
+            continue
+        try:
+            body = json.loads(body_text)
+        except (ValueError, TypeError):
+            continue
+        listings = _find_property_array(body)
+        if listings:
+            return listings
+    return []
+
+
+def _find_property_array(data: Any, depth: int = 0) -> list[dict] | None:
+    """Recursively search a parsed API response for a hotel property array."""
+    if depth > 8:
+        return None
+
+    if isinstance(data, list) and len(data) >= 3:
+        if all(_looks_like_property(item) for item in data[:3]):
+            return [_normalize_property(item) for item in data[:25]]
+
+    if isinstance(data, dict):
+        for key in ("properties", "propertySearchListings", "listings",
+                     "results", "searchResults", "hotels", "items"):
+            if key in data:
+                found = _find_property_array(data[key], depth + 1)
+                if found:
+                    return found
+        for val in data.values():
+            if isinstance(val, (dict, list)):
+                found = _find_property_array(val, depth + 1)
+                if found:
+                    return found
+    return None
+
+
+_PROPERTY_SIGNALS = {"name", "propertyName", "hotelName", "title"}
+_PRICE_SIGNALS = {"price", "ratePlan", "rate", "lead", "displayPrice", "priceMetadata"}
+
+
+def _looks_like_property(item: Any) -> bool:
+    if not isinstance(item, dict):
+        return False
+    keys = set(item.keys())
+    has_name = bool(keys & _PROPERTY_SIGNALS) or any(
+        isinstance(v, dict) and set(v.keys()) & _PROPERTY_SIGNALS
+        for v in item.values()
+    )
+    has_price = bool(keys & _PRICE_SIGNALS) or any(
+        isinstance(v, dict) and set(v.keys()) & _PRICE_SIGNALS
+        for v in item.values()
+    )
+    return has_name and has_price
+
+
+def _deep_get(d: dict, *paths: str) -> Any:
+    """Walk nested dicts for the first matching dotted path."""
+    for path in paths:
+        cur: Any = d
+        for part in path.split("."):
+            if isinstance(cur, dict):
+                cur = cur.get(part)
+            else:
+                cur = None
+                break
+        if cur is not None:
+            return cur
+    return None
+
+
+def _normalize_property(item: dict) -> dict:
+    name = _deep_get(
+        item, "name", "propertyName", "hotelName", "title",
+        "header.headline", "cardHeader.headline",
+    ) or ""
+
+    nightly = _deep_get(
+        item, "price.lead.formatted", "price.displayPrice",
+        "ratePlan.price.current", "price.options.0.formattedDisplayPrice",
+        "mapMarker.label",
+    ) or ""
+    total = _deep_get(
+        item, "price.strikeOut.formatted", "price.displayTotalPrice",
+        "ratePlan.price.total", "price.total.formatted",
+    ) or ""
+
+    rating = _deep_get(
+        item, "reviews.score", "guestReviews.rating",
+        "star", "starRating", "reviews.overallScore",
+    )
+    rating_str = f"{rating}/10" if rating else ""
+
+    rating_label = _deep_get(
+        item, "reviews.qualitativeScoreText", "guestReviews.qualitativeScoreText",
+        "reviews.qualitative",
+    ) or ""
+
+    reviews_count = _deep_get(
+        item, "reviews.total", "guestReviews.total",
+        "reviews.count", "reviews.totalCount",
+    )
+    reviews_str = str(reviews_count) if reviews_count else ""
+
+    url = _deep_get(
+        item, "propertyUrl", "url", "deeplink",
+        "cardLink.resource.value",
+    ) or ""
+    if url and not url.startswith("http"):
+        url = f"https://www.expedia.com{url}"
+
+    refundable = bool(_deep_get(
+        item, "freeCancellation", "price.freeCancellation",
+        "offerBadge.secondary",
+    ))
+
+    return {
+        "name": str(name),
+        "price_per_night": str(nightly),
+        "price_total": str(total),
+        "rating": rating_str,
+        "rating_label": str(rating_label),
+        "reviews_count": reviews_str,
+        "refundable": refundable,
+        "url": str(url),
+    }
+
+
+def _extract_listings_from_summary(summary: dict) -> list[dict]:
+    """Fallback: extract hotel names from get_page_summary headings."""
+    listings = []
+    headings = summary.get("headings", [])
+    links = {l.get("text", "").strip(): l.get("href", "") for l in summary.get("links", [])}
+
+    for h in headings:
+        text = (h.get("text") or "").strip()
+        if not text or text.startswith("Photo gallery"):
+            continue
+        url = links.get(text, "")
+        if url or h.get("level") == "H3":
+            listings.append({
+                "name": text,
+                "price_per_night": "",
+                "price_total": "",
+                "rating": "",
+                "rating_label": "",
+                "reviews_count": "",
+                "refundable": False,
+                "url": url,
+            })
+    return listings[:25]
+
+
 async def _search_properties(
-    ws_url: str,
+    profile_id: str,
     region_id: str,
     destination_name: str,
     check_in: str,
@@ -181,21 +254,31 @@ async def _search_properties(
     }
     search_url = "https://www.expedia.com/Hotel-Search?" + urllib.parse.urlencode(params)
 
-    async with websockets.connect(ws_url) as ws:
-        await ws.send(
-            json.dumps(
-                {
-                    "id": 1,
-                    "method": "Page.navigate",
-                    "params": {"url": search_url},
-                }
-            )
+    await execute_browser(profile_id, "har_start")
+
+    await execute_browser(
+        profile_id, "navigate", {"url": search_url}, timeout_ms=45_000
+    )
+
+    try:
+        await execute_browser(
+            profile_id,
+            "wait_for_selector",
+            {"selector": '[data-stid="lodging-card-responsive"]'},
+            timeout_ms=15_000,
         )
-        await ws.recv()
+    except RuntimeError:
+        pass
 
-    await asyncio.sleep(7)
+    har_data = await execute_browser(profile_id, "har_stop")
 
-    return await _cdp_eval(ws_url, _JS_EXTRACT_LISTINGS)
+    listings = _extract_listings_from_har(har_data)
+    if listings:
+        return {"total_on_page": len(listings), "results": listings}
+
+    summary = await execute_browser(profile_id, "get_page_summary")
+    fallback = _extract_listings_from_summary(summary)
+    return {"total_on_page": len(fallback), "results": fallback}
 
 
 async def execute(
@@ -204,13 +287,16 @@ async def execute(
     check_out: str,
     guests: int = 2,
     rooms: int = 1,
+    profile_slug: str | None = None,
 ) -> dict:
-    """Search for hotels on Expedia using the authenticated browser session."""
-    ws_url = await _find_expedia_page()
-    if not ws_url:
-        return {"error": "No Expedia browser session found. Is Tabby running?"}
+    """Search for hotels on Expedia using the Tabby execute endpoints."""
+    profile_id = (
+        profile_slug
+        or os.environ.get("PROFILE_SLUG")
+        or "expedia"
+    )
 
-    dest_info = await _resolve_destination(ws_url, destination)
+    dest_info = await _resolve_destination(profile_id, destination)
     region_id = dest_info.get("region_id", "")
 
     if not region_id:
@@ -220,7 +306,7 @@ async def execute(
         }
 
     search_data = await _search_properties(
-        ws_url,
+        profile_id,
         region_id,
         dest_info["name"],
         check_in,
@@ -255,7 +341,7 @@ async def execute(
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="search_hotels",
-        description="Search Expedia for hotels by destination and dates via Tabby CDP.",
+        description="Search Expedia for hotels by destination and dates via Tabby execute endpoints.",
     )
     parser.add_argument("--destination", required=True, help="City or place name (e.g. 'Paris').")
     parser.add_argument("--check-in", dest="check_in", required=True, help="YYYY-MM-DD.")
@@ -266,7 +352,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--profile-slug",
         dest="profile_slug",
         default=None,
-        help="Tabby profile slug. Unused for CDP transport but accepted for contract parity.",
+        help="Tabby profile slug (default: $PROFILE_SLUG or 'expedia').",
     )
     return parser
 
@@ -281,6 +367,7 @@ def main(argv: list[str] | None = None) -> int:
                 check_out=args.check_out,
                 guests=args.guests,
                 rooms=args.rooms,
+                profile_slug=args.profile_slug,
             )
         )
     except Exception as exc:

--- a/skills/expedia-stay-search/operations/search_hotels.py
+++ b/skills/expedia-stay-search/operations/search_hotels.py
@@ -102,8 +102,15 @@ def _find_property_array(data: Any, depth: int = 0) -> list[dict] | None:
             return [_normalize_property(item) for item in data[:25]]
 
     if isinstance(data, dict):
-        for key in ("properties", "propertySearchListings", "listings",
-                     "results", "searchResults", "hotels", "items"):
+        for key in (
+            "properties",
+            "propertySearchListings",
+            "listings",
+            "results",
+            "searchResults",
+            "hotels",
+            "items",
+        ):
             if key in data:
                 found = _find_property_array(data[key], depth + 1)
                 if found:
@@ -125,12 +132,10 @@ def _looks_like_property(item: Any) -> bool:
         return False
     keys = set(item.keys())
     has_name = bool(keys & _PROPERTY_SIGNALS) or any(
-        isinstance(v, dict) and set(v.keys()) & _PROPERTY_SIGNALS
-        for v in item.values()
+        isinstance(v, dict) and set(v.keys()) & _PROPERTY_SIGNALS for v in item.values()
     )
     has_price = bool(keys & _PRICE_SIGNALS) or any(
-        isinstance(v, dict) and set(v.keys()) & _PRICE_SIGNALS
-        for v in item.values()
+        isinstance(v, dict) and set(v.keys()) & _PRICE_SIGNALS for v in item.values()
     )
     return has_name and has_price
 
@@ -151,49 +156,91 @@ def _deep_get(d: dict, *paths: str) -> Any:
 
 
 def _normalize_property(item: dict) -> dict:
-    name = _deep_get(
-        item, "name", "propertyName", "hotelName", "title",
-        "header.headline", "cardHeader.headline",
-    ) or ""
+    name = (
+        _deep_get(
+            item,
+            "name",
+            "propertyName",
+            "hotelName",
+            "title",
+            "header.headline",
+            "cardHeader.headline",
+        )
+        or ""
+    )
 
-    nightly = _deep_get(
-        item, "price.lead.formatted", "price.displayPrice",
-        "ratePlan.price.current", "price.options.0.formattedDisplayPrice",
-        "mapMarker.label",
-    ) or ""
-    total = _deep_get(
-        item, "price.strikeOut.formatted", "price.displayTotalPrice",
-        "ratePlan.price.total", "price.total.formatted",
-    ) or ""
+    nightly = (
+        _deep_get(
+            item,
+            "price.lead.formatted",
+            "price.displayPrice",
+            "ratePlan.price.current",
+            "price.options.0.formattedDisplayPrice",
+            "mapMarker.label",
+        )
+        or ""
+    )
+    total = (
+        _deep_get(
+            item,
+            "price.strikeOut.formatted",
+            "price.displayTotalPrice",
+            "ratePlan.price.total",
+            "price.total.formatted",
+        )
+        or ""
+    )
 
     rating = _deep_get(
-        item, "reviews.score", "guestReviews.rating",
-        "star", "starRating", "reviews.overallScore",
+        item,
+        "reviews.score",
+        "guestReviews.rating",
+        "star",
+        "starRating",
+        "reviews.overallScore",
     )
     rating_str = f"{rating}/10" if rating else ""
 
-    rating_label = _deep_get(
-        item, "reviews.qualitativeScoreText", "guestReviews.qualitativeScoreText",
-        "reviews.qualitative",
-    ) or ""
+    rating_label = (
+        _deep_get(
+            item,
+            "reviews.qualitativeScoreText",
+            "guestReviews.qualitativeScoreText",
+            "reviews.qualitative",
+        )
+        or ""
+    )
 
     reviews_count = _deep_get(
-        item, "reviews.total", "guestReviews.total",
-        "reviews.count", "reviews.totalCount",
+        item,
+        "reviews.total",
+        "guestReviews.total",
+        "reviews.count",
+        "reviews.totalCount",
     )
     reviews_str = str(reviews_count) if reviews_count else ""
 
-    url = _deep_get(
-        item, "propertyUrl", "url", "deeplink",
-        "cardLink.resource.value",
-    ) or ""
+    url = (
+        _deep_get(
+            item,
+            "propertyUrl",
+            "url",
+            "deeplink",
+            "cardLink.resource.value",
+        )
+        or ""
+    )
     if url and not url.startswith("http"):
         url = f"https://www.expedia.com{url}"
 
-    refundable = bool(_deep_get(
-        item, "freeCancellation", "price.freeCancellation",
-        "offerBadge.secondary",
-    ))
+    refundable = bool(
+        _deep_get(
+            item,
+            "freeCancellation",
+            "price.freeCancellation",
+            "offerBadge.secondary",
+        )
+    )
 
     return {
         "name": str(name),
@@ -208,10 +255,20 @@ def _normalize_property(item: dict) -> dict:
 
 
 _FILTER_HEADINGS = {
-    "total price", "popular filters", "star rating", "guest rating",
-    "property amenities", "room amenities", "room views", "payment type",
-    "property cancellation options", "property type", "property brand",
-    "meal plans available", "traveler experience", "from",
+    "total price",
+    "popular filters",
+    "star rating",
+    "guest rating",
+    "property amenities",
+    "room amenities",
+    "room views",
+    "payment type",
+    "property cancellation options",
+    "property type",
+    "property brand",
+    "meal plans available",
+    "traveler experience",
+    "from",
 }
 
 
@@ -229,22 +286,24 @@ def _extract_listings_from_summary(summary: dict) -> list[dict]:
             continue
         for prefix in ("Opens ", "More information about "):
             if text.startswith(prefix):
-                text = text[len(prefix):]
+                text = text[len(prefix) :]
                 break
         for suffix in (", opens in a new tab", " in new tab"):
             if text.endswith(suffix):
-                text = text[:-len(suffix)]
+                text = text[: -len(suffix)]
                 break
-        listings.append({
-            "name": text,
-            "price_per_night": "",
-            "price_total": "",
-            "rating": "",
-            "rating_label": "",
-            "reviews_count": "",
-            "refundable": False,
-            "url": href,
-        })
+        listings.append(
+            {
+                "name": text,
+                "price_per_night": "",
+                "price_total": "",
+                "rating": "",
+                "rating_label": "",
+                "reviews_count": "",
+                "refundable": False,
+                "url": href,
+            }
+        )
     return listings[:25]
 
 
@@ -272,9 +331,7 @@ async def _search_properties(
 
     await execute_browser(profile_id, "har_start")
 
-    await execute_browser(
-        profile_id, "navigate", {"url": search_url}, timeout_ms=60_000
-    )
+    await execute_browser(profile_id, "navigate", {"url": search_url}, timeout_ms=60_000)
 
     try:
         await execute_browser(
@@ -306,11 +363,7 @@ async def execute(
     profile_slug: str | None = None,
 ) -> dict:
     """Search for hotels on Expedia using the Tabby execute endpoints."""
-    profile_id = (
-        profile_slug
-        or os.environ.get("PROFILE_SLUG")
-        or "expedia"
-    )
+    profile_id = profile_slug or os.environ.get("PROFILE_SLUG") or "expedia"
 
     dest_info = await _resolve_destination(profile_id, destination)
     region_id = dest_info.get("region_id", "")

--- a/skills/expedia-stay-search/operations/search_hotels.py
+++ b/skills/expedia-stay-search/operations/search_hotels.py
@@ -207,28 +207,44 @@ def _normalize_property(item: dict) -> dict:
     }
 
 
-def _extract_listings_from_summary(summary: dict) -> list[dict]:
-    """Fallback: extract hotel names from get_page_summary headings."""
-    listings = []
-    headings = summary.get("headings", [])
-    links = {l.get("text", "").strip(): l.get("href", "") for l in summary.get("links", [])}
+_FILTER_HEADINGS = {
+    "total price", "popular filters", "star rating", "guest rating",
+    "property amenities", "room amenities", "room views", "payment type",
+    "property cancellation options", "property type", "property brand",
+    "meal plans available", "traveler experience", "from",
+}
 
-    for h in headings:
-        text = (h.get("text") or "").strip()
-        if not text or text.startswith("Photo gallery"):
+
+def _extract_listings_from_summary(summary: dict) -> list[dict]:
+    """Fallback: extract hotel names from get_page_summary links."""
+    listings = []
+    for link in summary.get("links", []):
+        text = (link.get("text") or "").strip()
+        href = link.get("href", "")
+        if not text or not href:
             continue
-        url = links.get(text, "")
-        if url or h.get("level") == "H3":
-            listings.append({
-                "name": text,
-                "price_per_night": "",
-                "price_total": "",
-                "rating": "",
-                "rating_label": "",
-                "reviews_count": "",
-                "refundable": False,
-                "url": url,
-            })
+        if "Hotel-Information" not in href and "hotel-deals" not in href.lower():
+            continue
+        if text.startswith("Photo gallery") or text.lower() in _FILTER_HEADINGS:
+            continue
+        for prefix in ("Opens ", "More information about "):
+            if text.startswith(prefix):
+                text = text[len(prefix):]
+                break
+        for suffix in (", opens in a new tab", " in new tab"):
+            if text.endswith(suffix):
+                text = text[:-len(suffix)]
+                break
+        listings.append({
+            "name": text,
+            "price_per_night": "",
+            "price_total": "",
+            "rating": "",
+            "rating_label": "",
+            "reviews_count": "",
+            "refundable": False,
+            "url": href,
+        })
     return listings[:25]
 
 
@@ -257,7 +273,7 @@ async def _search_properties(
     await execute_browser(profile_id, "har_start")
 
     await execute_browser(
-        profile_id, "navigate", {"url": search_url}, timeout_ms=45_000
+        profile_id, "navigate", {"url": search_url}, timeout_ms=60_000
     )
 
     try:


### PR DESCRIPTION
## Summary

- Replace direct CDP WebSocket connections (`localhost:9222`, `websockets` lib) with Tabby's `POST /execute/fetch` and `POST /execute/browser` HTTP endpoints
- New `noui_runtime/execute.py` adapter providing `execute_fetch()` and `execute_browser()` helpers with agent token exchange
- Typeahead resolution uses `execute_fetch` (runs `fetch()` inside the browser session)
- Hotel search uses `execute_browser` with HAR capture (`har_start` → `navigate` → `wait_for_selector` → `har_stop`) to intercept API responses, falling back to `get_page_summary` link extraction
- Fallback extracts clean hotel names from `Hotel-Information` links, stripping accessibility prefixes
- Removes `websockets` dependency; only needs `httpx`

## Test plan

- [x] Python syntax validation (`ast.parse`)
- [x] No CDP references remain (`grep` verification)
- [x] Agent token exchange against live Tabby API
- [x] `execute_fetch` and `execute_browser` auth + routing (verified against live API)
- [x] End-to-end: Paris search returned 25 hotel listings via `get_page_summary` fallback
- [x] End-to-end: Denver search returned 25 hotel listings with clean names and Hotel-Information URLs
- [x] Error handling: bad profile → 400, no worker → 502, meaningful messages

**Note:** Also debugged and fixed the Expedia login DSL — `fill()` was failing because it doesn't fire real DOM events; changed to `type` (keystroke simulation) with timing delays. This fix is in the local DB config only, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)