### PR TITLE
fix(noui): template-first login registration + manual credential default

### DIFF
--- a/skills/noui-harness/SKILL.md
+++ b/skills/noui-harness/SKILL.md
@@ -74,16 +74,19 @@ then click **Finish & export** in the viewer, and tell me when you're done."* Re
 `session_id`. **End your turn here** — do not poll, do not continue until the user
 confirms.
 
-### A2. Import the login → App Template + ServiceProfile (after the user confirms)
+### A2. Import the login → App Template (after the user confirms)
 ```bash
 cd /workspace/noui
-python scripts/capture_import.py <login_session_id> \
-    --name "<app-name>" --credential-mode takeover --promote --as-template
+python scripts/capture_import.py <login_session_id> --name "<app-name>"
 # same-origin apps: add --post-login-url-pattern '<glob the logged-in URL matches>'
 ```
-`--promote` makes the profile runtime-usable (CANARY); `--as-template` creates the
-tenant-wide App Template (per-user auto-provisioning). Note the **profile slug** it
-reports — you need it for Part B. The drained bundle is saved under `workbench/bundles/`.
+Registration is **template-first**: this creates a tenant-wide **App Template**
+only — it does NOT create an App/ServiceProfile directly. Tabby auto-provisions a
+private, per-user App+Profile (straight to ACTIVE) on each member's first
+`call_web_api`, so there is no `--promote` step and the credential model defaults
+to `manual:` (the member logs in via VNC; nothing is stored). Note the **profile
+slug** it reports — you need it for Part B. The drained bundle is saved under
+`workbench/bundles/`.
 
 ## Part B — author the Skill (record the WORKFLOW)
 

--- a/skills/noui/noui_core/activate/register.py
+++ b/skills/noui/noui_core/activate/register.py
@@ -1,13 +1,15 @@
 """Pillar 3 — Activate: register a compiled login bundle with Tabby.
 
-Creates an Application + STAGING ServiceProfile from a compiled login result
-(the dict produced by noui_core.compile.login). Optionally promotes
-STAGING → CANARY → ACTIVE so the runtime resolver (ACTIVE/CANARY only) can
-resolve the profile at the first tool call.
+Template-first: a login recording becomes a tenant-wide **App Template** (the
+per-user auto-provisioning blueprint) — we never create an App/ServiceProfile
+directly. When a federated member (platform JWT, owner_user_id set) first
+requests the profile slug, Tabby's ``autoProvisionFromTemplate`` clones a
+private, owner-scoped App + Profile (straight to ACTIVE) + session for them. A
+directly-created App is creator-only / tenant-shared with no per-user isolation.
 
-Registration (POST /apps, POST /admin/profiles, profile promote) is gated by
-Tabby at the **Editor** role — NOT Admin; the /admin/ prefix is a URL namespace,
-not an admin-credential gate. In local/self-host mode the bearer is read from
+Creating the template (POST /admin/app-templates) is gated by Tabby at the
+**Editor** role — NOT Admin; the /admin/ prefix is a URL namespace, not an
+admin-credential gate. In local/self-host mode the bearer is read from
 TABBY_ADMIN_TOKEN (any Editor+ token works); in broker mode the sandbox sends its
 capability and the broker forwards the user's own federated (Editor) bearer. The
 only genuinely Admin-gated bit is the cross-tenant ``tenant_id`` override.
@@ -25,7 +27,7 @@ def resolve_admin_token() -> str:
     # In broker mode the sandbox holds no Tabby credential — it sends the opaque
     # per-conversation capability token; the broker swaps it for the user's own
     # federated (Editor-role) bearer and forwards. No admin privileges are
-    # injected: register/promote are Editor-gated, and the broker allowlists them.
+    # injected: App Template creation is Editor-gated, and the broker allowlists it.
     if settings.broker_mode():
         if not settings.broker_token:
             raise RuntimeError(
@@ -35,33 +37,38 @@ def resolve_admin_token() -> str:
         return settings.broker_token
     token = os.environ.get("TABBY_ADMIN_TOKEN", "") or settings.tabby_admin_token
     if not token:
-        raise RuntimeError("TABBY_ADMIN_TOKEN must be set to register apps/profiles with Tabby.")
+        raise RuntimeError("TABBY_ADMIN_TOKEN must be set to create the App Template in Tabby.")
     return token
 
 
 def register_login(
     result: dict,
     *,
-    promote: bool = False,
-    as_template: bool = False,
     token: str = "",
     tenant_id: str = "",
 ) -> dict:
-    """Register App + STAGING ServiceProfile from a compiled login result.
+    """Register a compiled login as a tenant-wide Tabby **App Template**.
+
+    Template-first is the ONLY path — we never create an App/ServiceProfile
+    directly. The template is the per-user auto-provisioning blueprint: when a
+    federated member (platform JWT, ``owner_user_id`` set) first requests this
+    profile slug, Tabby's ``autoProvisionFromTemplate`` clones a PRIVATE,
+    owner-scoped App + Profile (straight to ACTIVE) + session for that member. A
+    directly-created App would be creator-only / tenant-shared with no per-user
+    isolation — exactly what we must avoid.
 
     Args:
-        result: the dict from compile.login (application_draft, service_profile_draft, validation).
-        promote: if True, promote STAGING → CANARY (runtime-usable; the resolver
-            serves CANARY). CANARY → ACTIVE is gated by canary traffic and is not
-            forced here.
-        as_template: if True, also create a tenant-wide App Template for
-            per-user auto-provisioning (platform_jwt / federated users).
-        token: admin token; defaults to TABBY_ADMIN_TOKEN.
-        tenant_id: Admin-only override — create the App/Profile/Template in this
-            tenant. Pass the *agent token's* tenant so the agent can resolve and
-            drive them (avoids the admin-token vs agent-token tenant mismatch).
+        result: the dict from compile.login (application_draft,
+            service_profile_draft, validation).
+        token: bearer for POST /admin/app-templates; defaults to
+            resolve_admin_token. Editor role suffices (not Admin-only).
+        tenant_id: Admin-only override — create the template in this tenant. Pass
+            the *agent token's* tenant so the agent can resolve + drive the
+            per-user profiles auto-provisioned from it.
 
-    Returns {app_id, profile_db_id, profile_id, version_state, template_id?}.
+    Returns {template_id, profile_id}. ``profile_id`` is the template's
+    ``profile_name_pattern`` (the runtime slug generated ops bake in). There is
+    no profile to promote — per-user provisioning lands directly in ACTIVE.
     """
     if not tabby_client.is_alive():
         raise RuntimeError(f"Tabby API not reachable at {settings.tabby_api_host}")
