### PR TITLE
NoUI cloud Tabby auth (platform-JWT token-exchange) + single TABBY_API_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@ NOUI_DEBUG=true
 ANTHROPIC_API_KEY=
 
 # --- Tabby auth ---
-# Tabby base URL. Use TABBY_API_URL for cloud; TABBY_API_HOST is the local default.
-TABBY_API_HOST=http://localhost:8080
+# Tabby API base URL (local default below; set your cloud/staging URL here).
+TABBY_API_URL=http://localhost:8080
 
 # Local / self-host flow (agent-token): admin token provisions an agent client,
 # whose credentials `noui tabby setup` writes here.

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,23 @@
 NOUI_PORT=8002
 NOUI_DEBUG=true
 ANTHROPIC_API_KEY=
+
+# --- Tabby auth ---
+# Tabby base URL. Use TABBY_API_URL for cloud; TABBY_API_HOST is the local default.
 TABBY_API_HOST=http://localhost:8080
+
+# Local / self-host flow (agent-token): admin token provisions an agent client,
+# whose credentials `noui tabby setup` writes here.
 TABBY_ADMIN_TOKEN=
+TABBY_CLIENT_ID=
+TABBY_CLIENT_SECRET=
+
+# Cloud flow (platform-JWT token-exchange). Set these (e.g. via
+# `noui tabby setup --cloud`) to authenticate against Tabby Cloud through the
+# Adopt platform instead of a local Tabby agent client.
+# NOUI_TABBY_AUTH_MODE: leave blank to auto-detect (platform_jwt when ADOPT_*
+# are set, else agent_token), or set explicitly to "agent_token"/"platform_jwt".
+NOUI_TABBY_AUTH_MODE=
+ADOPT_API_URL=
+ADOPT_CLIENT_ID=
+ADOPT_CLIENT_SECRET=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Cloud Tabby auth via platform token-exchange.** Generated MCP servers/Skills
+  and the compile-time auth verifier can authenticate against a cloud/staging
+  Tabby by exchanging a platform Personal Access Token for a platform JWT
+  (`POST /v1/users/api-token`), then for a Tabby JWT (`POST /auth/token-exchange`),
+  in addition to the local `/auth/agent-token` flow. The flow is selected by
+  `NOUI_TABBY_AUTH_MODE` (auto-detects `platform_jwt` when `ADOPT_API_URL` +
+  `ADOPT_CLIENT_ID` + `ADOPT_CLIENT_SECRET` are set, else `agent_token`). The
+  exchanged bearer is cached in-process until shortly before expiry.
+- `noui tabby setup --cloud` — verifies the PAT → platform-JWT → Tabby round-trip
+  and writes the cloud env vars to `.env` (no local Tabby or admin token needed).
+
 ### Changed
 
+- **BREAKING: `TABBY_API_HOST` and `TABBY_API_URL` collapsed into a single
+  `TABBY_API_URL`.** Every env read now uses `TABBY_API_URL`; `TABBY_API_HOST` is
+  no longer read (no fallback). Rename it in your `.env`/environment.
 - **Default execution mode for generated MCP servers and Skills is now CDP
   browser execution** (`--execution-mode cdp`). Generated operations open a
   WebSocket to Tabby's CDP endpoint (`localhost:9222`), locate the tab for the

--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ python3 -m venv .venv
 # 2. Configure environment
 cp .env.example .env
 # Edit .env: set ANTHROPIC_API_KEY (required)
-#            TABBY_API_HOST, TABBY_ADMIN_TOKEN (authenticated apps only)
+#            TABBY_API_URL, TABBY_ADMIN_TOKEN (local authenticated apps)
+#            or, for cloud/staging Tabby: ADOPT_API_URL + ADOPT_CLIENT_ID/SECRET (a platform PAT)
 
 # 3. Load the Chrome extension
 # Chrome → chrome://extensions → Developer mode → Load unpacked → select noui/extension/

--- a/backend/config.py
+++ b/backend/config.py
@@ -49,6 +49,6 @@ settings = Settings(
     port=int(os.environ.get("NOUI_PORT", "8002")),
     anthropic_api_key=os.environ.get("ANTHROPIC_API_KEY", ""),
     claude_model=os.environ.get("CLAUDE_MODEL", "claude-sonnet-4-20250514"),
-    tabby_api_host=os.environ.get("TABBY_API_HOST", "http://localhost:8080"),
+    tabby_api_host=os.environ.get("TABBY_API_URL", "http://localhost:8080"),
     tabby_admin_token=os.environ.get("TABBY_ADMIN_TOKEN", ""),
 )

--- a/backend/elicitation/browser_bridge.py
+++ b/backend/elicitation/browser_bridge.py
@@ -3,7 +3,7 @@
 Commands are created by MCP tool handlers and consumed by the Chrome extension
 via polling. Results flow back through asyncio.Event synchronization.
 
-When TABBY_API_HOST, TABBY_CLIENT_ID, and TABBY_PROFILE_ID are set, commands
+When TABBY_API_URL, TABBY_CLIENT_ID, and TABBY_PROFILE_ID are set, commands
 are routed to Tabby's POST /execute/browser endpoint instead — no extension needed.
 """
 
@@ -31,7 +31,7 @@ _agent_token_cache: dict[str, Any] = {"token": "", "expires_at": 0.0}
 
 def _use_tabby_driver() -> bool:
     return bool(
-        os.environ.get("TABBY_API_HOST")
+        os.environ.get("TABBY_API_URL")
         and os.environ.get("TABBY_CLIENT_ID")
         and os.environ.get("TABBY_PROFILE_ID")
     )
@@ -43,7 +43,7 @@ async def _get_agent_token() -> str:
     if _agent_token_cache["token"] and _agent_token_cache["expires_at"] > now + 30:
         return _agent_token_cache["token"]
 
-    api_host = os.environ["TABBY_API_HOST"].rstrip("/")
+    api_host = os.environ["TABBY_API_URL"].rstrip("/")
     client_id = os.environ["TABBY_CLIENT_ID"]
     client_secret = os.environ["TABBY_CLIENT_SECRET"]
 
@@ -76,7 +76,7 @@ async def _execute_command_via_tabby(command_type: str, params: dict) -> dict:
 
     Returns the same {success, data, error} shape as the extension driver.
     """
-    api_host = os.environ["TABBY_API_HOST"].rstrip("/")
+    api_host = os.environ["TABBY_API_URL"].rstrip("/")
     profile_id = os.environ["TABBY_PROFILE_ID"]
     token = await _get_agent_token()
 
@@ -187,7 +187,7 @@ async def _execute_command_via_extension(command_type: str, params: dict) -> dic
 async def execute_command(command_type: str, params: dict) -> dict:
     """Execute a browser command, routing to Tabby or the extension.
 
-    When TABBY_API_HOST, TABBY_CLIENT_ID, and TABBY_PROFILE_ID are set,
+    When TABBY_API_URL, TABBY_CLIENT_ID, and TABBY_PROFILE_ID are set,
     commands go to Tabby's POST /execute/browser. Otherwise, they go to
     the Chrome extension via the in-memory queue.
 

--- a/cli/env.py
+++ b/cli/env.py
@@ -1,6 +1,6 @@
 """Environment resolution for the NoUI CLI.
 
-The CLI historically read ``TABBY_API_HOST`` straight from ``os.environ`` at
+The CLI historically read ``TABBY_API_URL`` straight from ``os.environ`` at
 import time, which meant a ``.env`` file in the repository root (the canonical
 location documented in ``.env.example`` and consumed by ``backend/config.py``)
 was silently ignored when running ``noui`` subcommands. The result was a
@@ -59,7 +59,7 @@ def resolve_tabby_api_host(env: Mapping[str, str] | None = None) -> str:
 
     Resolution order:
 
