### PR TITLE
feat(skills): add EasyJet flight search skill

### DIFF
--- a/skills/easyjet-search/API.md
+++ b/skills/easyjet-search/API.md
@@ -1,0 +1,46 @@
+# API Reference: EasyJet Search
+
+## Endpoint
+
+**GET** `https://www.easyjet.com/homepage/api/availability`
+
+Search EasyJet flights for a given route and date. Returns lowest available price per date.
+
+## Authentication
+
+None required. The endpoint is publicly accessible. A homepage visit is made first to establish session cookies.
+
+## Query Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `origin` | string | yes | Departure IATA airport code (e.g. `LGW`) |
+| `destination` | string | yes | Arrival IATA airport code (e.g. `AMS`) |
+| `currency` | string | no | Currency code for returned prices (default: `GBP`) |
+| `isReturn` | string | no | `"true"` for round-trip search (default: `"false"`) |
+| `startDate` | string | yes | Outbound date in `YYYY-MM-DD` format |
+| `endDate` | string | no | Return date in `YYYY-MM-DD` format (round-trip only) |
+
+## Response
+
+```json
+{
+  "startDate": "2026-07-15",
+  "endDate": "2026-07-15",
+  "departureFlights": [
+    {
+      "date": "2026-07-15",
+      "price": 43,
+      "lowFare": false
+    }
+  ],
+  "returnFlights": null
+}
+```
+
+| Field | Description |
+|---|---|
+| `departureFlights` | Array of available outbound dates with lowest price |
+| `returnFlights` | Array of available return dates (null for one-way searches) |
+| `price` | Lowest available fare for that date in the requested currency |
+| `lowFare` | Whether this date is flagged as a low-fare day |

--- a/skills/easyjet-search/SKILL.md
+++ b/skills/easyjet-search/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: easyjet-search
+description: "Use this skill when the user wants to search EasyJet flights for a given route, date, and currency. Triggers on \"easyjet flight search\", \"easyjet availability\", \"search easyjet\", or any request that implies searching for EasyJet flights between two airports. No authentication required — uses the public EasyJet availability API directly."
+---
+
+# EasyJet Search
+
+Search EasyJet's availability API for flights between two airports. Returns lowest available price per date (a price calendar). No authentication or Tabby session required.
+
+## Operations
+
+### `get_homepage_api_availability`
+
+Search EasyJet flights for a given route and date.
+
+| Argument | Required | Description |
+|---|---|---|
+| `--origin` | Yes | Departure IATA airport code, e.g. `LGW`, `LTN`, `BRS` |
+| `--destination` | Yes | Arrival IATA airport code, e.g. `AMS`, `BCN` |
+| `--date` | Yes | Outbound date in YYYY-MM-DD format |
+| `--currency` | No | Currency code for prices (default: `GBP`) |
+| `--round-trip` | No | Flag: search for a return flight |
+| `--date-in` | No | Return date in YYYY-MM-DD format (used with `--round-trip`) |
+
+## Examples
+
+```bash
+# One-way LGW → AMS
+.venv/bin/python3 skills/easyjet-search/operations/get_homepage_api_availability.py \
+  --origin LGW --destination AMS --date 2026-07-15
+
+# Round trip LGW → BCN in EUR
+.venv/bin/python3 skills/easyjet-search/operations/get_homepage_api_availability.py \
+  --origin LGW --destination BCN --date 2026-07-15 \
+  --round-trip --date-in 2026-07-22 --currency EUR
+```
+
+## Notes
+
+- Returns a price calendar (lowest fare per date), not a full flight list with departure times
+- No Tabby or Docker required

--- a/skills/easyjet-search/manifest.json
+++ b/skills/easyjet-search/manifest.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "1",
+  "skill_id": "easyjet-search",
+  "app": {
+    "name": "EasyJet Search",
+    "slug": "easyjet-search"
+  },
+  "workflow": {
+    "id": "easyjet-search",
+    "name": "EasyJet Search",
+    "workflow_session_id": "5ecaf023-ab79-4172-b1a3-4daaefaa9769",
+    "start_url": "https://www.easyjet.com"
+  },
+  "auth": {
+    "requires_auth": false,
+    "profile_slug": null,
+    "profile_db_id": null,
+    "strategy": "none",
+    "execution_strategy": "none",
+    "auth_plan_file": null
+  },
+  "runtime": {
+    "type": "claude-code-skill",
+    "entrypoint": "SKILL.md",
+    "operation_style": "subprocess-cli",
+    "python": ">=3.11"
+  },
+  "operations": [
+    {
+      "name": "get_homepage_api_availability",
+      "description": "Search EasyJet flights for a given route and date. Returns available flights with prices.",
+      "module": "operations/get_homepage_api_availability.py",
+      "entry": "execute",
+      "method": "GET",
+      "path": "/homepage/api/availability",
+      "args": [
+        {
+          "name": "origin",
+          "type": "string",
+          "required": true,
+          "description": "Departure IATA airport code, e.g. \"LGW\" or \"LTN\"."
+        },
+        {
+          "name": "destination",
+          "type": "string",
+          "required": true,
+          "description": "Arrival IATA airport code, e.g. \"AMS\" or \"BCN\"."
+        },
+        {
+          "name": "date",
+          "type": "string",
+          "required": true,
+          "description": "Outbound date in YYYY-MM-DD format."
+        },
+        {
+          "name": "currency",
+          "type": "string",
+          "required": false,
+          "description": "Currency code for prices (default: GBP)."
+        },
+        {
+          "name": "round-trip",
+          "type": "boolean",
+          "required": false,
+          "description": "Search for a return flight (flag, default: false)."
+        },
+        {
+          "name": "date-in",
+          "type": "string",
+          "required": false,
+          "description": "Return date in YYYY-MM-DD format (used with --round-trip)."
+        }
+      ]
+    }
+  ]
+}

