### PR TITLE
fix(noui): inject static_secret_header auth in tabby-mode skill ops

### DIFF
--- a/skills/noui/noui_core/compile/operation_generator.py
+++ b/skills/noui/noui_core/compile/operation_generator.py
@@ -45,6 +45,13 @@ def _render_skill_operation_tabby(td: dict, *, auth_plan: dict) -> str:
 
     profile_slug = auth_plan.get("profile_slug", "") if auth_plan else ""
 
+    # A static-secret-header app (Authorization/x-api-key, no login cookies) gets
+    # no auth from the browser session's credentials:'include', so the op must
+    # inject the secret header itself via resolve_auth() — the same wiring the
+    # http mode uses. (tabby_credentials apps ride their session cookies and need
+    # no injection here.)
+    needs_static_auth = bool(auth_plan and auth_plan.get("strategy") == "static_secret_header")
+
     static_headers = {
         h["name"]: h["value"] for h in request_headers if h.get("name") and h.get("value")
     }
@@ -85,6 +92,10 @@ def _render_skill_operation_tabby(td: dict, *, auth_plan: dict) -> str:
         "    sys.path.insert(0, str(_SKILL_ROOT))",
         "",
         "from noui_runtime.execute import execute_fetch  # noqa: E402",
+    ]
+    if needs_static_auth:
+        lines.append("from noui_runtime.auth import resolve_auth  # noqa: E402")
+    lines += [
         "",
         f"BASE_URL = {base_url!r}",
         f"PROFILE_SLUG = {profile_slug!r}",
@@ -112,7 +123,12 @@ def _render_skill_operation_tabby(td: dict, *, auth_plan: dict) -> str:
         _ = content_type
         lines.append(f"    body = {{{body_dict}}}")
 
-    if static_headers:
+    if needs_static_auth and static_headers:
+        lines.append(f"    _recorded = {static_headers!r}")
+        lines.append("    headers = {**_recorded, **await resolve_auth()}")
+    elif needs_static_auth:
+        lines.append("    headers = await resolve_auth()")
+    elif static_headers:
         lines.append(f"    headers = {static_headers!r}")
     else:
         lines.append("    headers: dict[str, str] | None = None")


### PR DESCRIPTION
## Summary
Tabby-mode skill operations never called `resolve_auth()`, so a **static-secret-header** app (e.g. an `Authorization`/`x-api-key` API with no login cookies) compiled to operations with **no auth header**. The generated `/execute/fetch` call ran with `credentials:'include'` only and `401`'d — there is no session cookie to carry. Only `http` mode wired the secret in.

This fixes `_render_skill_operation_tabby` to inject `resolve_auth()` when `auth_plan.strategy == "static_secret_header"`, merging it over any recorded headers (`headers = {**recorded, **await resolve_auth()}`) — mirroring the existing `http`-mode behavior.

Cookie-session (`tabby_credentials`) apps are **unaffected**: they continue to ride the browser session and inject nothing extra here.

## Why
Discovered while compiling a Skill for a static-API-key service (a simulated bank: `Authorization: Bearer <key>`, no `Set-Cookie`). The compiled tabby-mode op shipped `headers = None` and 401'd, even though `auth_plan.json` correctly resolved to `static_secret_header`.

## Test plan
- [x] `pytest tests/` — all 417 pass
- [x] End-to-end against a live static-key API: registered profile → scaled session → ran the generated op as a subprocess → op resolved `Bearer ${SECRET}`, called `/execute/fetch`, returned authenticated `200` data
- [x] Confirmed cookie-session (`tabby_credentials`) ops are byte-for-byte unchanged

Made with [Cursor](https://cursor.com)