### PR TITLE
noui: VNC pod-ready wait + register/secret doc corrections

### DIFF
--- a/skills/noui-harness/SKILL.md
+++ b/skills/noui-harness/SKILL.md
@@ -133,14 +133,20 @@ with the compiled directory:
 install_skill(skill_dir="/workspace/noui/workbench/skills/<app>")
 ```
 
-It writes the skill to the org catalog (listable on a new turn, ~30s) and returns the
-`${SECRET:...}` name(s) the skill's operations need. **Relay those to the user**: an org
-admin must register each secret in the org secret store before the skill can actually
-run — that registration is the only step between "installed" and "runnable" (the skill
-auth itself is the signed-in user's session; the secret is any extra static API key).
+It writes the skill to the org catalog (listable on a new turn, ~30s). A skill whose
+auth is the signed-in user's **session** (the usual login-recording case — e.g. a
+Tabby `profile_slug` was bound) needs **nothing more**: it is runnable as soon as it's
+listed. Do **not** invent a secret-registration step for these.
 
-Then report the deliverable: the profile slug, the compiled skill path, the installed
-skill name, and the required secret(s).
+`install_skill` returns a `${SECRET:...}` name list, but it is populated **only** when
+the API needs an *extra static secret* (an API key sent on every request, on top of —
+or instead of — the session). **Only if that list is non-empty**, relay it to the user:
+an org admin must register each named secret in the org secret store before the skill
+can run. **If it's empty (the common session-auth case), there is no secret step — say
+nothing about secrets.**
+
+Then report the deliverable: the profile slug, the compiled skill path, and the
+installed skill name — plus the required secret(s) only if `install_skill` returned any.
 
 ## Troubleshooting
 

--- a/skills/noui/noui_core/activate/register.py
+++ b/skills/noui/noui_core/activate/register.py
@@ -5,8 +5,12 @@ Creates an Application + STAGING ServiceProfile from a compiled login result
 STAGING → CANARY → ACTIVE so the runtime resolver (ACTIVE/CANARY only) can
 resolve the profile at the first tool call.
 
-Registration of apps/profiles requires an admin token (POST /apps,
-POST /admin/profiles). It is read from TABBY_ADMIN_TOKEN.
+Registration (POST /apps, POST /admin/profiles, profile promote) is gated by
+Tabby at the **Editor** role — NOT Admin; the /admin/ prefix is a URL namespace,
+not an admin-credential gate. In local/self-host mode the bearer is read from
+TABBY_ADMIN_TOKEN (any Editor+ token works); in broker mode the sandbox sends its
+capability and the broker forwards the user's own federated (Editor) bearer. The
+only genuinely Admin-gated bit is the cross-tenant ``tenant_id`` override.
 """
 
 from __future__ import annotations
@@ -18,9 +22,10 @@ from noui_core.config import settings
 
 
 def resolve_admin_token() -> str:
-    # In broker mode the sandbox holds no admin credential — it sends the opaque
-    # per-conversation capability token and the broker decides whether to inject
-    # admin privileges for register/promote paths (broker v2). See the broker plan.
+    # In broker mode the sandbox holds no Tabby credential — it sends the opaque
+    # per-conversation capability token; the broker swaps it for the user's own
+    # federated (Editor-role) bearer and forwards. No admin privileges are
+    # injected: register/promote are Editor-gated, and the broker allowlists them.
     if settings.broker_mode():
         if not settings.broker_token:
             raise RuntimeError(

--- a/skills/noui/noui_core/capture/recording.py
+++ b/skills/noui/noui_core/capture/recording.py
@@ -11,6 +11,7 @@ noui_core.capture.autopilot.
 from __future__ import annotations
 
 import os
+import time
 import urllib.parse
 
 from noui_core import tabby_client
@@ -93,6 +94,36 @@ def _stream_token(vnc_url: str) -> str:
     return urllib.parse.parse_qs(frag).get("token", [""])[0]
 
 
+def _wait_for_pod_ready(
+    session_id: str, stream_token: str, *, attempts: int = 30, interval: float = 2.0
+) -> str:
+    """Block until the recording session's pod leaves ``STARTING``.
+
+    The viewer shows "Disconnected" while the pod boots — noVNC (port 6080) isn't
+    listening yet. ``GET /vnc/{id}/panel-state`` reads from the DB (not the pod),
+    so it answers even during ``STARTING``; we poll it and return as soon as the
+    state is anything else (``HEALTHY`` / ``LOGIN_NEEDED`` / ``FAILED`` /
+    ``TERMINATED``). At that point the pod is up, so the link we mint next opens a
+    viewer that connects immediately. The ~60s cap (30 × 2s) covers worst-case
+    startup; any non-``STARTING`` state — including a dead one — exits the loop,
+    so we never hang (a dead session is then caught by minting and refreshed).
+
+    Returns the last observed state ("" if it never became readable).
+    """
+    state = ""
+    for _ in range(attempts):
+        try:
+            state = tabby_client.get_recording_panel_state(session_id, stream_token).get(
+                "state", ""
+            )
+        except Exception:
+            state = ""
+        if state and state != "STARTING":
+            return state
+        time.sleep(interval)
+    return state
+
+
 def provision_live_link(
     mode: str,
     url: str = "",
@@ -101,13 +132,18 @@ def provision_live_link(
     from_session: str = "",
 ) -> dict:
     """Provision a recording session and return its payload with a ``login_url``
-    that is **verified live** — never a stale/dead link.
+    that is **verified live** — never a stale/dead link, and never handed over
+    before the pod can actually serve the viewer.
 
-    We never poll through browser startup: a live-but-still-``STARTING`` session
-    is returned immediately (the viewer reconnects on its own once the pod is up).
-    What we DO guard against is handing over a *dead* session. Minting the short
-    link is the liveness check — Tabby 400s ("Cannot open stream") on a
-    TERMINATED session. If that happens we refresh rather than fall back to the
+    First we wait out pod startup: a freshly-provisioned session is ``STARTING``
+    for ~20-40s while the browser pod boots and noVNC starts listening, and the
+    viewer shows "Disconnected" the whole time. ``_wait_for_pod_ready`` polls
+    ``panel-state`` (a DB read, safe during ``STARTING``) until the state flips,
+    so the link we surface opens a viewer that connects right away.
+
+    Then we guard against handing over a *dead* session. Minting the short link
+    is the liveness check — Tabby 400s ("Cannot open stream") on a TERMINATED
+    session. If that happens we refresh rather than fall back to the
     (also-dead) raw ``vnc_url``:
 
       1. ``restart`` the session in place (keeps the same ``session_id``), then
@@ -120,16 +156,17 @@ def provision_live_link(
     token = resolve_agent_token()
     result = start(mode, url, profile=profile, from_session=from_session)
 
+    stream_token = _stream_token(result.get("vnc_url", ""))
+    sid = result.get("session_id", "")
+    if stream_token and sid:
+        _wait_for_pod_ready(sid, stream_token)
+
     try:
-        result["login_url"] = tabby_client.create_short_link(
-            result.get("session_id", ""), token, mode="recording"
-        )
+        result["login_url"] = tabby_client.create_short_link(sid, token, mode="recording")
         return result
     except RuntimeError:
         pass  # session can't serve a viewer → stale; refresh below.
 
-    stream_token = _stream_token(result.get("vnc_url", ""))
-    sid = result.get("session_id", "")
     if stream_token and tabby_client.restart_recording_session(sid, stream_token):
         try:
             result["login_url"] = tabby_client.create_short_link(sid, token, mode="recording")

--- a/skills/noui/noui_core/tabby_client.py
+++ b/skills/noui/noui_core/tabby_client.py
@@ -6,7 +6,11 @@ Tabby Application + ServiceProfile records via urllib.request.
 
 Configuration is read from noui_core.config.settings:
     settings.tabby_api_host   — e.g. "http://localhost:8080"
-    settings.tabby_admin_token — bearer token for /admin/* endpoints
+    settings.tabby_admin_token — bearer for register/promote in local/self-host
+                                 mode. Those endpoints are Editor-gated, NOT
+                                 Admin-only, despite the /admin/ path prefix (the
+                                 name is conventional); broker mode forwards the
+                                 user's own federated bearer instead.
 """
 
 from __future__ import annotations

--- a/tests/test_recording_provision.py
+++ b/tests/test_recording_provision.py
@@ -16,6 +16,11 @@ def test_live_on_first_try_surfaces_link_without_refresh():
         patch.object(recording, "resolve_agent_token", return_value="agent"),
         patch.object(recording, "start", return_value=_session("s1")) as start,
         patch.object(
+            recording.tabby_client,
+            "get_recording_panel_state",
+            return_value={"state": "HEALTHY"},
+        ),
+        patch.object(
             recording.tabby_client, "create_short_link", return_value="https://t/s/aaa"
         ) as sl,
     ):
@@ -26,11 +31,43 @@ def test_live_on_first_try_surfaces_link_without_refresh():
     assert sl.call_count == 1
 
 
+def test_waits_through_starting_then_surfaces_link():
+    # pod is STARTING twice, then HEALTHY — we poll until it leaves STARTING
+    # before minting the link, and never sleep once it has.
+    with (
+        patch.object(recording, "resolve_agent_token", return_value="agent"),
+        patch.object(recording, "start", return_value=_session("s1")),
+        patch.object(
+            recording.tabby_client,
+            "get_recording_panel_state",
+            side_effect=[
+                {"state": "STARTING"},
+                {"state": "STARTING"},
+                {"state": "HEALTHY"},
+            ],
+        ) as panel,
+        patch.object(
+            recording.tabby_client, "create_short_link", return_value="https://t/s/aaa"
+        ),
+        patch.object(recording.time, "sleep") as sleep,
+    ):
+        out = recording.provision_live_link("workflow", "https://x")
+    assert out["login_url"] == "https://t/s/aaa"
+    assert "refreshed" not in out
+    assert panel.call_count == 3  # polled until it left STARTING
+    assert sleep.call_count == 2  # slept once per STARTING observation, not after
+
+
 def test_stale_session_is_restarted_in_place():
     # short-link 400s on the dead session, restart revives it, second mint works.
     with (
         patch.object(recording, "resolve_agent_token", return_value="agent"),
         patch.object(recording, "start", return_value=_session("s1")) as start,
+        patch.object(
+            recording.tabby_client,
+            "get_recording_panel_state",
+            return_value={"state": "TERMINATED"},
+        ),
         patch.object(
             recording.tabby_client,
             "create_short_link",
@@ -52,6 +89,11 @@ def test_dead_session_reprovisions_when_restart_fails():
     with (
         patch.object(recording, "resolve_agent_token", return_value="agent"),
         patch.object(recording, "start", side_effect=[_session("s1"), _session("s2")]) as start,
+        patch.object(
+            recording.tabby_client,
+            "get_recording_panel_state",
+            return_value={"state": "TERMINATED"},
+        ),
         patch.object(
             recording.tabby_client,
             "create_short_link",

--- a/tests/test_recording_provision.py
+++ b/tests/test_recording_provision.py
@@ -46,9 +46,7 @@ def test_waits_through_starting_then_surfaces_link():
                 {"state": "HEALTHY"},
             ],
         ) as panel,
-        patch.object(
-            recording.tabby_client, "create_short_link", return_value="https://t/s/aaa"
-        ),
+        patch.object(recording.tabby_client, "create_short_link", return_value="https://t/s/aaa"),
         patch.object(recording.time, "sleep") as sleep,
     ):
         out = recording.provision_live_link("workflow", "https://x")


### PR DESCRIPTION
Three related fixes to the NoUI harness capture/activate flow.

### 1. VNC pod-ready wait (`28bb592`)
`provision_live_link` returned the short VNC link the moment the recording session's DB row existed — while the worker pod was still `STARTING` and noVNC (6080) wasn't listening — so the viewer opened on "Disconnected" and leaned on flaky auto-retry. Now polls `GET /vnc/{id}/panel-state` (a DB read, safe during `STARTING`) until the pod leaves `STARTING` before minting the link (`_wait_for_pod_ready`, 30×2s cap). Any non-`STARTING` state (incl. `FAILED`/`TERMINATED`) exits the loop, so a dead session still falls through to the existing restart→reprovision refresh.

### 2. "admin token required" doc corrections (`ac85e14`)
`POST /apps`, `/admin/profiles`, and profile promote are gated by Tabby at the **Editor** role, not Admin — the `/admin/` prefix is a URL namespace, not an admin-credential gate. Corrected the stale docstrings in `register.py` and `tabby_client.py` (the cross-tenant `tenant_id` override notes — genuinely Admin-only — are left as-is).

### 3. Conditional secret-registration step (`8ef9daf`)
`noui-harness/SKILL.md` Step C framed secret registration unconditionally, so the agent emitted a spurious "Secret registration — org admin must register secret" step for a session-cookie skill (seen on the Airbnb skill) that has **no** secret. Gated the guidance on a non-empty `${SECRET:...}` list returned by `install_skill`.

### Validation
- `tests/test_recording_provision.py` — 4 pass (incl. new STARTING→HEALTHY poll test)
- `tests/test_activate_register.py` — 6 pass

### Related
Pairs with adoptai-workflows PR for the broker allowlist (`fix/noui-broker-allowlist-register`) — that PR lets the in-sandbox register paths reach Tabby; the doc fixes here explain why no admin credential is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
