### PR TITLE
feat(skills): add British Airways flight search skill

### DIFF
--- a/skills/british-airways-search/API.md
+++ b/skills/british-airways-search/API.md
@@ -1,0 +1,41 @@
+# British Airways Flight Search API
+
+## Endpoint
+
+```
+GET https://www.britishairways.com/nx/b/bff/offer-flight/v0/oneway/outbound
+  ?from=LHR&to=JFK&departureDate=2026-08-20
+  &adults=1&youngAdults=0&children=0&infants=0
+  &page=1&maxResult=100&travelClass=economy
+```
+
+No auth, no bot protection bypass needed. Fresh UUIDs for correlation headers only.
+
+## Key Headers (all static except UUIDs)
+
+| Header | Value |
+|---|---|
+| `x-ba-application-name` | `airselect` |
+| `x-ba-client-name` | `airselect` |
+| `x-ba-market` | `us` |
+| `x-ba-language` | `en` |
+| `x-ba-channel` | `WEB` |
+| `x-amzn-waf-ba-rule` | `EMPTY` |
+| `x-ba-action-name` | `search-flights-get-flights-oneway-outbound` |
+| `x-ba-interaction-id` etc. | Fresh UUID v4 per request |
+
+## Key Response Fields
+
+| Field | Description |
+|---|---|
+| `result.matchingBounds[]` | List of available flights |
+| `.departureAirport.code` | Departure IATA code |
+| `.arrivalAirport.code` | Arrival IATA code |
+| `.departureTime` | Departure datetime (ISO 8601 with offset) |
+| `.arrivalTime` | Arrival datetime |
+| `.duration` | Duration in minutes |
+| `.flightNumber` | BA flight number |
+| `.stops` | Number of stops |
+| `.cabin.cabinCode` | Cabin code (M=Economy, W=Premium Economy, J=Business, F=First) |
+| `.lowestFare.amount` | Lowest fare amount |
+| `.lowestFare.currency` | Currency code |

--- a/skills/british-airways-search/SKILL.md
+++ b/skills/british-airways-search/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: British Airways Flight Search
+description: Search British Airways (BA) for available one-way flights on a given route and date. No Tabby required — uses the public BFF GET API. Returns flights with departure/arrival times, cabin availability, and fare families.
+---
+
+# British Airways Flight Search
+
+**No Tabby required** — stdlib urllib only.
+
+## Examples
+
+```bash
+.venv/bin/python3 skills/british-airways-search/operations/search_flights.py \
+  --origin LHR --destination JFK --date 2026-08-20
+
+.venv/bin/python3 skills/british-airways-search/operations/search_flights.py \
+  --origin JFK --destination LHR --date 2026-09-10 --cabin-class BUSINESS
+```

--- a/skills/british-airways-search/manifest.json
+++ b/skills/british-airways-search/manifest.json
@@ -1,0 +1,17 @@
+{
+  "skill_id": "british-airways-search",
+  "app": {"name": "British Airways", "slug": "british-airways-search"},
+  "workflow": {"session_id": "1b505250-a3a2-4865-8fa2-f4ec1d35e8ca", "start_url": "https://www.britishairways.com"},
+  "tabby": null,
+  "operations": [{
+    "name": "search_flights",
+    "description": "Search British Airways for available one-way flights. No Tabby required — public GET BFF endpoint.",
+    "args": [
+      {"name": "origin", "type": "string", "required": true, "description": "Departure IATA code (e.g. LHR, JFK)"},
+      {"name": "destination", "type": "string", "required": true, "description": "Arrival IATA code (e.g. JFK, LHR, SYD)"},
+      {"name": "date", "type": "string", "required": true, "description": "Departure date in YYYY-MM-DD format"},
+      {"name": "cabin_class", "type": "string", "required": false, "default": "ECONOMY", "description": "ECONOMY, PREMIUM_ECONOMY, BUSINESS, or FIRST"},
+      {"name": "adults", "type": "integer", "required": false, "default": 1}
+    ]
+  }]
+}

