### PR TITLE
fix(noui-harness-md): only emit ${SECRET:...} prose when the skill has secrets

### DIFF
--- a/skills/noui/noui_core/compile/harness_md_generator.py
+++ b/skills/noui/noui_core/compile/harness_md_generator.py
@@ -288,12 +288,15 @@ def _render_body(
     sections.append("## Running operations")
     sections.append("")
     if authed:
+        # Only mention ${SECRET:...} headers when the skill actually has them.
+        # For a session-only skill there are none, and emitting the example token
+        # in prose is both misleading and a false-positive for any secret scanner.
+        secret_clause = " (and passing any `${SECRET:...}` headers verbatim)" if secrets else ""
         sections.append(
             "For each operation below, call the `call_web_api` tool with the shown payload, "
-            "substituting `<param>` placeholders (and passing any `${SECRET:...}` headers "
-            "verbatim). Text/JSON responses come back inline, truncated past "
-            f"~{_RESULT_CAP_CHARS_DEFAULT:,} characters — prefer narrow or paginated queries "
-            "over one huge fetch."
+            "substituting `<param>` placeholders" + secret_clause + ". Text/JSON responses "
+            f"come back inline, truncated past ~{_RESULT_CAP_CHARS_DEFAULT:,} characters — "
+            "prefer narrow or paginated queries over one huge fetch."
         )
         sections.append("")
         sections.append(

--- a/tests/test_harness_md_secret_prose.py
+++ b/tests/test_harness_md_secret_prose.py
@@ -1,0 +1,50 @@
+"""Regression: the generated harness SKILL.md must only mention ${SECRET:...}
+when the skill actually needs a static secret. For a session-auth skill the
+prose example used to leak a bare ${SECRET:...} token, which downstream secret
+scanners (install_skill) mistook for a required secret named '...'."""
+
+from noui_core.compile.harness_md_generator import render_harness_skill_md
+
+_TOOL_DEFS = [
+    {
+        "name": "create_api_v3_stayssearch",
+        "method": "GET",
+        "path": "/api/v3/StaysSearch",
+        "base_url": "https://www.airbnb.com",
+        "description": "Search stays",
+    }
+]
+
+_SESSION_PLAN = {"strategy": "tabby_credentials", "fallbacks": []}
+_STATIC_PLAN = {
+    "strategy": "static_secret_header",
+    "fallbacks": [
+        {
+            "type": "static_secret_header",
+            "header": "Authorization",
+            "value_template": "Bearer ${AIRBNB_API_KEY}",
+            "secret_env_var": "AIRBNB_API_KEY",
+        }
+    ],
+}
+
+
+def _render(plan):
+    return render_harness_skill_md(
+        skill_id="airbnb",
+        app_name="Airbnb",
+        workflow_name="search",
+        tool_defs=_TOOL_DEFS,
+        auth_plan=plan,
+        profile_slug="airbnb",
+    )
+
+
+def test_session_auth_skill_md_has_no_secret_placeholder():
+    md = _render(_SESSION_PLAN)
+    assert "${SECRET:" not in md  # no bait for secret scanners, no misleading prose
+
+
+def test_static_secret_skill_md_keeps_secret_guidance():
+    md = _render(_STATIC_PLAN)
+    assert "${SECRET:" in md  # a real static-secret skill still documents it


### PR DESCRIPTION
The generated harness SKILL.md's "Running operations" intro always instructed the agent to pass "any `${SECRET:...}` headers verbatim" — even for a session-auth skill with no secrets. That bare example token is both misleading (there are no secrets) and a false-positive for downstream secret scanners: `install_skill` captured `...` as a required secret name and told the user an admin must register it (seen on the Airbnb skill).

### Fix
Gate the clause on the already-computed `secrets` list. A session-only skill now contains no `${SECRET:...}` token anywhere in its SKILL.md; a static-secret skill still documents it.

### Validation
New `tests/test_harness_md_secret_prose.py` — asserts session-auth SKILL.md has no `${SECRET:}` while a static-secret skill keeps the guidance. Full suite 433 pass, ruff clean.

### Related
Pairs with adoptai-workflows PR adoptai/adoptai-workflows#<wf-pr> — the harness-side fix that scans `operations.json` (not SKILL.md prose) for real secrets. This PR is defense-in-depth + corrects the generated docs. Distinct from #71 (which fixed the toolkit's own SKILL.md instructions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