--- a/skills/easyjet-search/operations/get_homepage_api_availability.py
+++ b/skills/easyjet-search/operations/get_homepage_api_availability.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Skill operation: get_homepage_api_availability (PATCHED)
+Method: GET
+Path: /homepage/api/availability
+
+Patched manually after auto-generation:
+  - Accepts --origin, --destination, --date, --currency, --round-trip,
+    --date-in CLI args
+  - Uses stdlib urllib only (no httpx, no Tabby, no cdp_fetch)
+  - Bootstraps EasyJet session cookies via homepage visit before calling
+    the availability API
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.cookiejar
+import json
+import sys
+import urllib.parse
+import urllib.request
+from typing import Any
+
+BASE_URL = "https://www.easyjet.com"
+_BOOTSTRAP_URL = "https://www.easyjet.com/en/"
+_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/147.0.0.0 Safari/537.36"
+)
+
+
+def execute(
+    origin: str = "LGW",
+    destination: str = "AMS",
+    date: str = "2026-07-15",
+    currency: str = "GBP",
+    round_trip: bool = False,
+    date_in: str = "",
+) -> dict[str, Any]:
+    """Search EasyJet flights for a given route and date.
+
+    Args:
+        origin: Departure IATA airport code (e.g. "LGW", "LTN", "BRS").
+        destination: Arrival IATA airport code (e.g. "AMS", "BCN").
+        date: Outbound date in YYYY-MM-DD format.
+        currency: Currency code for prices (e.g. "GBP", "EUR").
+        round_trip: Whether to search for a return flight.
+        date_in: Return date in YYYY-MM-DD format (used when round_trip=True).
+    """
+    cj = http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cj))
+    opener.addheaders = [
+        ("User-Agent", _UA),
+        ("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
+        ("Accept-Language", "en-US,en;q=0.9"),
+    ]
+
+    # Bootstrap session cookies.
+    with opener.open(_BOOTSTRAP_URL, timeout=15):
+        pass
+
+    params: dict[str, str] = {
+        "origin": origin,
+        "destination": destination,
+        "currency": currency,
+        "isReturn": "true" if round_trip else "false",
+        "startDate": date,
+        "endDate": date_in if round_trip and date_in else date,
+    }
+    url = f"{BASE_URL}/homepage/api/availability?" + urllib.parse.urlencode(params)
+
+    req = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": _UA,
+            "Accept": "application/json",
+            "Accept-Language": "en-US,en;q=0.9",
+            "sec-ch-ua": '"Google Chrome";v="147", "Not.A/Brand";v="8", "Chromium";v="147"',
+            "sec-ch-ua-mobile": "?0",
+            "sec-ch-ua-platform": '"macOS"',
+            "Sec-Fetch-Site": "same-origin",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Dest": "empty",
+            "Referer": "https://www.easyjet.com/en/",
+        },
+        method="GET",
+    )
+
+    with opener.open(req, timeout=30) as resp:
+        raw = resp.read()
+        return json.loads(raw.decode("utf-8"))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="get_homepage_api_availability",
+        description="Search EasyJet flights for a given route and date.",
+    )
+    parser.add_argument("--origin", required=True, help='Departure IATA airport code, e.g. "LGW".')
+    parser.add_argument(
+        "--destination", required=True, help='Arrival IATA airport code, e.g. "AMS".'
+    )
+    parser.add_argument("--date", required=True, help="Outbound date in YYYY-MM-DD format.")
+    parser.add_argument(
+        "--currency", default="GBP", help="Currency code for prices (default: GBP)."
+    )
+    parser.add_argument("--round-trip", action="store_true", help="Search for a return flight.")
+    parser.add_argument(
+        "--date-in", default="", help="Return date in YYYY-MM-DD format (used with --round-trip)."
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = execute(
+            origin=args.origin,
+            destination=args.destination,
+            date=args.date,
+            currency=args.currency,
+            round_trip=args.round_trip,
+            date_in=args.date_in,
+        )
+    except Exception as exc:
+        print(f"get_homepage_api_availability failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    if isinstance(result, dict) and "error" in result:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add EasyJet flight search skill using stdlib urllib (no Tabby required)
- Calls EasyJet's internal availability API directly to return flight options with prices

## Why
Adds EasyJet coverage to the airline flight search skill collection.

## Validation
Tested manually via the operation script against live routes (e.g. LTN→AMS).
Returns real flight data with prices.

## Checklist
- [ ] Tests added or updated (or explain why not)
- [x] Ran `ruff check`, `ruff format --check`, `mypy`, `pytest` locally
- [ ] Updated `CHANGELOG.md` if user-visible
- [x] No secrets or customer data in the diff
- [ ] If bumping the Tabby submodule, ran the compat matrix and updated the README compatibility section