--- a/skills/british-airways-search/operations/search_flights.py
+++ b/skills/british-airways-search/operations/search_flights.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Search British Airways for available one-way flights on a given route and date.
+
+BA's BFF API (Next.js backend-for-frontend) is a public GET endpoint that does
+not require bot protection or session tokens. Headers include static BA app IDs
+and fresh UUIDs for correlation tracking.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+_SEARCH_URL = "https://www.britishairways.com/nx/b/bff/offer-flight/v0/oneway/outbound"
+_CABIN_MAP = {
+    "ECONOMY": "economy",
+    "PREMIUM_ECONOMY": "premiumeconomy",
+    "BUSINESS": "business",
+    "FIRST": "first",
+}
+
+_SKILL_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _search(
+    origin: str,
+    destination: str,
+    date: str,
+    cabin: str,
+    adults: int,
+    children: int,
+    infants: int,
+) -> dict[str, Any]:
+    params = (
+        f"?from={origin}&to={destination}&departureDate={date}"
+        f"&adults={adults}&youngAdults=0&children={children}&infants={infants}"
+        f"&page=1&maxResult=100&travelClass={cabin}"
+    )
+    req = urllib.request.Request(
+        _SEARCH_URL + params,
+        headers={
+            "Accept": "*/*",
+            "x-ba-application-name": "airselect",
+            "x-ba-client-name": "airselect",
+            "x-ba-market": "us",
+            "x-ba-language": "en",
+            "x-ba-channel": "WEB",
+            "x-ba-interaction-id": str(uuid.uuid4()),
+            "x-ba-request-id": str(uuid.uuid4()),
+            "x-ba-track-id": str(uuid.uuid4()),
+            "x-ba-device-id": str(uuid.uuid4()),
+            "x-ba-user-anon-id": str(uuid.uuid4()),
+            "x-amzn-waf-ba-rule": "EMPTY",
+            "x-ba-action-name": "search-flights-get-flights-oneway-outbound",
+            "Content-Type": "application/json",
+            "Referer": "https://www.britishairways.com/nx/b/airselect/en/usa/book/search/",
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+async def execute(
+    origin: str = "LHR",
+    destination: str = "JFK",
+    date: str = "2026-08-20",
+    cabin_class: str = "ECONOMY",
+    adults: int = 1,
+    children: int = 0,
+    infants: int = 0,
+) -> dict[str, Any]:
+    """Search British Airways for available one-way flights on a given route and date.
+
+    Args:
+        origin: Departure IATA airport code (e.g. "LHR", "LGW", "JFK").
+        destination: Arrival IATA airport code (e.g. "JFK", "LHR", "SYD").
+        date: Departure date in YYYY-MM-DD format.
+        cabin_class: ECONOMY, PREMIUM_ECONOMY, BUSINESS, or FIRST.
+        adults: Number of adult travelers.
+        children: Number of child travelers.
+        infants: Number of infant travelers.
+    """
+    cabin = _CABIN_MAP.get(cabin_class.upper(), "economy")
+    return await asyncio.get_event_loop().run_in_executor(
+        None, _search, origin, destination, date, cabin, adults, children, infants
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="search_flights",
+        description="Search British Airways for available flights on a given route and date.",
+    )
+    parser.add_argument("--origin", required=True, help='Departure IATA code, e.g. "LHR".')
+    parser.add_argument("--destination", required=True, help='Arrival IATA code, e.g. "JFK".')
+    parser.add_argument("--date", required=True, help="Departure date in YYYY-MM-DD format.")
+    parser.add_argument(
+        "--cabin-class",
+        default="ECONOMY",
+        choices=["ECONOMY", "PREMIUM_ECONOMY", "BUSINESS", "FIRST"],
+        help="Cabin class (default: ECONOMY).",
+    )
+    parser.add_argument("--adults", type=int, default=1)
+    parser.add_argument("--children", type=int, default=0)
+    parser.add_argument("--infants", type=int, default=0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = asyncio.run(
+            execute(
+                origin=args.origin,
+                destination=args.destination,
+                date=args.date,
+                cabin_class=args.cabin_class,
+                adults=args.adults,
+                children=args.children,
+                infants=args.infants,
+            )
+        )
+    except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+        print(f"search_flights failed: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"search_flights failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    if isinstance(result, dict) and result.get("error"):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add British Airways flight search skill using stdlib urllib
- Calls British Airways's internal availability API directly to return flight options with prices

## Why
Adds British Airways coverage to the airline flight search skill collection.

## Validation
Tested manually via the operation script against live routes.
Returns real flight data with prices.

## Checklist
- [ ] Tests added or updated (or explain why not)
- [x] Ran `ruff check`, `ruff format --check`, `mypy`, `pytest` locally
- [ ] Updated `CHANGELOG.md` if user-visible
- [x] No secrets or customer data in the diff
- [ ] If bumping the Tabby submodule, ran the compat matrix and updated the README compatibility section
