### PR TITLE
feat(skills): add JetBlue flight search skill

### DIFF
--- a/skills/jetblue-search/API.md
+++ b/skills/jetblue-search/API.md
@@ -1,0 +1,78 @@
+# API Reference: JetBlue Search
+
+## Endpoint
+
+**POST** `https://cb-api.jetblue.com/cb-flight-search/v1/search/NGB`
+
+Returns available flights for a given route and date with pricing and schedule details.
+
+## Authentication
+
+Static subscription key in request header — no session cookies required.
+
+```
+ocp-apim-subscription-key: a5ee654e981b4577a58264fed9b1669c
+```
+
+## Request
+
+**Content-Type:** `application/json`
+
+**Body:**
+
+```json
+{
+  "awardBooking": false,
+  "travelerTypes": [{"type": "ADULT", "quantity": 1}],
+  "searchComponents": [
+    {
+      "from": "JFK",
+      "to": "LAX",
+      "date": "2026-08-21"
+    }
+  ]
+}
+```
+
+## Response
+
+```json
+{
+  "status": {"transactionStatus": "success"},
+  "data": {
+    "searchResults": [
+      {
+        "productOffers": [
+          {
+            "originAndDestination": [
+              {
+                "originDestinationType": "NONSTOP",
+                "departure": {"date": "2026-08-21T06:00:00", "airport": "JFK", "terminal": "5"},
+                "arrival": {"date": "2026-08-21T08:48:00", "airport": "LAX", "terminal": "1"},
+                "stops": 0,
+                "totalDuration": 348,
+                "flightSegments": [...]
+              }
+            ],
+            "pricingDetail": [
+              {
+                "fareFamily": "Blue",
+                "price": {"totalPrice": 159.00, "currency": "USD"},
+                "fareAvailability": "AVAILABLE"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+| Field | Description |
+|---|---|
+| `originDestinationType` | `NONSTOP`, `ONE_STOP`, etc. |
+| `totalDuration` | Flight duration in minutes |
+| `fareFamily` | Fare class: `Blue`, `Blue Plus`, `Blue Extra`, `Mint` |
+| `price.totalPrice` | Total price per person |
+| `fareAvailability` | `AVAILABLE` or `SOLD_OUT` |

--- a/skills/jetblue-search/SKILL.md
+++ b/skills/jetblue-search/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: jetblue-search
+description: "Use this skill to search JetBlue flights for a given route and date. Returns available flights with pricing, schedules, and flight details. No Tabby required."
+---
+
+# JetBlue Search
+
+Search JetBlue's flight booking API for available flights between two airports on a given date.
+
+## Requirements
+
+No Tabby or browser session needed — uses a static public API subscription key.
+
+## Operations
+
+### `create_v1_search_ngb`
+
+Search for available JetBlue flights on a given route and date.
+
+| Argument | Required | Description |
+|---|---|---|
+| `--origin` | Yes | Origin metro or airport code, e.g. `JFK`, `NYC`, `BOS` |
+| `--destination` | Yes | Destination metro or airport code, e.g. `BOS`, `LAX`, `LON` |
+| `--date` | Yes | Departure date in YYYY-MM-DD format |
+| `--adults` | No | Number of adult travelers (default: 1) |
+| `--children` | No | Number of child travelers (default: 0) |
+| `--infants` | No | Number of infant travelers (default: 0) |
+
+## Examples
+
+```bash
+# JFK → LAX
+.venv/bin/python3 skills/jetblue-search/operations/create_v1_search_ngb.py \
+  --origin JFK --destination LAX --date 2026-08-21
+
+# NYC → LON for 2 adults
+.venv/bin/python3 skills/jetblue-search/operations/create_v1_search_ngb.py \
+  --origin NYC --destination LON --date 2026-08-15 --adults 2
+
+# BOS → FLL
+.venv/bin/python3 skills/jetblue-search/operations/create_v1_search_ngb.py \
+  --origin BOS --destination FLL --date 2026-09-01
+```
+
+## Notes
+
+- JetBlue uses metro codes (`NYC`, `LON`) as well as airport codes (`JFK`, `LHR`)
+- Returns full flight listings (not a price calendar) — includes flight number, departure/arrival times, pricing tiers, and stops
+- JetBlue operates primarily in the US, Caribbean, and select transatlantic routes (London, Amsterdam, Paris)
+- No bot protection — the static `ocp-apim-subscription-key` is sufficient

--- a/skills/jetblue-search/manifest.json
+++ b/skills/jetblue-search/manifest.json
@@ -1,0 +1,76 @@
+{
+  "schema_version": "1",
+  "skill_id": "jetblue-search",
+  "app": {
+    "name": "JetBlue Search",
+    "slug": "jetblue-search"
+  },
+  "workflow": {
+    "id": "jetblue-search",
+    "name": "JetBlue Search",
+    "workflow_session_id": null,
+    "start_url": "https://www.jetblue.com"
+  },
+  "auth": {
+    "requires_auth": false,
+    "profile_slug": null,
+    "profile_db_id": null,
+    "strategy": "none",
+    "execution_strategy": "stdlib",
+    "auth_plan_file": null
+  },
+  "runtime": {
+    "type": "claude-code-skill",
+    "entrypoint": "SKILL.md",
+    "operation_style": "subprocess-cli",
+    "python": ">=3.11"
+  },
+  "operations": [
+    {
+      "name": "create_v1_search_ngb",
+      "description": "Search JetBlue flights for a given route and date. Returns available flights with pricing, flight numbers, departure/arrival times, and stop information.",
+      "module": "operations/create_v1_search_ngb.py",
+      "entry": "execute",
+      "method": "POST",
+      "path": "/cb-flight-search/v1/search/NGB",
+      "args": [
+        {
+          "name": "origin",
+          "type": "string",
+          "required": true,
+          "description": "Origin metro or airport code, e.g. \"JFK\", \"NYC\", \"BOS\"."
+        },
+        {
+          "name": "destination",
+          "type": "string",
+          "required": true,
+          "description": "Destination metro or airport code, e.g. \"BOS\", \"LAX\", \"LON\"."
+        },
+        {
+          "name": "date",
+          "type": "string",
+          "required": true,
+          "description": "Departure date in YYYY-MM-DD format."
+        },
+        {
+          "name": "adults",
+          "type": "integer",
+          "required": false,
+          "description": "Number of adult travelers (default: 1)."
+        },
+        {
+          "name": "children",
+          "type": "integer",
+          "required": false,
+          "description": "Number of child travelers (default: 0)."
+        },
+        {
+          "name": "infants",
+          "type": "integer",
+          "required": false,
+          "description": "Number of infant travelers (default: 0)."
+        }
+      ]
+    }
+  ]
+}

--- a/skills/jetblue-search/operations/create_v1_search_ngb.py
+++ b/skills/jetblue-search/operations/create_v1_search_ngb.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Skill operation: create_v1_search_ngb
+Method: POST
+Path: /cb-flight-search/v1/search/NGB
+
+No Tabby required — static ocp-apim-subscription-key is sufficient for search.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from typing import Any
+
+BASE_URL = "https://cb-api.jetblue.com"
+
+_OCP_KEY = "a5ee654e981b4577a58264fed9b1669c"
+_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/148.0.0.0 Safari/537.36"
+)
+
+
+def execute(
+    origin: str = "JFK",
+    destination: str = "BOS",
+    date: str = "2026-08-21",
+    adults: int = 1,
+    children: int = 0,
+    infants: int = 0,
+) -> dict[str, Any]:
+    """Search JetBlue flights for a given route and date.
+
+    Args:
+        origin: Origin metro or airport code (e.g. "JFK", "NYC", "BOS").
+        destination: Destination metro or airport code (e.g. "BOS", "LAX", "LON").
+        date: Departure date in YYYY-MM-DD format.
+        adults: Number of adult travelers.
+        children: Number of child travelers.
+        infants: Number of infant travelers.
+    """
+    url = f"{BASE_URL}/cb-flight-search/v1/search/NGB"
+
+    traveler_types: list[dict[str, Any]] = [{"type": "ADULT", "quantity": adults}]
+    if children > 0:
+        traveler_types.append({"type": "CHILD", "quantity": children})
+    if infants > 0:
+        traveler_types.append({"type": "INFANT", "quantity": infants})
+
+    body = {
+        "awardBooking": False,
+        "travelerTypes": traveler_types,
+        "searchComponents": [
+            {
+                "from": origin,
+                "to": destination,
+                "date": date,
+            }
+        ],
+    }
+
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={
+            "Accept": "application/json, text/plain, */*",
+            "Content-Type": "application/json",
+            "ocp-apim-subscription-key": _OCP_KEY,
+            "Origin": "https://www.jetblue.com",
+            "Referer": "https://www.jetblue.com/",
+            "User-Agent": _UA,
+            "Sec-Fetch-Site": "same-site",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Dest": "empty",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="create_v1_search_ngb",
+        description="Search JetBlue flights for a given route and date.",
+    )
+    parser.add_argument(
+        "--origin", required=True, help='Origin metro/airport code, e.g. "JFK" or "NYC".'
+    )
+    parser.add_argument(
+        "--destination", required=True, help='Destination metro/airport code, e.g. "BOS" or "LAX".'
+    )
+    parser.add_argument("--date", required=True, help="Departure date in YYYY-MM-DD format.")
+    parser.add_argument("--adults", type=int, default=1, help="Number of adult travelers.")
+    parser.add_argument("--children", type=int, default=0, help="Number of child travelers.")
+    parser.add_argument("--infants", type=int, default=0, help="Number of infant travelers.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = execute(
+            origin=args.origin,
+            destination=args.destination,
+            date=args.date,
+            adults=args.adults,
+            children=args.children,
+            infants=args.infants,
+        )
+    except Exception as exc:
+        print(f"create_v1_search_ngb failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    if isinstance(result, dict) and "error" in result:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add JetBlue flight search skill using stdlib urllib
- Calls JetBlue's internal availability API directly to return flight options with prices

## Why
Adds JetBlue coverage to the airline flight search skill collection.

## Validation
Tested manually via the operation script against live routes.
Returns real flight data with prices.

## Checklist
- [ ] Tests added or updated (or explain why not)
- [x] Ran `ruff check`, `ruff format --check`, `mypy`, `pytest` locally
- [ ] Updated `CHANGELOG.md` if user-visible
- [x] No secrets or customer data in the diff
- [ ] If bumping the Tabby submodule, ran the compat matrix and updated the README compatibility section