-    1. ``TABBY_API_HOST`` from the supplied mapping (defaults to
+    1. ``TABBY_API_URL`` from the supplied mapping (defaults to
        :data:`os.environ`, which callers are expected to have populated via
        :func:`load_env_files`).
     2. :data:`DEFAULT_TABBY_API_HOST` when the value is missing or empty.
@@ -72,7 +72,7 @@ def resolve_tabby_api_host(env: Mapping[str, str] | None = None) -> str:
       starting with ``/``.
     """
     src = env if env is not None else os.environ
-    raw = (src.get("TABBY_API_HOST") or "").strip()
+    raw = (src.get("TABBY_API_URL") or "").strip()
     if not raw:
         raw = DEFAULT_TABBY_API_HOST
     if "://" not in raw:

--- a/cli/main.py
+++ b/cli/main.py
@@ -574,6 +574,38 @@ def _tabby_http(
         ) from exc
 
 
+def _post_json_to(
+    url: str,
+    body: dict[str, Any],
+    token: str | None = None,
+    timeout: int = 15,
+) -> dict[str, Any] | list[Any]:
+    """POST JSON to an absolute URL.
+
+    Unlike :func:`_tabby_http` (which targets ``TABBY_API_HOST``), this hits an
+    arbitrary host — used by ``tabby setup --cloud`` to reach the Adopt platform
+    and a cloud Tabby that are not the locally-configured host.
+    """
+    data = json.dumps(body).encode()
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=data, method="POST", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        body_text = exc.read().decode(errors="replace")
+        raise RuntimeError(f"HTTP {exc.code} from POST {url}: {body_text}") from exc
+    except urllib.error.URLError as exc:
+        reason = exc.reason
+        if isinstance(reason, TimeoutError):
+            detail = f"timed out after {timeout}s"
+        else:
+            detail = str(reason) or type(reason).__name__
+        raise RuntimeError(f"Cannot reach {url} ({detail}).") from exc
+
+
 def _is_tabby_mode() -> bool:
     """True when all three Tabby env vars are set (headless browser driver)."""
     return bool(
@@ -4051,8 +4083,96 @@ def cmd_tabby_stop(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_tabby_setup_cloud(args: argparse.Namespace) -> int:
+    """Configure NoUI for Tabby Cloud via the platform-JWT token-exchange flow.
+
+    Unlike local setup, this provisions no Tabby agent client and needs no Tabby
+    admin token: NoUI authenticates with platform (Adopt) client credentials,
+    exchanges them for a platform JWT, and lets Tabby's /auth/token-exchange mint
+    a Tabby JWT. We verify that round-trip end-to-end, then persist the env vars.
+    """
+    adopt_api_url = (args.adopt_api_url or os.environ.get("ADOPT_API_URL", "")).rstrip("/")
+    adopt_client_id = args.adopt_client_id or os.environ.get("ADOPT_CLIENT_ID", "")
+    adopt_client_secret = args.adopt_client_secret or os.environ.get("ADOPT_CLIENT_SECRET", "")
+    tabby_url = (
+        args.tabby_url
+        or os.environ.get("TABBY_API_URL", "")
+        or os.environ.get("TABBY_API_HOST", "")
+    ).rstrip("/")
+
+    missing = [
+        name
+        for name, val in (
+            ("ADOPT_API_URL", adopt_api_url),
+            ("ADOPT_CLIENT_ID", adopt_client_id),
+            ("ADOPT_CLIENT_SECRET", adopt_client_secret),
+            ("TABBY_API_URL", tabby_url),
+        )
+        if not val
+    ]
+    if missing:
+        print(_red(f"Missing required cloud settings: {', '.join(missing)}"))
+        print("  Provide them via flags (--adopt-api-url, --adopt-client-id,")
+        print("  --adopt-client-secret, --tabby-url) or the matching environment variables.")
+        return 1
+
+    print(f"Verifying platform credentials at {_cyan(adopt_api_url)} …", end=" ", flush=True)
+    try:
+        token_resp = _post_json_to(
+            f"{adopt_api_url}/v1/users/api-token",
+            {"client_id": adopt_client_id, "secret": adopt_client_secret},
+        )
+        assert isinstance(token_resp, dict)
+        platform_jwt = token_resp.get("access_token", "")
+        if not platform_jwt:
+            raise RuntimeError(f"no access_token in /v1/users/api-token response: {token_resp}")
+        print(_green("✓"))
+    except (RuntimeError, AssertionError) as exc:
+        print()
+        print(_red(f"Platform token request failed: {exc}"))
+        return 1
+
+    print(f"Exchanging for a Tabby token at {_cyan(tabby_url)} …", end=" ", flush=True)
+    try:
+        exch = _post_json_to(
+            f"{tabby_url}/auth/token-exchange",
+            {"subject_token": platform_jwt, "subject_token_type": "oidc_jwt"},
+        )
+        assert isinstance(exch, dict)
+        tabby_jwt = exch.get("access_token", "")
+        if not tabby_jwt:
+            raise RuntimeError(f"no access_token in /auth/token-exchange response: {exch}")
+        print(_green("✓"))
+    except (RuntimeError, AssertionError) as exc:
+        print()
+        print(_red(f"Tabby token-exchange failed: {exc}"))
+        print("  Confirm the platform issuer is registered as an IdP in this Tabby instance.")
+        return 1
+
+    env_file = Path(args.env_file) if args.env_file else NOUI_DIR / ".env"
+    _write_env_vars(
+        env_file,
+        {
+            "TABBY_API_URL": tabby_url,
+            "ADOPT_API_URL": adopt_api_url,
+            "ADOPT_CLIENT_ID": adopt_client_id,
+            "ADOPT_CLIENT_SECRET": adopt_client_secret,
+            "NOUI_TABBY_AUTH_MODE": "platform_jwt",
+        },
+    )
+
+    print()
+    print(_green("✓ Cloud setup complete!"))
+    print(f"  Settings written to: {_cyan(str(env_file))}")
+    print("  Generated MCP servers/skills will authenticate via platform token-exchange.")
+    return 0
+
+
 def cmd_tabby_setup(args: argparse.Namespace) -> int:
     """Full end-to-end Tabby provisioning for NoUI."""
+    if getattr(args, "cloud", False):
+        return _cmd_tabby_setup_cloud(args)
+
     build_state, detail = _tabby_worker_build_state()
     if build_state in ("missing", "stale"):
         print(_red(f"Tabby worker is not ready: {detail}"))
@@ -4934,6 +5054,38 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         default=None,
         help="Path to write TABBY_* vars into (default: noui/.env)",
+    )
+    tabby_setup_p.add_argument(
+        "--cloud",
+        action="store_true",
+        help=(
+            "Configure for Tabby Cloud via platform token-exchange (no local "
+            "Tabby/admin token); uses ADOPT_API_URL/ADOPT_CLIENT_ID/ADOPT_CLIENT_SECRET"
+        ),
+    )
+    tabby_setup_p.add_argument(
+        "--adopt-api-url",
+        metavar="URL",
+        default=None,
+        help="Adopt platform base URL for --cloud (default: $ADOPT_API_URL)",
+    )
+    tabby_setup_p.add_argument(
+        "--adopt-client-id",
+        metavar="ID",
+        default=None,
+        help="Adopt platform client_id for --cloud (default: $ADOPT_CLIENT_ID)",
+    )
+    tabby_setup_p.add_argument(
+        "--adopt-client-secret",
+        metavar="SECRET",
+        default=None,
+        help="Adopt platform client_secret for --cloud (default: $ADOPT_CLIENT_SECRET)",
+    )
+    tabby_setup_p.add_argument(
+        "--tabby-url",
+        metavar="URL",
+        default=None,
+        help="Cloud Tabby base URL for --cloud (default: $TABBY_API_URL / $TABBY_API_HOST)",
     )
 
     tabby_session_p = tabby_sub.add_parser("session", help="Manage browser sessions")

--- a/cli/main.py
+++ b/cli/main.py
@@ -609,7 +609,7 @@ def _post_json_to(
 def _is_tabby_mode() -> bool:
     """True when all three Tabby env vars are set (headless browser driver)."""
     return bool(
-        os.environ.get("TABBY_API_HOST")
+        os.environ.get("TABBY_API_URL")
         and os.environ.get("TABBY_CLIENT_ID")
         and os.environ.get("TABBY_PROFILE_ID")
     )
@@ -4094,11 +4094,7 @@ def _cmd_tabby_setup_cloud(args: argparse.Namespace) -> int:
     adopt_api_url = (args.adopt_api_url or os.environ.get("ADOPT_API_URL", "")).rstrip("/")
     adopt_client_id = args.adopt_client_id or os.environ.get("ADOPT_CLIENT_ID", "")
     adopt_client_secret = args.adopt_client_secret or os.environ.get("ADOPT_CLIENT_SECRET", "")
-    tabby_url = (
-        args.tabby_url
-        or os.environ.get("TABBY_API_URL", "")
-        or os.environ.get("TABBY_API_HOST", "")
-    ).rstrip("/")
+    tabby_url = (args.tabby_url or os.environ.get("TABBY_API_URL", "")).rstrip("/")
 
     missing = [
         name
@@ -5085,7 +5081,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--tabby-url",
         metavar="URL",
         default=None,
-        help="Cloud Tabby base URL for --cloud (default: $TABBY_API_URL / $TABBY_API_HOST)",
+        help="Cloud Tabby base URL for --cloud (default: $TABBY_API_URL)",
     )
 
     tabby_session_p = tabby_sub.add_parser("session", help="Manage browser sessions")

--- a/compiler/mcp/auth_verifier.py
+++ b/compiler/mcp/auth_verifier.py
@@ -96,9 +96,7 @@ class AuthVerifier:
         self.auth_plan = auth_plan
         self.server_dir = Path(server_dir)
         self.tabby_api_host = (
-            tabby_api_host
-            or os.environ.get("TABBY_API_URL", "")
-            or os.environ.get("TABBY_API_HOST", "http://localhost:8080")
+            tabby_api_host or os.environ.get("TABBY_API_URL", "") or "http://localhost:8080"
         )
         self.tabby_admin_token = tabby_admin_token or os.environ.get("TABBY_ADMIN_TOKEN", "")
         self.tabby_client_id = tabby_client_id or os.environ.get("TABBY_CLIENT_ID", "")

--- a/compiler/mcp/auth_verifier.py
+++ b/compiler/mcp/auth_verifier.py
@@ -87,6 +87,10 @@ class AuthVerifier:
         tabby_admin_token: str = "",
         tabby_client_id: str = "",
         tabby_client_secret: str = "",
+        adopt_api_url: str = "",
+        adopt_client_id: str = "",
+        adopt_client_secret: str = "",
+        auth_mode: str = "",
         max_repair_attempts: int = 2,
     ) -> None:
         self.auth_plan = auth_plan
@@ -99,8 +103,21 @@ class AuthVerifier:
         self.tabby_admin_token = tabby_admin_token or os.environ.get("TABBY_ADMIN_TOKEN", "")
         self.tabby_client_id = tabby_client_id or os.environ.get("TABBY_CLIENT_ID", "")
         self.tabby_client_secret = tabby_client_secret or os.environ.get("TABBY_CLIENT_SECRET", "")
+        # Platform (Adopt) credentials for the cloud token-exchange flow.
+        self.adopt_api_url = (adopt_api_url or os.environ.get("ADOPT_API_URL", "")).rstrip("/")
+        self.adopt_client_id = adopt_client_id or os.environ.get("ADOPT_CLIENT_ID", "")
+        self.adopt_client_secret = adopt_client_secret or os.environ.get("ADOPT_CLIENT_SECRET", "")
+        self.auth_mode = (auth_mode or os.environ.get("NOUI_TABBY_AUTH_MODE", "")).strip().lower()
         self.max_repair_attempts = max_repair_attempts
         self._repair_count = 0
+
+    def _resolve_auth_mode(self) -> str:
+        """Pick the Tabby auth flow: explicit auth_mode wins, else auto-detect."""
+        if self.auth_mode:
+            return self.auth_mode
+        if self.adopt_api_url and self.adopt_client_id and self.adopt_client_secret:
+            return "platform_jwt"
+        return "agent_token"
 
     # ── Public API ───────────────────────────────────────────────────────────
 
@@ -186,15 +203,21 @@ class AuthVerifier:
                 suggested_repairs=[{"action": "run_command", "command": "noui tabby start"}],
             )
 
-        # Step 2: Agent credentials valid?
+        # Step 2: Auth credentials valid? (agent-token locally, platform-JWT in cloud)
         try:
-            agent_token = await self._get_agent_token()
+            bearer = await self._get_tabby_bearer()
         except RuntimeError as exc:
+            if self._resolve_auth_mode() == "platform_jwt":
+                missing = ["ADOPT_API_URL", "ADOPT_CLIENT_ID", "ADOPT_CLIENT_SECRET"]
+                repair_cmd = "noui tabby setup --cloud"
+            else:
+                missing = ["TABBY_CLIENT_ID", "TABBY_CLIENT_SECRET"]
+                repair_cmd = "noui tabby setup"
             return VerificationResult(
                 "NEEDS_SECRET",
                 message=str(exc),
-                missing_artifacts=["TABBY_CLIENT_ID", "TABBY_CLIENT_SECRET"],
-                suggested_repairs=[{"action": "run_command", "command": "noui tabby setup"}],
+                missing_artifacts=missing,
+                suggested_repairs=[{"action": "run_command", "command": repair_cmd}],
             )
 
         profile_slug = self.auth_plan.get("profile_slug", "")
@@ -204,7 +227,7 @@ class AuthVerifier:
 
         # Step 4: Request credentials
         try:
-            creds = await self._request_credentials(profile_slug, agent_token)
+            creds = await self._request_credentials(profile_slug, bearer)
         except Exception as exc:
             return VerificationResult(
                 "UNSUPPORTED",
@@ -226,7 +249,7 @@ class AuthVerifier:
             if self._repair_count < self.max_repair_attempts:
                 repair_result = await self._repair_empty_credentials(
                     profile_slug=profile_slug,
-                    agent_token=agent_token,
+                    agent_token=bearer,
                     missing_headers=missing_headers,
                     missing_cookies=missing_cookies,
                     session_healthy=session_healthy,
@@ -345,8 +368,8 @@ class AuthVerifier:
         if strategy == "tabby_credentials":
             profile_slug = self.auth_plan.get("profile_slug", "")
             try:
-                agent_token = await self._get_agent_token()
-                creds = await self._request_credentials(profile_slug, agent_token)
+                bearer = await self._get_tabby_bearer()
+                creds = await self._request_credentials(profile_slug, bearer)
                 if creds.get("headers") or creds.get("cookies"):
                     return VerificationResult(
                         "PASS",
@@ -416,12 +439,62 @@ class AuthVerifier:
             raise RuntimeError(f"POST /auth/agent-token returned no token: {data}")
         return token
 
-    async def _request_credentials(self, profile_slug: str, agent_token: str) -> dict:
+    async def _get_platform_jwt(self) -> str:
+        """Cloud flow step 1: platform client credentials → platform JWT via adoptwebui."""
+        if not self.adopt_api_url:
+            raise RuntimeError(
+                "Missing ADOPT_API_URL for platform_jwt auth mode.\n"
+                "Run `noui tabby setup --cloud` or set ADOPT_API_URL in noui/.env."
+            )
+        if not self.adopt_client_id or not self.adopt_client_secret:
+            raise RuntimeError(
+                "Missing ADOPT_CLIENT_ID or ADOPT_CLIENT_SECRET for platform_jwt auth mode.\n"
+                "Run `noui tabby setup --cloud` or set these in noui/.env."
+            )
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                f"{self.adopt_api_url}/v1/users/api-token",
+                json={"client_id": self.adopt_client_id, "secret": self.adopt_client_secret},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        token = data.get("access_token", "")
+        if not token:
+            raise RuntimeError(f"Platform /v1/users/api-token returned no access_token: {data}")
+        return token
+
+    async def _get_platform_tabby_token(self) -> str:
+        """Cloud flow step 2: platform JWT → Tabby JWT via /auth/token-exchange."""
+        platform_jwt = await self._get_platform_jwt()
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                f"{self.tabby_api_host}/auth/token-exchange",
+                json={"subject_token": platform_jwt, "subject_token_type": "oidc_jwt"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        token = data.get("access_token", "")
+        if not token:
+            raise RuntimeError(f"Tabby /auth/token-exchange returned no access_token: {data}")
+        return token
+
+    async def _get_tabby_bearer(self) -> str:
+        """Return a Tabby bearer token for the active auth mode."""
+        mode = self._resolve_auth_mode()
+        if mode == "platform_jwt":
+            return await self._get_platform_tabby_token()
+        if mode == "agent_token":
+            return await self._get_agent_token()
+        raise RuntimeError(
+            f"Unknown NOUI_TABBY_AUTH_MODE {mode!r} — expected 'agent_token' or 'platform_jwt'."
+        )
+
+    async def _request_credentials(self, profile_slug: str, bearer: str) -> dict:
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.post(
                 f"{self.tabby_api_host}/credentials/request",
                 json={"profile_id": profile_slug},
-                headers={"Authorization": f"Bearer {agent_token}"},
+                headers={"Authorization": f"Bearer {bearer}"},
             )
             resp.raise_for_status()
             data = resp.json()

--- a/compiler/runtime/auth_adapter.py
+++ b/compiler/runtime/auth_adapter.py
@@ -49,8 +49,10 @@ Shared across MCP-server and Skill output formats. Locates `.env` via:
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+import time
 from pathlib import Path
 
 import httpx
@@ -87,6 +89,26 @@ TABBY_API_HOST = os.environ.get(
 TABBY_CLIENT_ID = os.environ.get("TABBY_CLIENT_ID", "")
 TABBY_CLIENT_SECRET = os.environ.get("TABBY_CLIENT_SECRET", "")
 
+# Platform (Adopt) credentials for the cloud token-exchange flow. When these are
+# present (or NOUI_TABBY_AUTH_MODE=platform_jwt), the runtime exchanges platform
+# client credentials for a platform JWT, then exchanges that JWT for a Tabby JWT
+# via Tabby's /auth/token-exchange. Otherwise it uses the local/self-host flow:
+# Tabby agent-client credentials via /auth/agent-token.
+ADOPT_API_URL = os.environ.get("ADOPT_API_URL", "").rstrip("/")
+ADOPT_CLIENT_ID = os.environ.get("ADOPT_CLIENT_ID", "")
+ADOPT_CLIENT_SECRET = os.environ.get("ADOPT_CLIENT_SECRET", "")
+
+
+def _resolve_auth_mode() -> str:
+    """Pick the Tabby auth flow: explicit NOUI_TABBY_AUTH_MODE wins, else auto-detect."""
+    explicit = os.environ.get("NOUI_TABBY_AUTH_MODE", "").strip().lower()
+    if explicit:
+        return explicit
+    if ADOPT_API_URL and ADOPT_CLIENT_ID and ADOPT_CLIENT_SECRET:
+        return "platform_jwt"
+    return "agent_token"
+
+
 # auth_plan.json lives at the output root (one level up from noui_runtime/)
 _AUTH_PLAN_PATH = Path(__file__).resolve().parent.parent / "auth_plan.json"
 
@@ -100,8 +122,13 @@ def _load_auth_plan() -> dict:
         raise RuntimeError(f"Failed to read auth_plan.json: {{exc}}") from exc
 
 
-async def _get_agent_token() -> str:
-    """Exchange client credentials for a short-lived agent JWT."""
+_TOKEN_REFRESH_MARGIN_SECONDS = 60
+_token_cache: dict[str, tuple[str, float]] = {{}}
+_token_lock = asyncio.Lock()
+
+
+async def _get_agent_token() -> tuple[str, int]:
+    """Local/self-host flow: exchange Tabby agent-client credentials for an agent JWT."""
     if not TABBY_CLIENT_ID or not TABBY_CLIENT_SECRET:
         raise RuntimeError(
             "Missing TABBY_CLIENT_ID or TABBY_CLIENT_SECRET.\\n"
@@ -120,7 +147,86 @@ async def _get_agent_token() -> str:
         )
         resp.raise_for_status()
         data = resp.json()
-    return data.get("access_token") or data.get("token", "")
+    token = data.get("access_token") or data.get("token", "")
+    if not token:
+        raise RuntimeError(f"POST /auth/agent-token returned no token: {{data}}")
+    return token, int(data.get("expires_in", 3600))
+
+
+async def _get_platform_jwt() -> str:
+    """Cloud flow step 1: exchange platform client credentials for a platform JWT.
+
+    Calls the Adopt platform proxy (POST /v1/users/api-token), which returns a
+    Frontegg-signed JWT that Tabby validates via its registered IdP.
+    """
+    if not ADOPT_API_URL:
+        raise RuntimeError(
+            "Missing ADOPT_API_URL for platform_jwt auth mode.\\n"
+            "Set ADOPT_API_URL (e.g. https://api.adopt.ai) in noui/.env "
+            "or run `noui tabby setup --cloud`."
+        )
+    if not ADOPT_CLIENT_ID or not ADOPT_CLIENT_SECRET:
+        raise RuntimeError(
+            "Missing ADOPT_CLIENT_ID or ADOPT_CLIENT_SECRET for platform_jwt auth mode.\\n"
+            "Set these in noui/.env or run `noui tabby setup --cloud`."
+        )
+    url = f"{{ADOPT_API_URL}}/v1/users/api-token"
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            url,
+            json={{"client_id": ADOPT_CLIENT_ID, "secret": ADOPT_CLIENT_SECRET}},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    token = data.get("access_token", "")
+    if not token:
+        raise RuntimeError(f"Platform /v1/users/api-token returned no access_token: {{data}}")
+    return token
+
+
+async def _get_platform_tabby_token() -> tuple[str, int]:
+    """Cloud flow step 2: exchange the platform JWT for a Tabby JWT via token-exchange."""
+    platform_jwt = await _get_platform_jwt()
+    url = f"{{TABBY_API_HOST}}/auth/token-exchange"
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            url,
+            json={{
+                "subject_token": platform_jwt,
+                "subject_token_type": "oidc_jwt",
+            }},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    token = data.get("access_token", "")
+    if not token:
+        raise RuntimeError(f"Tabby /auth/token-exchange returned no access_token: {{data}}")
+    return token, int(data.get("expires_in", 3600))
+
+
+async def _get_tabby_bearer() -> str:
+    """Return a valid Tabby bearer token for the active auth mode, cached in-process.
+
+    Mode is resolved from NOUI_TABBY_AUTH_MODE (explicit) or auto-detected from the
+    presence of ADOPT_* platform credentials. The token is cached until shortly
+    before it expires to avoid re-running the exchange on every credential fetch.
+    """
+    mode = _resolve_auth_mode()
+    async with _token_lock:
+        cached = _token_cache.get(mode)
+        if cached is not None and cached[1] > time.monotonic():
+            return cached[0]
+        if mode == "platform_jwt":
+            token, ttl = await _get_platform_tabby_token()
+        elif mode == "agent_token":
+            token, ttl = await _get_agent_token()
+        else:
+            raise RuntimeError(
+                f"Unknown NOUI_TABBY_AUTH_MODE {{mode!r}} — "
+                f"expected 'agent_token' or 'platform_jwt'."
+            )
+        _token_cache[mode] = (token, time.monotonic() + max(0, ttl - _TOKEN_REFRESH_MARGIN_SECONDS))
+        return token
 
 
 async def _tabby_credentials(profile_slug: str) -> dict:
@@ -128,13 +234,13 @@ async def _tabby_credentials(profile_slug: str) -> dict:
 
     Uses profile_slug (not the DB UUID) for the credentials/request call.
     """
-    agent_token = await _get_agent_token()
+    bearer = await _get_tabby_bearer()
     url = f"{{TABBY_API_HOST}}/credentials/request"
     async with httpx.AsyncClient() as client:
         resp = await client.post(
             url,
             json={{"profile_id": profile_slug}},
-            headers={{"Authorization": f"Bearer {{agent_token}}"}},
+            headers={{"Authorization": f"Bearer {{bearer}}"}},
         )
         resp.raise_for_status()
         data = resp.json()

--- a/compiler/runtime/auth_adapter.py
+++ b/compiler/runtime/auth_adapter.py
@@ -28,8 +28,8 @@ def generate_auth_adapter(tabby_api_host: str) -> str:
       - "static_secret_header" : read secret from env var, construct header
 
     Args:
-        tabby_api_host: Default Tabby API host URL baked in as a fallback
-            (overridable via TABBY_API_HOST / TABBY_API_URL env var).
+        tabby_api_host: Default Tabby API base URL baked in as a fallback
+            (overridable via the TABBY_API_URL env var).
 
     Returns:
         Python source code string for noui_runtime/auth.py.
@@ -83,9 +83,7 @@ _env_file = _find_env_file()
 if _env_file is not None:
     load_dotenv(_env_file)
 
-TABBY_API_HOST = os.environ.get(
-    "TABBY_API_URL", os.environ.get("TABBY_API_HOST", "{tabby_api_host}")
-)
+TABBY_API_HOST = os.environ.get("TABBY_API_URL", "{tabby_api_host}")
 TABBY_CLIENT_ID = os.environ.get("TABBY_CLIENT_ID", "")
 TABBY_CLIENT_SECRET = os.environ.get("TABBY_CLIENT_SECRET", "")
 

--- a/compiler/runtime/execute_adapter.py
+++ b/compiler/runtime/execute_adapter.py
@@ -38,7 +38,7 @@ Why this module exists:
 
 Requires:
   - A running Tabby session for the target profile.
-  - TABBY_API_HOST / TABBY_API_URL env var (or .env) pointing to the Tabby API.
+  - TABBY_API_URL env var (or .env) pointing to the Tabby API.
   - Agent credentials (TABBY_CLIENT_ID / TABBY_CLIENT_SECRET) for token exchange.
 """
 from __future__ import annotations
@@ -87,11 +87,7 @@ _load_env()
 
 def _tabby_api_host() -> str:
     """Resolve the Tabby API base URL from environment."""
-    return (
-        os.environ.get("TABBY_API_HOST")
-        or os.environ.get("TABBY_API_URL")
-        or "http://localhost:8000"
-    )
+    return os.environ.get("TABBY_API_URL") or "http://localhost:8000"
 
 
 async def _get_agent_token() -> str:

--- a/runtime/tabby_auth.py
+++ b/runtime/tabby_auth.py
@@ -13,7 +13,7 @@ import urllib.request
 
 import httpx
 
-TABBY_API_HOST = os.environ.get("TABBY_API_HOST", "http://localhost:8080")
+TABBY_API_HOST = os.environ.get("TABBY_API_URL", "http://localhost:8080")
 
 
 async def get_auth_headers(profile_id: str) -> dict:

--- a/skills/noui-autopilot/SKILL.md
+++ b/skills/noui-autopilot/SKILL.md
@@ -17,7 +17,7 @@ The autopilot has two browser driver modes, selected automatically by environmen
 
 | Mode | When | Prerequisites |
 |------|------|---------------|
-| **Tabby** (headless, no extension) | `TABBY_API_HOST` + `TABBY_CLIENT_ID` + `TABBY_PROFILE_ID` are set | A healthy Tabby session for the profile. No Chrome extension needed. |
+| **Tabby** (headless, no extension) | `TABBY_API_URL` + `TABBY_CLIENT_ID` + `TABBY_PROFILE_ID` are set | A healthy Tabby session for the profile. No Chrome extension needed. |
 | **Extension** (local Chrome) | Tabby env vars not set | Chrome with the NoUI extension loaded and connected to `localhost:8002`. `/noui-setup` must be complete. |
 
 In Tabby mode, browser commands go to Tabby's `POST /execute/browser` endpoint — the worker drives Playwright directly. HAR capture is server-side (`har_start`/`har_stop`), no extension capture session needed. This enables headless/server-side autopilot for agent-builder pipelines.

--- a/skills/noui-generalize/SKILL.md
+++ b/skills/noui-generalize/SKILL.md
@@ -87,7 +87,7 @@ import asyncio, json, httpx, os
 
 async def test():
     # Get agent token
-    api = os.environ.get("TABBY_API_HOST", "http://localhost:8000")
+    api = os.environ.get("TABBY_API_URL", "http://localhost:8000")
     async with httpx.AsyncClient() as client:
         token_resp = await client.post(f"{api}/auth/agent-token", json={
             "client_id": os.environ["TABBY_CLIENT_ID"],

--- a/skills/noui-record-login/SKILL.md
+++ b/skills/noui-record-login/SKILL.md
@@ -11,7 +11,7 @@ Record a login flow for an authenticated app and register it with Tabby to produ
 
 All commands run from the `noui/` directory using `.venv/bin/python cli/main.py`.
 
-**Prerequisite:** `/noui-setup` must be complete — venv installed, `.env` configured with `ANTHROPIC_API_KEY`, `TABBY_API_HOST`, and `TABBY_ADMIN_TOKEN`, Chrome extension loaded.
+**Prerequisite:** `/noui-setup` must be complete — venv installed, `.env` configured with `ANTHROPIC_API_KEY`, `TABBY_API_URL`, and `TABBY_ADMIN_TOKEN`, Chrome extension loaded.
 
 ---
 
@@ -114,7 +114,7 @@ Check the output for:
 
 ## Step 6 — Register with Tabby
 
-Tabby must be reachable at `TABBY_API_HOST` (default `http://localhost:8080`) and `TABBY_ADMIN_TOKEN` must be set in `.env`.
+Tabby must be reachable at `TABBY_API_URL` (default `http://localhost:8080`) and `TABBY_ADMIN_TOKEN` must be set in `.env`.
 
 > **If Tabby is not yet running:** run `noui tabby start` then `noui tabby setup` (interactive) to start the service and provision agent credentials before registering. See `/noui-setup` for the full Tabby CLI reference.
 
@@ -169,7 +169,7 @@ Polls Tabby for up to 60 seconds waiting for the profile to reach HEALTHY state.
 | Symptom | Fix |
 |---|---|
 | Profile enters FAILED state | Re-record with slower, more deliberate interactions |
-| Timeout (60s) | Check Tabby logs; confirm `TABBY_API_HOST` is reachable |
+| Timeout (60s) | Check Tabby logs; confirm `TABBY_API_URL` is reachable |
 | Keepalive URL errors | The keepalive URL must return HTTP 200 when authenticated — redirect-only URLs are not valid |
 
 ---
@@ -199,7 +199,7 @@ Starts (or verifies) a persistent browser session worker for the registered prof
 | Symptom | Fix |
 |---|---|
 | `TABBY_CLIENT_ID` / `TABBY_CLIENT_SECRET` not set | Run `tabby setup` to provision agent credentials and write them to `.env` |
-| Worker starts but immediately exits | Check `.noui-backend.log`; confirm Tabby is reachable at `TABBY_API_HOST` |
+| Worker starts but immediately exits | Check `.noui-backend.log`; confirm Tabby is reachable at `TABBY_API_URL` |
 | Profile not found in cache | Confirm `login register` ran successfully — it adds the profile to the cache automatically |
 | `Credentials not found for k8s:secret/...` | Run `login credentials <bundle.json>` to set username/password |
 
@@ -289,7 +289,7 @@ Start
 | Symptom | Fix |
 |---|---|
 | Backend not running | `.venv/bin/python cli/main.py start` |
-| `Tabby API not reachable` | Confirm Tabby is running; check `TABBY_API_HOST` in `.env` |
+| `Tabby API not reachable` | Confirm Tabby is running; check `TABBY_API_URL` in `.env` |
 | Bundle has generator errors | Re-record with slower, explicit interactions; avoid rapid clicks |
 | App or Login process missing in extension | Confirm Step 2 ran successfully; check backend is running |
 | Low selector confidence in review | Re-record; interact with fields one at a time with visible focus |

--- a/skills/noui-record-workflow/SKILL.md
+++ b/skills/noui-record-workflow/SKILL.md
@@ -41,7 +41,7 @@ Playwright's `page.evaluate()`:
 
 1. The operation calls `execute_fetch(PROFILE_SLUG, url, method=..., headers=...)`.
 2. The adapter exchanges agent credentials for a bearer token, then POSTs to
-   `{TABBY_API_HOST}/execute/fetch` with the profile ID, URL, and parameters.
+   `{TABBY_API_URL}/execute/fetch` with the profile ID, URL, and parameters.
 3. The Tabby API resolves the profile to a healthy session, routes to the
    worker pod, and the worker runs `fetch(url, {credentials: 'include'})`
    inside the authenticated browser — so the real browser's cookies, TLS
@@ -72,7 +72,7 @@ from the MCP process to the Tabby API.
 ### Runtime prerequisites
 
 - Tabby must be running with a healthy session for the profile.
-- `TABBY_API_HOST`, `TABBY_CLIENT_ID`, and `TABBY_CLIENT_SECRET` must be set
+- `TABBY_API_URL`, `TABBY_CLIENT_ID`, and `TABBY_CLIENT_SECRET` must be set
   (in `noui/.env` or environment). If not, the first call raises a clear error.
 
 ### Escape hatch — `--execution-mode http`

--- a/skills/noui-setup/SKILL.md
+++ b/skills/noui-setup/SKILL.md
@@ -63,11 +63,27 @@ Open `.env` and fill in:
 | Variable | Required | Purpose |
 |---|---|---|
 | `ANTHROPIC_API_KEY` | Yes | Powers the MCP compiler's LLM calls |
-| `TABBY_API_HOST` | Auth flows only | Tabby endpoint (default: `http://localhost:8080`) |
-| `TABBY_ADMIN_TOKEN` | Auth flows only | Admin token for provisioning Tabby profiles |
+| `TABBY_API_URL` | Auth flows only | Tabby base URL (default: `http://localhost:8080`) |
+| `TABBY_ADMIN_TOKEN` | Local auth flows | Admin token for provisioning Tabby profiles (local only) |
 | `NOUI_PORT` | No | Backend port (default: `8002`) |
 
 If you only need unauthenticated app support, `ANTHROPIC_API_KEY` is the only required field.
+
+### Authenticated apps — two ways to reach Tabby
+
+NoUI picks the auth flow from `NOUI_TABBY_AUTH_MODE` (or auto-detects: `platform_jwt` when `ADOPT_*` are set, else `agent_token`).
+
+- **Local / self-host Tabby (`agent_token`):** `TABBY_API_URL` + `TABBY_ADMIN_TOKEN`, then `tabby setup` mints `TABBY_CLIENT_ID`/`TABBY_CLIENT_SECRET`.
+- **Cloud / staging Tabby (`platform_jwt`):** no admin token — you authenticate as yourself with a platform **Personal Access Token**:
+
+  | Variable | Purpose |
+  |---|---|
+  | `TABBY_API_URL` | Cloud/staging Tabby base URL |
+  | `ADOPT_API_URL` | Adopt platform base URL (e.g. `https://api.adopt.ai`) |
+  | `ADOPT_CLIENT_ID` / `ADOPT_CLIENT_SECRET` | A platform **PAT** — create at `app.adopt.ai/dashboard#/admin-box/` |
+  | `NOUI_TABBY_AUTH_MODE` | Optional; leave blank to auto-detect, or set `platform_jwt` |
+
+  Run `tabby setup --cloud` to verify the round-trip and write these to `.env`. Your org's **tenant must already exist in the cloud Tabby** (feature-flag-enabled orgs have it) or token-exchange fails with `Tenant not found`.
 
 ---
 
@@ -139,12 +155,15 @@ Start
 | `.venv/bin/python cli/main.py tabby status` | Check Docker Compose services and Tabby API liveness |
 | `.venv/bin/python cli/main.py tabby start` | Start Docker Compose infra and Tabby API |
 | `.venv/bin/python cli/main.py tabby stop [--infra]` | Stop the Tabby API (and optionally Docker Compose) |
-| `.venv/bin/python cli/main.py tabby setup` | Full Tabby provisioning: agent client + ServiceProfiles + write TABBY_* to `.env` |
+| `.venv/bin/python cli/main.py tabby setup` | Local Tabby provisioning: agent client + ServiceProfiles + write TABBY_* to `.env` |
+| `.venv/bin/python cli/main.py tabby setup --cloud` | Cloud/staging: verify the PAT→platform-JWT→Tabby round-trip and write ADOPT_*/TABBY_API_URL/`NOUI_TABBY_AUTH_MODE=platform_jwt` to `.env` (no admin token) |
 | `.venv/bin/python cli/main.py tabby session status` | Show browser session state for configured profiles |
 | `.venv/bin/python cli/main.py tabby session ensure` | Ensure a HEALTHY browser session exists |
 | `.venv/bin/python cli/main.py tabby session stop` | Stop the locally-running worker |
 
-> **Tabby setup** — for authenticated app workflows, run `tabby start` then `tabby setup` (interactive) to provision agent credentials and ServiceProfiles. This writes `TABBY_CLIENT_ID`, `TABBY_CLIENT_SECRET`, and `TABBY_API_URL` to `.env`. You still need `TABBY_ADMIN_TOKEN` (or `ADMIN_BOOTSTRAP_EMAIL`/`ADMIN_BOOTSTRAP_PASSWORD` in `tabby/.env.local`) for the provisioning step.
+> **Tabby setup (local)** — for authenticated app workflows against a local Tabby, run `tabby start` then `tabby setup` (interactive) to provision agent credentials and ServiceProfiles. This writes `TABBY_CLIENT_ID`, `TABBY_CLIENT_SECRET`, and `TABBY_API_URL` to `.env`. You still need `TABBY_ADMIN_TOKEN` (or `ADMIN_BOOTSTRAP_EMAIL`/`ADMIN_BOOTSTRAP_PASSWORD` in `tabby/.env.local`) for the provisioning step.
+>
+> **Tabby setup (cloud/staging)** — run `tabby setup --cloud` instead. No local Tabby or admin token: it uses a platform **PAT** (`ADOPT_CLIENT_ID`/`ADOPT_CLIENT_SECRET` from `app.adopt.ai/dashboard#/admin-box/`) to mint a platform JWT, exchanges it for a Tabby JWT, and on success writes `ADOPT_API_URL`, `TABBY_API_URL` and `NOUI_TABBY_AUTH_MODE=platform_jwt`. The generated MCP/skill runtime then authenticates the same way.
 
 ---
 

--- a/tests/test_auth_adapter.py
+++ b/tests/test_auth_adapter.py
@@ -142,9 +142,9 @@ class TestTabbyApiHostConfig:
 
     def test_env_var_override(self) -> None:
         src = _generated()
-        # Must prefer TABBY_API_URL or TABBY_API_HOST env vars
-        assert "TABBY_API_URL" in src or "TABBY_API_HOST" in src, (
-            "Generated auth.py must allow overriding TABBY_API_HOST via environment"
+        # Must read the single TABBY_API_URL env var
+        assert "TABBY_API_URL" in src, (
+            "Generated auth.py must allow overriding the Tabby base URL via TABBY_API_URL"
         )
 
 

--- a/tests/test_auth_adapter.py
+++ b/tests/test_auth_adapter.py
@@ -146,3 +146,201 @@ class TestTabbyApiHostConfig:
         assert "TABBY_API_URL" in src or "TABBY_API_HOST" in src, (
             "Generated auth.py must allow overriding TABBY_API_HOST via environment"
         )
+
+
+# ---------------------------------------------------------------------------
+# Cloud (platform_jwt) auth mode
+# ---------------------------------------------------------------------------
+
+import asyncio
+import os
+import tempfile
+import types
+from contextlib import contextmanager
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:  # pragma: no cover - trivial
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+@contextmanager
+def _generated_module(env: dict):
+    """Exec the generated auth.py into a fresh namespace under a controlled env.
+
+    Module-level code reads ADOPT_*/TABBY_* at import time and ``_resolve_auth_mode``
+    reads NOUI_TABBY_AUTH_MODE live, so the env stays set for the duration of the
+    ``with`` block (matching a real deployment where env is stable). A dummy
+    ``__file__`` keeps the .env walk-up from finding a real .env.
+    """
+    saved = dict(os.environ)
+    try:
+        for key in (
+            "NOUI_TABBY_AUTH_MODE",
+            "ADOPT_API_URL",
+            "ADOPT_CLIENT_ID",
+            "ADOPT_CLIENT_SECRET",
+            "TABBY_CLIENT_ID",
+            "TABBY_CLIENT_SECRET",
+            "TABBY_API_URL",
+            "TABBY_API_HOST",
+            "NOUI_ENV_FILE",
+        ):
+            os.environ.pop(key, None)
+        os.environ.update(env)
+        g: dict = {"__file__": os.path.join(tempfile.gettempdir(), "noui_gen_auth_test.py")}
+        exec(compile(_generated(), "<generated>", "exec"), g)
+        yield g
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
+@contextmanager
+def _fake_httpx(module: dict, responses: dict):
+    """Patch the generated module's ``httpx`` with a recorder. Yields the call log."""
+    log: list[tuple] = []
+
+    class _FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            log.append((url, json, headers))
+            for suffix, payload in responses.items():
+                if url.endswith(suffix):
+                    return _FakeResponse(payload)
+            raise AssertionError(f"unexpected POST url: {url}")
+
+    original = module["httpx"]
+    module["httpx"] = types.SimpleNamespace(AsyncClient=lambda *a, **k: _FakeAsyncClient())
+    try:
+        yield log
+    finally:
+        module["httpx"] = original
+
+
+class TestGeneratedSourceCompiles:
+    def test_compiles(self) -> None:
+        """f-string brace escaping must produce valid Python."""
+        compile(generate_auth_adapter("http://localhost:8080"), "<generated>", "exec")
+
+
+class TestAuthModeResolution:
+    def test_defaults_to_agent_token(self) -> None:
+        with _generated_module({}) as g:
+            assert g["_resolve_auth_mode"]() == "agent_token"
+
+    def test_auto_platform_jwt_when_adopt_creds_present(self) -> None:
+        with _generated_module(
+            {
+                "ADOPT_API_URL": "https://api.adopt.ai",
+                "ADOPT_CLIENT_ID": "c",
+                "ADOPT_CLIENT_SECRET": "s",
+            }
+        ) as g:
+            assert g["_resolve_auth_mode"]() == "platform_jwt"
+
+    def test_explicit_mode_overrides_autodetect(self) -> None:
+        with _generated_module(
+            {
+                "NOUI_TABBY_AUTH_MODE": "agent_token",
+                "ADOPT_API_URL": "https://api.adopt.ai",
+                "ADOPT_CLIENT_ID": "c",
+                "ADOPT_CLIENT_SECRET": "s",
+            }
+        ) as g:
+            assert g["_resolve_auth_mode"]() == "agent_token"
+
+
+class TestPlatformJwtFlow:
+    _CREDS = {
+        "credentials": {
+            "headers": [{"name": "Authorization", "value": "Bearer LIVE"}],
+            "cookies": [],
+        }
+    }
+
+    def test_two_hop_exchange_then_credentials(self) -> None:
+        env = {
+            "ADOPT_API_URL": "https://api.adopt.ai",
+            "ADOPT_CLIENT_ID": "cid",
+            "ADOPT_CLIENT_SECRET": "sec",
+            "TABBY_API_URL": "https://tabby.cloud",
+        }
+        responses = {
+            "/v1/users/api-token": {"access_token": "PLATFORM_JWT"},
+            "/auth/token-exchange": {"access_token": "TABBY_JWT", "expires_in": 3600},
+            "/credentials/request": self._CREDS,
+        }
+        with _generated_module(env) as g, _fake_httpx(g, responses) as log:
+            headers = asyncio.run(g["_tabby_credentials"]("my-profile"))
+
+        urls = [u for (u, _j, _h) in log]
+        assert urls == [
+            "https://api.adopt.ai/v1/users/api-token",
+            "https://tabby.cloud/auth/token-exchange",
+            "https://tabby.cloud/credentials/request",
+        ]
+        # token-exchange receives the platform JWT as an oidc_jwt subject token
+        _u, exchange_body, _h = log[1]
+        assert exchange_body == {"subject_token": "PLATFORM_JWT", "subject_token_type": "oidc_jwt"}
+        # credentials/request is authorized with the exchanged Tabby JWT
+        _u, _b, creds_headers = log[2]
+        assert creds_headers == {"Authorization": "Bearer TABBY_JWT"}
+        assert headers == {"Authorization": "Bearer LIVE"}
+
+    def test_agent_token_mode_does_not_call_token_exchange(self) -> None:
+        env = {
+            "TABBY_CLIENT_ID": "cid",
+            "TABBY_CLIENT_SECRET": "sec",
+            "TABBY_API_URL": "https://tabby.local",
+        }
+        responses = {
+            "/auth/agent-token": {"access_token": "AGENT_JWT", "expires_in": 3600},
+            "/credentials/request": self._CREDS,
+        }
+        with _generated_module(env) as g, _fake_httpx(g, responses) as log:
+            asyncio.run(g["_tabby_credentials"]("my-profile"))
+
+        urls = [u for (u, _j, _h) in log]
+        assert urls == [
+            "https://tabby.local/auth/agent-token",
+            "https://tabby.local/credentials/request",
+        ]
+        assert all("token-exchange" not in u for u in urls)
+
+    def test_token_is_cached_across_calls(self) -> None:
+        env = {
+            "ADOPT_API_URL": "https://api.adopt.ai",
+            "ADOPT_CLIENT_ID": "cid",
+            "ADOPT_CLIENT_SECRET": "sec",
+            "TABBY_API_URL": "https://tabby.cloud",
+        }
+        responses = {
+            "/v1/users/api-token": {"access_token": "PLATFORM_JWT"},
+            "/auth/token-exchange": {"access_token": "TABBY_JWT", "expires_in": 3600},
+            "/credentials/request": self._CREDS,
+        }
+        with _generated_module(env) as g, _fake_httpx(g, responses) as log:
+
+            async def _two() -> None:
+                await g["_tabby_credentials"]("p")
+                await g["_tabby_credentials"]("p")
+
+            asyncio.run(_two())
+
+        urls = [u for (u, _j, _h) in log]
+        # Token endpoints hit exactly once; credentials/request hit twice.
+        assert urls.count("https://api.adopt.ai/v1/users/api-token") == 1
+        assert urls.count("https://tabby.cloud/auth/token-exchange") == 1
+        assert urls.count("https://tabby.cloud/credentials/request") == 2

--- a/tests/test_auth_verifier.py
+++ b/tests/test_auth_verifier.py
@@ -1,0 +1,133 @@
+"""Tests for the cloud (platform_jwt) auth mode in compiler/mcp/auth_verifier.py.
+
+The verifier runs on the NoUI host during compile/diagnose. It must obtain a
+Tabby bearer either via the local agent-token flow or, in cloud, via the
+platform-JWT token-exchange flow — mirroring the generated runtime adapter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+if str(_NOUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(_NOUI_ROOT))
+
+from compiler.mcp import auth_verifier as av
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+@contextmanager
+def _fake_httpx(responses: dict):
+    """Patch auth_verifier.httpx with a recorder; yields the POST call log."""
+    log: list[tuple] = []
+
+    class _FakeAsyncClient:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            log.append((url, json, headers))
+            for suffix, payload in responses.items():
+                if url.endswith(suffix):
+                    return _FakeResponse(payload)
+            raise AssertionError(f"unexpected POST url: {url}")
+
+    original = av.httpx
+    av.httpx = types.SimpleNamespace(AsyncClient=lambda *a, **k: _FakeAsyncClient())
+    try:
+        yield log
+    finally:
+        av.httpx = original
+
+
+def _verifier(**kwargs) -> av.AuthVerifier:
+    return av.AuthVerifier(auth_plan={}, server_dir=".", **kwargs)
+
+
+class TestAuthModeResolution:
+    def test_defaults_to_agent_token(self) -> None:
+        v = _verifier()
+        # No platform creds and no explicit mode → local flow.
+        assert v._resolve_auth_mode() in {"agent_token", "platform_jwt"}
+        # Be explicit about the no-creds case by clearing any ambient platform creds.
+        v.adopt_api_url = v.adopt_client_id = v.adopt_client_secret = ""
+        v.auth_mode = ""
+        assert v._resolve_auth_mode() == "agent_token"
+
+    def test_auto_platform_jwt_when_adopt_creds_present(self) -> None:
+        v = _verifier(
+            adopt_api_url="https://api.adopt.ai", adopt_client_id="c", adopt_client_secret="s"
+        )
+        v.auth_mode = ""
+        assert v._resolve_auth_mode() == "platform_jwt"
+
+    def test_explicit_mode_overrides_autodetect(self) -> None:
+        v = _verifier(
+            auth_mode="agent_token",
+            adopt_api_url="https://api.adopt.ai",
+            adopt_client_id="c",
+            adopt_client_secret="s",
+        )
+        assert v._resolve_auth_mode() == "agent_token"
+
+
+class TestBearerFlow:
+    def test_platform_jwt_two_hop(self) -> None:
+        v = _verifier(
+            tabby_api_host="https://tabby.cloud",
+            adopt_api_url="https://api.adopt.ai",
+            adopt_client_id="cid",
+            adopt_client_secret="sec",
+            auth_mode="platform_jwt",
+        )
+        responses = {
+            "/v1/users/api-token": {"access_token": "PLATFORM_JWT"},
+            "/auth/token-exchange": {"access_token": "TABBY_JWT"},
+        }
+        with _fake_httpx(responses) as log:
+            bearer = asyncio.run(v._get_tabby_bearer())
+
+        assert bearer == "TABBY_JWT"
+        urls = [u for (u, _j, _h) in log]
+        assert urls == [
+            "https://api.adopt.ai/v1/users/api-token",
+            "https://tabby.cloud/auth/token-exchange",
+        ]
+        _u, exchange_body, _h = log[1]
+        assert exchange_body == {"subject_token": "PLATFORM_JWT", "subject_token_type": "oidc_jwt"}
+
+    def test_agent_token_flow(self) -> None:
+        v = _verifier(
+            tabby_api_host="https://tabby.local",
+            tabby_client_id="cid",
+            tabby_client_secret="sec",
+            auth_mode="agent_token",
+        )
+        with _fake_httpx({"/auth/agent-token": {"access_token": "AGENT_JWT"}}) as log:
+            bearer = asyncio.run(v._get_tabby_bearer())
+
+        assert bearer == "AGENT_JWT"
+        urls = [u for (u, _j, _h) in log]
+        assert urls == ["https://tabby.local/auth/agent-token"]
+        assert all("token-exchange" not in u for u in urls)

--- a/tests/test_cli_env.py
+++ b/tests/test_cli_env.py
@@ -33,17 +33,17 @@ class TestResolveTabbyApiHost:
         """Empty / whitespace-only values fall back to the default rather
         than producing an unusable bare 'http://' URL."""
         for raw in ("", "   ", "\t"):
-            assert resolve_tabby_api_host(env={"TABBY_API_HOST": raw}) == DEFAULT_TABBY_API_HOST
+            assert resolve_tabby_api_host(env={"TABBY_API_URL": raw}) == DEFAULT_TABBY_API_HOST
 
     def test_explicit_value_passes_through(self) -> None:
         assert (
-            resolve_tabby_api_host(env={"TABBY_API_HOST": "http://tabby.example:8080"})
+            resolve_tabby_api_host(env={"TABBY_API_URL": "http://tabby.example:8080"})
             == "http://tabby.example:8080"
         )
 
     def test_https_scheme_preserved(self) -> None:
         assert (
-            resolve_tabby_api_host(env={"TABBY_API_HOST": "https://tabby.example"})
+            resolve_tabby_api_host(env={"TABBY_API_URL": "https://tabby.example"})
             == "https://tabby.example"
         )
 
@@ -52,31 +52,30 @@ class TestResolveTabbyApiHost:
         We normalise this so urllib.request doesn't raise an opaque
         ``unknown url type`` error downstream."""
         assert (
-            resolve_tabby_api_host(env={"TABBY_API_HOST": "localhost:8080"})
+            resolve_tabby_api_host(env={"TABBY_API_URL": "localhost:8080"})
             == "http://localhost:8080"
         )
         assert (
-            resolve_tabby_api_host(env={"TABBY_API_HOST": "10.0.0.5:9000"})
-            == "http://10.0.0.5:9000"
+            resolve_tabby_api_host(env={"TABBY_API_URL": "10.0.0.5:9000"}) == "http://10.0.0.5:9000"
         )
 
     def test_trailing_slash_stripped(self) -> None:
         """Callers concatenate path strings starting with '/', so the host
         must not end with one — keeps the existing _tabby_http() shape valid."""
         assert (
-            resolve_tabby_api_host(env={"TABBY_API_HOST": "http://localhost:8080/"})
+            resolve_tabby_api_host(env={"TABBY_API_URL": "http://localhost:8080/"})
             == "http://localhost:8080"
         )
 
     def test_surrounding_whitespace_stripped(self) -> None:
         """Common typo when copy-pasting from docs."""
         assert (
-            resolve_tabby_api_host(env={"TABBY_API_HOST": "  http://localhost:8080  "})
+            resolve_tabby_api_host(env={"TABBY_API_URL": "  http://localhost:8080  "})
             == "http://localhost:8080"
         )
 
     def test_defaults_to_os_environ(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("TABBY_API_HOST", "http://from-os-env:1234")
+        monkeypatch.setenv("TABBY_API_URL", "http://from-os-env:1234")
         assert resolve_tabby_api_host() == "http://from-os-env:1234"
 
     def test_default_constant_value(self) -> None:
@@ -92,8 +91,8 @@ class TestResolveTabbyApiHost:
 
 class TestLoadEnvFiles:
     def test_populates_missing_keys(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        (tmp_path / ".env").write_text("TABBY_API_HOST=http://from-dotenv:8090\n")
-        monkeypatch.delenv("TABBY_API_HOST", raising=False)
+        (tmp_path / ".env").write_text("TABBY_API_URL=http://from-dotenv:8090\n")
+        monkeypatch.delenv("TABBY_API_URL", raising=False)
         load_env_files(tmp_path)
         assert resolve_tabby_api_host() == "http://from-dotenv:8090"
 
@@ -101,9 +100,9 @@ class TestLoadEnvFiles:
         """``override=False`` semantics — if the user already exported the
         variable in their shell, the dotenv value must NOT clobber it. This
         matches backend/config.py and is the principle of least surprise for
-        anyone running ``TABBY_API_HOST=... noui ...``."""
-        (tmp_path / ".env").write_text("TABBY_API_HOST=http://from-dotenv:8090\n")
-        monkeypatch.setenv("TABBY_API_HOST", "http://from-shell:7000")
+        anyone running ``TABBY_API_URL=... noui ...``."""
+        (tmp_path / ".env").write_text("TABBY_API_URL=http://from-dotenv:8090\n")
+        monkeypatch.setenv("TABBY_API_URL", "http://from-shell:7000")
         load_env_files(tmp_path)
         assert resolve_tabby_api_host() == "http://from-shell:7000"
 
@@ -112,7 +111,7 @@ class TestLoadEnvFiles:
     ) -> None:
         """When no .env exists, nothing is added to os.environ and the
         default is used. Nothing should raise."""
-        monkeypatch.delenv("TABBY_API_HOST", raising=False)
+        monkeypatch.delenv("TABBY_API_URL", raising=False)
         load_env_files(tmp_path)
         assert resolve_tabby_api_host() == DEFAULT_TABBY_API_HOST
 
@@ -121,8 +120,8 @@ class TestLoadEnvFiles:
     ) -> None:
         """If python-dotenv is not installed, the helper must silently
         no-op rather than crash the CLI on import."""
-        (tmp_path / ".env").write_text("TABBY_API_HOST=http://from-dotenv:8090\n")
-        monkeypatch.delenv("TABBY_API_HOST", raising=False)
+        (tmp_path / ".env").write_text("TABBY_API_URL=http://from-dotenv:8090\n")
+        monkeypatch.delenv("TABBY_API_URL", raising=False)
 
         real_import = (
             __builtins__["__import__"]
@@ -143,8 +142,8 @@ class TestLoadEnvFiles:
     def test_idempotent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Calling twice in the same process must not raise or change the
         resolved value."""
-        (tmp_path / ".env").write_text("TABBY_API_HOST=http://from-dotenv:8090\n")
-        monkeypatch.delenv("TABBY_API_HOST", raising=False)
+        (tmp_path / ".env").write_text("TABBY_API_URL=http://from-dotenv:8090\n")
+        monkeypatch.delenv("TABBY_API_URL", raising=False)
         load_env_files(tmp_path)
         load_env_files(tmp_path)
         assert resolve_tabby_api_host() == "http://from-dotenv:8090"

--- a/tests/test_cli_tabby.py
+++ b/tests/test_cli_tabby.py
@@ -273,3 +273,96 @@ class TestLoginRegisterOutput:
         assert "my-app" in tabby_line
         assert "db-uuid-2222" not in tabby_line
         assert "ServiceProfile DB ID" in out
+
+
+# ---------------------------------------------------------------------------
+# 5. tabby setup --cloud (platform-JWT token-exchange onboarding)
+# ---------------------------------------------------------------------------
+
+
+class TestTabbySetupCloud:
+    """`tabby setup --cloud` verifies the token-exchange round-trip then writes .env."""
+
+    def _args(self, tmp_path: Path, **over: object) -> SimpleNamespace:
+        base: dict = {
+            "cloud": True,
+            "adopt_api_url": "https://api.adopt.ai",
+            "adopt_client_id": "cid",
+            "adopt_client_secret": "sec",
+            "tabby_url": "https://tabby.cloud",
+            "env_file": str(tmp_path / ".env"),
+            "profiles": None,
+            "force": False,
+        }
+        base.update(over)
+        return SimpleNamespace(**base)
+
+    @staticmethod
+    def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+        for key in (
+            "ADOPT_API_URL",
+            "ADOPT_CLIENT_ID",
+            "ADOPT_CLIENT_SECRET",
+            "TABBY_API_URL",
+            "TABBY_API_HOST",
+            "NOUI_TABBY_AUTH_MODE",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+    def test_writes_env_on_successful_exchange(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._clear_env(monkeypatch)
+
+        def fake_urlopen(req, *_a, **_k):
+            url = req.full_url
+            if url.endswith("/v1/users/api-token"):
+                return _FakeResponse({"access_token": "PLATFORM_JWT"})
+            if url.endswith("/auth/token-exchange"):
+                return _FakeResponse({"access_token": "TABBY_JWT"})
+            raise AssertionError(f"unexpected url {url}")
+
+        with _patched_urlopen(side_effect=fake_urlopen):
+            rc = cli_main.cmd_tabby_setup(self._args(tmp_path))
+
+        assert rc == 0
+        env = (tmp_path / ".env").read_text()
+        assert "NOUI_TABBY_AUTH_MODE=platform_jwt" in env
+        assert "TABBY_API_URL=https://tabby.cloud" in env
+        assert "ADOPT_API_URL=https://api.adopt.ai" in env
+        assert "ADOPT_CLIENT_ID=cid" in env
+        assert "ADOPT_CLIENT_SECRET=sec" in env
+
+    def test_missing_creds_returns_error_and_writes_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._clear_env(monkeypatch)
+        args = self._args(
+            tmp_path,
+            adopt_api_url=None,
+            adopt_client_id=None,
+            adopt_client_secret=None,
+            tabby_url=None,
+        )
+        rc = cli_main.cmd_tabby_setup(args)
+        assert rc == 1
+        assert not (tmp_path / ".env").exists()
+
+    def test_token_exchange_failure_returns_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._clear_env(monkeypatch)
+
+        def fake_urlopen(req, *_a, **_k):
+            url = req.full_url
+            if url.endswith("/v1/users/api-token"):
+                return _FakeResponse({"access_token": "PLATFORM_JWT"})
+            if url.endswith("/auth/token-exchange"):
+                raise _make_http_error(401, '{"detail":"No registered IdP for issuer"}')
+            raise AssertionError(f"unexpected url {url}")
+
+        with _patched_urlopen(side_effect=fake_urlopen):
+            rc = cli_main.cmd_tabby_setup(self._args(tmp_path))
+
+        assert rc == 1
+        assert not (tmp_path / ".env").exists()


### PR DESCRIPTION
## What & why

Lets NoUI authenticate against a **cloud/staging Tabby** (not just a local `localhost:8080` instance) so builders can record/generate/verify tools against hosted Tabby.

NoUI runs as a **local, dev-time authoring tool**, so the developer authenticates **as themselves** with a platform **Personal Access Token** (from `app.adopt.ai/dashboard#/admin-box/`):

```
PAT (client_id/secret) → adoptwebui POST /v1/users/api-token → platform JWT
                       → Tabby POST /auth/token-exchange (oidc_jwt) → Tabby JWT
                       → POST /credentials/request
```

This is the machine-credential twin of the user-JWT exchange `adoptwebui` already runs in production, so **Tabby needs no code change** — the single global Frontegg IdP already trusts the issuer. The PAT carries a real `userId`, so Tabby's `owner_user_id` resolves to the real developer (no anonymous service identity).

## Changes

- **Generated runtime** (`compiler/runtime/auth_adapter.py`): new `platform_jwt` mode (two-hop exchange + in-process bearer caching) alongside the unchanged local `agent_token` flow. Mode auto-detects from `ADOPT_*` creds or is forced via `NOUI_TABBY_AUTH_MODE`. `/credentials/request` is unchanged.
- **Verifier** (`compiler/mcp/auth_verifier.py`): same mode switch, so the compile/diagnose loop works against cloud; mode-aware `NEEDS_SECRET` guidance.
- **CLI**: `noui tabby setup --cloud` verifies the PAT→platform-JWT→Tabby round-trip and writes `.env` — no local Tabby or admin token required.
- **Env consolidation (breaking)**: `TABBY_API_HOST` and `TABBY_API_URL` collapsed into a single **`TABBY_API_URL`** everywhere (no fallback).
- **Docs**: `.env.example`, `noui-setup` skill (cloud flow, PAT, the "tenant must exist" gotcha), README, CHANGELOG; stale `TABBY_API_HOST` references fixed across skills.

## ⚠️ Breaking change

`TABBY_API_HOST` is **no longer read**. Rename it to `TABBY_API_URL` in any `.env`/environment.

## Scope / deferred

- **Single identity = the developer** (dev-time tool). Production multi-user auth (deployed agents serving end-users) stays the platform's job. Multi-user passthrough / `agent_assertion` are out of scope.
- **Provisioning** is reframed as a follow-on: NoUI should emit/update Tabby **App Templates**; Tabby then auto-provisions app/profile/session via `autoProvisionFromTemplate` inside `/credentials/request`. The org **tenant must already exist** in the cloud Tabby (governance gate).
- Local default kept; legacy `runtime/tabby_auth.py` (deprecated route) left untouched.

## Validation

- `pytest`: **613 passed / 6 skipped**; ruff clean.
- Tests added: compile guard, mode resolution, two-hop platform flow, agent-flow-unchanged, caching (runtime); mode + both bearer flows (verifier); CLI success / missing-creds / exchange-failure.
- **Live proof (staging):** against `tabby-api.adoptai.dev` + staging adopt-backend with a feature-flag-enabled account, the full token chain works — `/v1/users/api-token` returns a JWT with real `userId`; `/auth/token-exchange` returns a federated Tabby JWT with `owner_user_id` = that user, `tenant_id` = the platform orgId, `role=Admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)