@@ -76,36 +83,15 @@ def register_login(
 
     token = token or resolve_admin_token()
 
-    app = tabby_client.register_application(result, token, tenant_id=tenant_id)
-    app_id = app["app_id"]
-    profile = tabby_client.register_service_profile(result, token, app_id, tenant_id=tenant_id)
-    profile_db_id = profile["id"]
+    # Local import avoids a compile↔activate import cycle at module load.
+    from noui_core.compile.login_assets import build_app_template_payload
 
-    version_state = "STAGING"
-    if promote:
-        # One promote: STAGING → CANARY. CANARY is already runtime-usable — the
-        # resolver serves ACTIVE *and* CANARY. The further CANARY → ACTIVE step is
-        # gated by Tabby behind a canary-traffic threshold (≥5 served requests),
-        # so it can't be forced at registration time; it's a production decision.
-        tabby_client.promote_profile(profile_db_id, token)
-        version_state = "CANARY"
-
-    out = {
-        "app_id": app_id,
-        "profile_db_id": profile_db_id,
+    payload = build_app_template_payload(
+        result.get("application_draft", {}),
+        result.get("service_profile_draft", {}),
+    )
+    template = tabby_client.register_app_template(payload, token, tenant_id=tenant_id)
+    return {
+        "template_id": template.get("id", ""),
         "profile_id": profile_id,
-        "version_state": version_state,
     }
-
-    if as_template:
-        # Local import avoids a compile↔activate import cycle at module load.
-        from noui_core.compile.login_assets import build_app_template_payload
-
-        payload = build_app_template_payload(
-            result.get("application_draft", {}),
-            result.get("service_profile_draft", {}),
-        )
-        template = tabby_client.register_app_template(payload, token, tenant_id=tenant_id)
-        out["template_id"] = template.get("id", "")
-
-    return out

--- a/skills/noui/noui_core/compile/login_assets.py
+++ b/skills/noui/noui_core/compile/login_assets.py
@@ -21,7 +21,6 @@ Outputs (returned as a dict):
 from __future__ import annotations
 
 import json
-import os
 import re
 from fnmatch import fnmatch
 from typing import Any
@@ -441,19 +440,6 @@ def merge_template_export_policy(existing_template: dict, new_payload: dict) -> 
 # ---------------------------------------------------------------------------
 
 
-def _resolve_auth_mode(auth_mode: str | None) -> str:
-    """Normalize the credential auth mode.
-
-    'platform_jwt' (Scenario A) → per-user, no stored credentials: the runtime
-    escalates to the end-user via HITL (credential_ref 'manual:').
-    'agent_token'  (Scenario B) → service identity stores credentials in a K8s
-    Secret and reuses them (credential_ref 'k8s:secret/...').
-    Defaults to 'agent_token' (the historical behavior) when unset.
-    """
-    mode = (auth_mode or os.environ.get("NOUI_TABBY_AUTH_MODE") or "agent_token").strip().lower()
-    return "platform_jwt" if mode == "platform_jwt" else "agent_token"
-
-
 def generate(
     session: dict,
     click_events: list[dict],
@@ -482,20 +468,29 @@ def generate(
     har:
         HAR object (or None)
     auth_mode:
-        'platform_jwt' (per-user, HITL-supplied creds) or 'agent_token' (stored
-        K8s Secret). Defaults to $NOUI_TABBY_AUTH_MODE, then 'agent_token'.
+        Runtime token mode hint ('platform_jwt' | 'agent_token'). Does NOT control
+        credential storage — that is governed by manual_credentials/manual_takeover
+        below, which default to manual (no stored secret).
+    manual_credentials:
+        True → `credential_ref: "manual:"` (no stored secret; human logs in via
+        HITL). False → `credential_ref: "k8s:secret/..."` (stored credentials,
+        explicit opt-in only). None (default) → manual.
+    manual_takeover:
+        True → manual: with a single VNC confirm step. Implies manual_credentials.
 
     Returns
     -------
     Full bundle dict.
     """
-    # Credential model is independent of the runtime token mode: `manual:` means
-    # no stored secret — the worker pod starts without a K8s secret mount and the
-    # login is completed by a human via HITL/VNC (request_human_input steps).
-    # `k8s:secret` reuses stored username/password. When manual_credentials is
-    # None, fall back to the legacy coupling (manual iff platform_jwt).
+    # Credential model: `manual:` means no stored secret — the worker pod starts
+    # without a K8s secret mount and the login is completed by a human via
+    # HITL/VNC (request_human_input steps). We DEFAULT to manual and NEVER
+    # provision a `k8s:secret` credential implicitly: a stored credential is only
+    # emitted when the caller explicitly opts in with manual_credentials=False
+    # (i.e. `--credential-mode stored`). This is independent of the runtime token
+    # mode (auth_mode) — agent_token sessions are manual too unless opted in.
     if manual_credentials is None:
-        manual_creds = _resolve_auth_mode(auth_mode) == "platform_jwt"
+        manual_creds = True
     else:
         manual_creds = manual_credentials
     # Takeover implies no stored secret — the human logs in via VNC.

--- a/skills/noui/noui_core/compile/login_assets.py
+++ b/skills/noui/noui_core/compile/login_assets.py
@@ -352,9 +352,13 @@ def build_app_template_payload(
         # vendor's auth/CDN domains in their egress allowlist.
         "extra_egress_allowlist": application_draft.get("extra_egress_allowlist") or [],
         "notification_config": application_draft.get("notification_config") or {},
-        # NOTE: execute_enabled is intentionally NOT emitted — the App Template
-        # DTO rejects the field and returns 400 (A4). The auto-provisioned app
-        # picks up execute_enabled from its own creation path, not the template.
+        # execute_enabled is carried onto every app auto-provisioned from this
+        # template (Tabby's autoProvisionFromTemplate clones it), so the per-user
+        # connection can run /execute/fetch | /execute/browser — which call_web_api
+        # depends on. The App Template DTO now accepts this field (the earlier A4
+        # 400 was fixed); omitting it would default to false and silently break
+        # execute for every provisioned user.
+        "execute_enabled": bool(application_draft.get("execute_enabled", True)),
     }
 
 

--- a/skills/noui/noui_core/tabby_client.py
+++ b/skills/noui/noui_core/tabby_client.py
@@ -71,69 +71,6 @@ def is_alive() -> bool:
         return False
 
 
-def register_application(bundle: dict, token: str, *, tenant_id: str = "") -> dict:
-    """
-    POST /apps with the application_draft from bundle.
-
-    Patches http://localhost target_urls to https://localhost so Tabby
-    validation does not reject local test origins.
-
-    tenant_id: optional Admin-only override — create the app in that tenant
-    (so an admin token can register into the agent token's tenant).
-
-    Returns the created application dict (includes app_id).
-    Raises RuntimeError on failure.
-    """
-    app_draft = bundle.get("application_draft", {})
-
-    # Rewrite http://localhost target_urls to https://localhost for Tabby
-    patched_urls = [
-        u.replace("http://localhost", "https://localhost", 1)
-        if u.startswith("http://localhost")
-        else u
-        for u in (app_draft.get("target_urls") or [])
-    ]
-    patched_draft: dict[str, Any] = {**app_draft}
-    if patched_urls:
-        patched_draft["target_urls"] = patched_urls
-    if tenant_id:
-        patched_draft["tenant_id"] = tenant_id
-
-    resp = _tabby_http("POST", "/apps", patched_draft, token=token)
-    if not isinstance(resp, dict):
-        raise RuntimeError(f"Unexpected response type from POST /apps: {type(resp)}")
-    return resp
-
-
-def register_service_profile(bundle: dict, token: str, app_id: str, *, tenant_id: str = "") -> dict:
-    """
-    POST /admin/profiles with the service_profile_draft from bundle,
-    injecting the given app_id and a freshly computed version string.
-
-    tenant_id: optional Admin-only override — create the profile in that tenant.
-
-    Returns the created profile dict (includes id as the DB primary key).
-    Raises RuntimeError on failure.
-    """
-    profile_draft = bundle.get("service_profile_draft", {})
-
-    t = time.localtime()
-    version = f"{t.tm_year % 100}.{t.tm_mon}.{t.tm_mday}"
-
-    profile_payload: dict[str, Any] = {
-        **profile_draft,
-        "app_id": app_id,
-        "version": version,
-    }
-    if tenant_id:
-        profile_payload["tenant_id"] = tenant_id
-
-    resp = _tabby_http("POST", "/admin/profiles", profile_payload, token=token)
-    if not isinstance(resp, dict):
-        raise RuntimeError(f"Unexpected response type from POST /admin/profiles: {type(resp)}")
-    return resp
-
-
 def validate_profile(profile_id: str, token: str, timeout_seconds: int = 60) -> dict:
     """
     Poll GET /admin/service-profiles/{id} until the profile's version_state
@@ -171,25 +108,6 @@ def validate_profile(profile_id: str, token: str, timeout_seconds: int = 60) -> 
         f"Profile {profile_id} did not reach HEALTHY within {timeout_seconds}s. "
         f"Last response: {last_resp}"
     )
-
-
-def promote_profile(profile_db_id: str, token: str) -> dict:
-    """
-    POST /admin/profiles/{id}/promote.
-
-    In the standard Tabby flow this must be called twice to move
-    STAGING → CANARY → ACTIVE. This function calls it once and
-    returns the updated profile dict.
-
-    Raises RuntimeError on failure.
-    """
-    resp = _tabby_http("POST", f"/admin/profiles/{profile_db_id}/promote", token=token)
-    if not isinstance(resp, dict):
-        raise RuntimeError(
-            f"Unexpected response type from POST /admin/profiles/{profile_db_id}/promote: "
-            f"{type(resp)}"
-        )
-    return resp
 
 
 def get_agent_token(client_id: str, client_secret: str) -> str:

--- a/skills/noui/scripts/activate_register.py
+++ b/skills/noui/scripts/activate_register.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""Register a compiled login result with Tabby (App + ServiceProfile).
+"""Register a compiled login result with Tabby as a tenant-wide App Template.
 
-    python scripts/activate_register.py compiled-login.json --promote
+    python scripts/activate_register.py compiled-login.json
 
-Requires TABBY_ADMIN_TOKEN. --promote moves STAGING → CANARY so the runtime
-resolver (serves ACTIVE/CANARY) can resolve the profile at the first tool call.
+Template-first: creates the App Template only (POST /admin/app-templates). Tabby
+auto-provisions a private per-user App+Profile (→ ACTIVE) on each member's first
+request — no direct App/Profile creation, no promote. Editor role suffices
+(TABBY_ADMIN_TOKEN locally; the broker forwards the user's federated bearer).
 """
 
 from __future__ import annotations
@@ -24,13 +26,6 @@ from noui_core.capture.recording import resolve_agent_token
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("compiled", help="path to a compiled login result JSON")
-    p.add_argument("--promote", action="store_true", help="promote STAGING → CANARY")
-    p.add_argument(
-        "--as-template",
-        dest="as_template",
-        action="store_true",
-        help="also create a tenant-wide App Template",
-    )
     p.add_argument(
         "--tenant-id",
         dest="tenant_id",
@@ -49,9 +44,7 @@ def main() -> int:
 
     result = json.loads(Path(args.compiled).read_text())
     try:
-        prov = register.register_login(
-            result, promote=args.promote, as_template=args.as_template, tenant_id=tenant_id
-        )
+        prov = register.register_login(result, tenant_id=tenant_id)
     except RuntimeError as exc:
         print(f"Register failed: {exc}", file=sys.stderr)
         return 1

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -53,7 +53,8 @@ def main() -> int:
         default="takeover",
         help="(login) takeover (default): manual:, human logs in via VNC + clicks "
         "'Mark as Resolved' (single confirm step); manual: per-field request_human_input "
-        "(Slack/MCP-delivered values); stored: k8s:secret username/password; auto: legacy",
+        "(Slack/MCP-delivered values); stored: k8s:secret username/password (explicit "
+        "opt-in — never the default); auto: same as manual (no stored secret)",
     )
     p.add_argument("--promote", action="store_true", help="(login) promote STAGING → ACTIVE")
     p.add_argument(

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -4,8 +4,8 @@
 Workflow recording → MCP and/or Skill:
     python scripts/capture_import.py <session_id> --as both --profile-slug <slug>
 
-Login recording → Tabby App + ServiceProfile:
-    python scripts/capture_import.py <session_id> --promote
+Login recording → Tabby App Template (per-user auto-provisioning blueprint):
+    python scripts/capture_import.py <session_id> --name <app-name>
 
 End to end, no NoUI backend round-trip: Tabby captured the bundle server-side.
 """
@@ -56,13 +56,9 @@ def main() -> int:
         "(Slack/MCP-delivered values); stored: k8s:secret username/password (explicit "
         "opt-in — never the default); auto: same as manual (no stored secret)",
     )
-    p.add_argument("--promote", action="store_true", help="(login) promote STAGING → ACTIVE")
-    p.add_argument(
-        "--as-template",
-        dest="as_template",
-        action="store_true",
-        help="(login) also create a tenant-wide App Template",
-    )
+    # (login) registration is always template-first — we create a tenant-wide App
+    # Template and let Tabby auto-provision a private per-user App+Profile on each
+    # member's first request. No direct App/Profile creation, no promote step.
     p.add_argument(
         "--tenant-id",
         dest="tenant_id",
@@ -145,22 +141,21 @@ def main() -> int:
         tenant_id = auth.tenant_id_from_token(recording.resolve_agent_token())
 
     try:
-        prov = register.register_login(
-            compiled, promote=args.promote, as_template=args.as_template, tenant_id=tenant_id
-        )
+        prov = register.register_login(compiled, tenant_id=tenant_id)
     except RuntimeError as exc:
         print(f"Register failed: {exc}", file=sys.stderr)
         # Still emit the compiled drafts so the user can register manually.
         print(json.dumps({"compiled": compiled.get("service_profile_draft", {})}, indent=2))
         return 1
 
-    print("Registered login profile:")
+    print("Registered App Template:")
     print(json.dumps(prov, indent=2))
-    if prov.get("version_state") not in ("ACTIVE", "CANARY"):
-        print(
-            "Profile is STAGING — re-run with --promote (runtime resolves ACTIVE/CANARY only).",
-            file=sys.stderr,
-        )
+    print(
+        f"Profile slug '{prov.get('profile_id', '')}' is now tenant-wide. Tabby "
+        "auto-provisions a private per-user profile (→ ACTIVE) on each member's "
+        "first request — no promote needed.",
+        file=sys.stderr,
+    )
     return 0
 
 

--- a/skills/noui/scripts/compile_login.py
+++ b/skills/noui/scripts/compile_login.py
@@ -29,9 +29,25 @@ def main() -> int:
         dest="auth_mode",
         choices=["agent_token", "platform_jwt"],
         default="agent_token",
+        help="runtime token mode hint; does NOT control credential storage "
+        "(see --credential-mode).",
+    )
+    p.add_argument(
+        "--credential-mode",
+        dest="credential_mode",
+        choices=["takeover", "manual", "stored"],
+        default="takeover",
+        help="takeover (default): manual:, human logs in via VNC + single confirm; "
+        "manual: per-field request_human_input; stored: k8s:secret username/password "
+        "(explicit opt-in — never the default).",
     )
     p.add_argument("--out", default="", help="write compiled drafts here (default: stdout)")
     args = p.parse_args()
+
+    # Default is manual (no stored secret). Only --credential-mode stored opts into
+    # a k8s:secret credential, and never implicitly.
+    manual_takeover = args.credential_mode == "takeover"
+    manual_credentials = {"takeover": True, "manual": True, "stored": False}[args.credential_mode]
 
     bundle = json.loads(Path(args.bundle).read_text())
     session_id = args.session_id or bundle.get("session_id") or "bundle"
@@ -42,6 +58,8 @@ def main() -> int:
             name=args.name,
             login_url=args.url,
             auth_mode=args.auth_mode,
+            manual_credentials=manual_credentials,
+            manual_takeover=manual_takeover,
         )
     except Exception as exc:  # noqa: BLE001
         print(f"Compile failed: {exc}", file=sys.stderr)

--- a/tests/test_activate_register.py
+++ b/tests/test_activate_register.py
@@ -27,23 +27,15 @@ def _compiled():
 
 
 class FakeClient:
+    # Template-first only: the client no longer exposes register_application /
+    # register_service_profile / promote_profile. If register_login tried to call
+    # one, this fake would AttributeError — a loud guard against regressing to
+    # direct App creation.
     def __init__(self):
         self.calls = []
 
     def is_alive(self):
         return True
-
-    def register_application(self, bundle, token, *, tenant_id=""):
-        self.calls.append(("register_application", token, tenant_id))
-        return {"app_id": "app-123"}
-
-    def register_service_profile(self, bundle, token, app_id, *, tenant_id=""):
-        self.calls.append(("register_service_profile", app_id, tenant_id))
-        return {"id": "profile-db-456"}
-
-    def promote_profile(self, profile_db_id, token):
-        self.calls.append(("promote_profile", profile_db_id))
-        return {}
 
     def register_app_template(self, payload, token, *, tenant_id=""):
         self.calls.append(("register_app_template", payload, tenant_id))
@@ -55,51 +47,36 @@ def _patch(monkeypatch, fake):
     monkeypatch.setattr(register, "resolve_admin_token", lambda: "admin-tok")
 
 
-def test_register_basic(monkeypatch):
+def test_register_creates_template_only(monkeypatch):
+    # Template-first: ONLY the App Template is created — no direct App/Profile.
     fake = FakeClient()
     _patch(monkeypatch, fake)
     out = register.register_login(_compiled())
-    assert out == {
-        "app_id": "app-123",
-        "profile_db_id": "profile-db-456",
-        "profile_id": "expedia-login",
-        "version_state": "STAGING",
-    }
-    assert [c[0] for c in fake.calls] == ["register_application", "register_service_profile"]
+    assert out == {"template_id": "tmpl-789", "profile_id": "expedia-login"}
+    assert [c[0] for c in fake.calls] == ["register_app_template"]
 
 
-def test_register_with_promote(monkeypatch):
+def test_template_payload_is_correct(monkeypatch):
     fake = FakeClient()
     _patch(monkeypatch, fake)
-    out = register.register_login(_compiled(), promote=True)
-    # One promote: STAGING → CANARY (runtime-usable). ACTIVE is gated by canary traffic.
-    assert out["version_state"] == "CANARY"
-    assert [c[0] for c in fake.calls].count("promote_profile") == 1
-
-
-def test_register_with_template(monkeypatch):
-    fake = FakeClient()
-    _patch(monkeypatch, fake)
-    out = register.register_login(_compiled(), promote=True, as_template=True)
-    assert out["template_id"] == "tmpl-789"
-    tmpl_call = next(c for c in fake.calls if c[0] == "register_app_template")
-    payload = tmpl_call[1]
-    # profile_name_pattern must equal the runtime slug; execute_enabled must NOT be present.
+    register.register_login(_compiled())
+    payload = next(c for c in fake.calls if c[0] == "register_app_template")[1]
+    # profile_name_pattern must equal the runtime slug (the auto-provision match key).
     assert payload["profile_name_pattern"] == "expedia-login"
-    assert "execute_enabled" not in payload
+    # execute_enabled MUST be present and true — cloned onto each per-user app so
+    # /execute (call_web_api) works; the DTO now accepts it.
+    assert payload["execute_enabled"] is True
     # profile credential_types/target_domains folded into export_policy.
     assert payload["export_policy"]["target_domains"] == ["www.expedia.com"]
 
 
 def test_register_threads_tenant_id(monkeypatch):
-    # An explicit tenant_id must reach app, profile, AND template creates so the
-    # agent token (whose tenant it is) can resolve + drive them.
+    # An explicit tenant_id must reach the template create so the agent token
+    # (whose tenant it is) can resolve + drive the per-user profiles it provisions.
     fake = FakeClient()
     _patch(monkeypatch, fake)
-    register.register_login(_compiled(), as_template=True, tenant_id="7f420cc0")
+    register.register_login(_compiled(), tenant_id="7f420cc0")
     by_name = {c[0]: c for c in fake.calls}
-    assert by_name["register_application"][2] == "7f420cc0"
-    assert by_name["register_service_profile"][2] == "7f420cc0"
     assert by_name["register_app_template"][2] == "7f420cc0"
 
 

--- a/tests/test_compile_login.py
+++ b/tests/test_compile_login.py
@@ -75,6 +75,30 @@ def test_credential_mode_manual_vs_stored():
     assert stored["application_draft"]["login_config"]["credential_ref"].startswith("k8s:secret/")
 
 
+def test_default_credential_mode_is_manual_never_k8s():
+    """Regression: with no explicit credential mode, compile DEFAULTS to `manual:`
+    and must NEVER implicitly provision a k8s:secret. The Airbnb incident came
+    from compile_login.py (auth_mode=agent_token, no manual flag) silently
+    emitting credential_ref=k8s:secret/tabby-airbnb."""
+    from noui_core.compile.login import compile_login_bundle
+
+    bundle = {
+        "recording_mode": "login",
+        "url_events": [{"to_url": "https://x.com/login"}],
+        "click_events": [],
+        "har": {"log": {"entries": []}},
+        "cookies": [],
+    }
+    # No manual_credentials passed → must be manual on both drafts.
+    default = compile_login_bundle(session_id="s", bundle=bundle, name="x")
+    assert default["application_draft"]["login_config"]["credential_ref"] == "manual:"
+    assert default["service_profile_draft"]["login_config"]["credential_ref"] == "manual:"
+
+    # agent_token must NOT couple to k8s anymore — storage is manual unless opted in.
+    agent = compile_login_bundle(session_id="s", bundle=bundle, name="x", auth_mode="agent_token")
+    assert agent["application_draft"]["login_config"]["credential_ref"] == "manual:"
+
+
 def test_manual_takeover_emits_confirm_step():
     from noui_core.compile.login import compile_login_bundle
 

--- a/tests/test_tabby_draft_generate.py
+++ b/tests/test_tabby_draft_generate.py
@@ -535,18 +535,19 @@ class TestBuildAppTemplatePayload:
         assert payload["export_policy"]["credential_types"] == prof["credential_types"]
         assert payload["export_policy"]["target_domains"] == ["app.example.com"]
 
-    def test_execute_enabled_omitted_from_template(self) -> None:
-        # A4: the App Template DTO rejects execute_enabled (400). It must NOT be
-        # emitted; the auto-provisioned app sets it on its own creation path.
+    def test_execute_enabled_emitted_on_template(self) -> None:
+        # autoProvisionFromTemplate clones execute_enabled onto each per-user app;
+        # it MUST be true or /execute/fetch (call_web_api) is dead for every user.
+        # The App Template DTO now accepts the field (the earlier A4 400 was fixed).
         app, prof = self._drafts()
         payload = build_app_template_payload(app, prof)
-        assert "execute_enabled" not in payload
+        assert payload["execute_enabled"] is True
 
-    def test_execute_enabled_omitted_even_when_app_sets_it(self) -> None:
+    def test_execute_enabled_defaults_true_when_app_omits_it(self) -> None:
         app, prof = self._drafts()
-        app = {**app, "execute_enabled": True}
+        app = {k: v for k, v in app.items() if k != "execute_enabled"}
         payload = build_app_template_payload(app, prof)
-        assert "execute_enabled" not in payload
+        assert payload["execute_enabled"] is True
 
     def test_merge_unions_export_policy_additive_fields(self) -> None:
         from noui_core.compile.login_assets import merge_template_export_policy

--- a/tests/test_tabby_draft_generate.py
+++ b/tests/test_tabby_draft_generate.py
@@ -103,8 +103,9 @@ class TestGenerate:
         assert any("observed.example.com" in str(s) for s in steps)
 
     def test_username_fill_step_generated(self) -> None:
+        # fill steps (${USERNAME}) are the stored-credential rendering — opt in.
         clicks = [_click(event_type="input", field_role="username", value="alice")]
-        result = generate(_session(), clicks, [])
+        result = generate(_session(), clicks, [], manual_credentials=False)
         steps = self._steps(result)
         fill_steps = [
             s for s in steps if s.get("action") == "fill" and s.get("value") == "${USERNAME}"
@@ -115,7 +116,7 @@ class TestGenerate:
         clicks = [
             _click(event_type="input", field_role="password", input_type="password", value="secret")
         ]
-        result = generate(_session(), clicks, [])
+        result = generate(_session(), clicks, [], manual_credentials=False)
         steps = self._steps(result)
         fill_steps = [
             s for s in steps if s.get("action") == "fill" and s.get("value") == "${PASSWORD}"
@@ -126,14 +127,22 @@ class TestGenerate:
         clicks = [
             _click(event_type="input", field_role="password", input_type="password", value="s")
         ]
-        result = generate(_session(), clicks, [])
+        result = generate(_session(), clicks, [], manual_credentials=False)
         steps = self._steps(result)
         pw_steps = [s for s in steps if s.get("value") == "${PASSWORD}"]
+        assert pw_steps  # not vacuous
         assert all(s.get("sensitive") is True for s in pw_steps)
 
-    def test_agent_mode_default_uses_k8s_secret(self) -> None:
+    def test_default_credential_ref_is_manual_not_k8s(self) -> None:
+        # Regression: default must be manual: — never an implicit k8s secret.
         clicks = [_click(event_type="input", field_role="username", value="alice")]
         result = generate(_session(), clicks, [])
+        cref = result["application_draft"]["login_config"]["credential_ref"]
+        assert cref == "manual:"
+
+    def test_stored_mode_uses_k8s_secret(self) -> None:
+        clicks = [_click(event_type="input", field_role="username", value="alice")]
+        result = generate(_session(), clicks, [], manual_credentials=False)
         cref = result["application_draft"]["login_config"]["credential_ref"]
         assert cref.startswith("k8s:secret/")
 
@@ -223,7 +232,7 @@ class TestGenerate:
             _click(event_type="input", field_role="username", value="ali"),
             _click(event_type="input", field_role="username", value="alice"),
         ]
-        result = generate(_session(), clicks, [])
+        result = generate(_session(), clicks, [], manual_credentials=False)
         steps = self._steps(result)
         fill_steps = [s for s in steps if s.get("value") == "${USERNAME}"]
         assert len(fill_steps) == 1
@@ -246,7 +255,7 @@ class TestGenerate:
                 "placeholder": None,
             }
         ]
-        result = generate(_session(), clicks, [])
+        result = generate(_session(), clicks, [], manual_credentials=False)
         steps = self._steps(result)
         pw_steps = [s for s in steps if s.get("value") == "${PASSWORD}"]
         assert len(pw_steps) >= 1
@@ -269,7 +278,7 @@ class TestGenerate:
                 "placeholder": None,
             }
         ]
-        result = generate(_session(), clicks, [])
+        result = generate(_session(), clicks, [], manual_credentials=False)
         steps = self._steps(result)
         user_steps = [s for s in steps if s.get("value") == "${USERNAME}"]
         assert len(user_steps) >= 1


### PR DESCRIPTION
Consolidates the NoUI login-registration fixes from the Airbnb-skill build review into one branch. Two commits, both off `dev`.

## 1. Default the login credential model to `manual:` — never an implicit k8s secret (`5bf498f`)

A login recording must not silently store credentials in a k8s secret. The default credential model was k8s: `generate()` coupled credential storage to the runtime token mode, so the `agent_token` default produced `credential_ref="k8s:secret/tabby-<profile>"`. `capture_import.py` hid this behind its `--credential-mode takeover` default, but `compile_login.py` (no such flag) hit the k8s default directly — which is how the airbnb profile got a k8s secret.

- `generate()` now defaults to `manual:`; `k8s:secret` is emitted only on explicit `manual_credentials=False` (`--credential-mode stored`), decoupled from `auth_mode`. Removed the orphaned `_resolve_auth_mode` + unused `import os`.
- `compile_login.py` gains `--credential-mode {takeover,manual,stored}` (default `takeover`) so it can't default to k8s.

## 2. Template-first login registration; remove direct App creation (`b824e66`)

A login recording must become a tenant-wide **App Template** (the per-user auto-provisioning blueprint), not a directly-created App+Profile. `register_login` used to `POST /apps` + `POST /admin/profiles` directly (creator-only, `owner_user_id` NULL, tenant-shared) and only optionally add a template afterward that was never used for provisioning — that's how the airbnb App got created directly.

- `register_login` is **template-first only** (hard block): builds + `POST /admin/app-templates`, returns `{template_id, profile_id}`. No App/Profile create, no promote. On a federated member's first request, Tabby's `autoProvisionFromTemplate` clones a private, owner-scoped App+Profile (→ ACTIVE) + session for that member.
- **Removed** the now-dead client fns `register_application` (`POST /apps`), `register_service_profile` (`POST /admin/profiles`), `promote_profile`. The test `FakeClient` drops them too, so any regression to direct creation `AttributeError`s.
- `build_app_template_payload` now emits `execute_enabled: true` (cloned onto each per-user app, or `call_web_api`/`/execute` is dead). The App Template DTO accepts the field now (the earlier A4 400 was fixed).
- `capture_import.py` / `activate_register.py`: drop `--promote`/`--as-template`. `SKILL.md` A2 updated to template-first.

## Together
template-first + manual creds + per-user auto-provision = each member logs in via VNC (nothing stored) and gets their own owner-scoped, ACTIVE profile from the shared template.

## Validation
Full noui suite **436 pass**, ruff clean. Register suite rewritten for template-first; credential default + stored opt-in covered; template payload asserts `execute_enabled=true` + `profile_name_pattern==slug`.

## Related / scope
- The generated-SKILL.md `${SECRET:...}` prose fix landed separately as #72 (already merged to `dev`).
- Depends on the broker allowlisting `/admin/app-templates` + answering `/health/live` (adoptai-workflows#1376) and needs the noui bundle rebuilt/republished to take effect in the harness.
- Supersedes branches `fix/noui-credential-mode-default-manual` and `fix/noui-login-template-first` (folded in here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
