### PR TITLE
feat(capture): skip login recording when a matching App Template exists

### DIFF
--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -69,7 +69,9 @@ python scripts/activate_install.py workbench/skills/<app> claude-code
 **Record a login → registered Tabby profile:**
 
 ```bash
-python scripts/capture_record.py --mode login --url https://example.com/login
+python scripts/capture_record.py --mode login --url https://example.com/login --name example
+# ^ --name triggers a check for an existing App Template with a similar name + same URL;
+#   if one matches, the capture is skipped and a reuse command is printed instead (--force to bypass)
 # drive the login in VNC, finish, then:
 python scripts/capture_import.py <session_id> --promote          # needs TABBY_ADMIN_TOKEN
 ```

--- a/skills/noui/noui_core/capture/template_match.py
+++ b/skills/noui/noui_core/capture/template_match.py
@@ -1,0 +1,79 @@
+"""Pre-capture check: does a similar App Template already exist for this login?
+
+Runs before a **login** recording starts (see ``capture_record.py``) to avoid
+capturing a duplicate login for a site that's already registered. A match
+requires the candidate URL's origin to overlap one of the template's known
+origins (``login_config.login_url`` or ``export_policy.target_urls`` — see
+``login_assets.py::generate``) AND the given name to be similar to the
+template's ``name``. Both signals are required: same origin alone is common
+(multiple logins can share a host), and name similarity alone proves nothing
+about the site.
+"""
+
+from __future__ import annotations
+
+import difflib
+from urllib.parse import urlparse
+
+from noui_core import tabby_client
+
+NAME_SIMILARITY_THRESHOLD = 0.6
+
+
+def _origin(url: str) -> str:
+    try:
+        p = urlparse(url)
+        return f"{p.scheme}://{p.netloc}".lower()
+    except Exception:
+        return url.lower()
+
+
+def _template_origins(template: dict) -> set[str]:
+    origins = set()
+    login_url = (template.get("login_config") or {}).get("login_url") or ""
+    if login_url:
+        origins.add(_origin(login_url))
+    for pattern in (template.get("export_policy") or {}).get("target_urls") or []:
+        # target_urls entries are "<origin>/**" (see login_assets.generate) — strip
+        # the glob suffix back down to an origin before comparing.
+        origins.add(_origin(pattern.rstrip("*/")))
+    return {o for o in origins if o}
+
+
+def find_similar_templates(
+    name: str,
+    url: str,
+    token: str,
+    *,
+    name_threshold: float = NAME_SIMILARITY_THRESHOLD,
+) -> list[dict]:
+    """Return existing App Templates that look like duplicates of (name, url).
+
+    Each returned template dict has an added ``_name_score`` (difflib ratio,
+    case-insensitive), sorted highest-first. Best-effort: returns ``[]``
+    (never raises) if Tabby is unreachable or the lookup fails — this is a
+    pre-flight nicety, not a required gate on recording.
+    """
+    if not name or not url:
+        return []
+    candidate_origin = _origin(url)
+    if not candidate_origin:
+        return []
+    try:
+        templates = tabby_client.list_app_templates(token)
+    except RuntimeError:
+        return []
+
+    name_norm = name.strip().lower()
+    matches = []
+    for t in templates:
+        if candidate_origin not in _template_origins(t):
+            continue
+        t_name = (t.get("name") or "").strip().lower()
+        if not t_name:
+            continue
+        score = difflib.SequenceMatcher(None, name_norm, t_name).ratio()
+        if score >= name_threshold or name_norm in t_name or t_name in name_norm:
+            matches.append({**t, "_name_score": score})
+    matches.sort(key=lambda t: t["_name_score"], reverse=True)
+    return matches

--- a/skills/noui/noui_core/tabby_client.py
+++ b/skills/noui/noui_core/tabby_client.py
@@ -409,6 +409,23 @@ def update_app_template(template_id: str, payload: dict, token: str) -> dict:
     return resp
 
 
+def list_app_templates(token: str) -> list[dict]:
+    """
+    GET /admin/app-templates (list). No @Roles restriction on this endpoint
+    (unlike /apps/{id}, which is Admin/Operator/Viewer only), so any
+    authenticated bearer — including a plain agent token — can call it.
+
+    Returns the list of template dicts (``[]`` if the API returns none).
+    Raises RuntimeError on API errors.
+    """
+    resp = _tabby_http("GET", "/admin/app-templates", token=token)
+    if isinstance(resp, list):
+        return resp
+    if isinstance(resp, dict):
+        return resp.get("data") or resp.get("templates") or []
+    return []
+
+
 def get_app_template_by_profile_slug(profile_slug: str, token: str) -> dict | None:
     """
     GET /admin/app-templates (list), filtered client-side by
@@ -426,14 +443,7 @@ def get_app_template_by_profile_slug(profile_slug: str, token: str) -> dict | No
     Returns the template dict, or None if not found. Raises RuntimeError on
     other API errors.
     """
-    resp = _tabby_http("GET", "/admin/app-templates", token=token)
-    if isinstance(resp, list):
-        templates = resp
-    elif isinstance(resp, dict):
-        templates = resp.get("data") or resp.get("templates") or []
-    else:
-        templates = []
-    for t in templates:
+    for t in list_app_templates(token):
         if t.get("profile_name_pattern") == profile_slug:
             return t
     return None

--- a/skills/noui/references/pillar-1-capture.md
+++ b/skills/noui/references/pillar-1-capture.md
@@ -57,6 +57,23 @@ python scripts/capture_record.py --mode workflow --url https://example.com --fro
 
 Tabby pulls the source recording's cookies server-side; they never pass through NoUI.
 
+## Duplicate-template pre-check (`--mode login`)
+Before provisioning a **login** recording session, pass `--name`:
+
+```bash
+python scripts/capture_record.py --mode login --url https://example.com/login --name example
+```
+
+This checks Tabby's existing App Templates (`GET /admin/app-templates`, via `tabby_client.list_app_templates`) for one with the **same origin** (from `login_config.login_url` or `export_policy.target_urls`) **and** a similar `name` (`noui_core.capture.template_match.find_similar_templates`, fuzzy match + substring check, threshold 0.6). Both signals are required — same host alone is common across unrelated logins, and name similarity alone proves nothing about the site.
+
+If a match is found, the login capture is **skipped** (no session is provisioned): the matching template's name/slug/id are printed along with the command to go straight to workflow recording against that profile —
+
+```bash
+python scripts/capture_record.py --mode workflow --url <workflow-url> --profile <slug>
+```
+
+— since the login is already covered. Pass `--force` to record the login anyway (e.g. deliberately re-capturing a login to widen or refresh it). Without `--name`, the pre-check is skipped entirely (nothing to compare against).
+
 ## Login profiles: manual VNC takeover (the supported flow) + auto-resolve
 A login profile compiled in **takeover** mode (`capture_import --credential-mode takeover`, the default) uses `credential_ref: manual:` and a minimal login DSL — the supported Tabby flow, mirroring the Salesforce template:
 

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -2,11 +2,16 @@
 """Provision a Tabby VNC recording session and print the viewer URL.
 
     python scripts/capture_record.py --mode workflow --url https://example.com
-    python scripts/capture_record.py --mode login --url https://example.com/login
+    python scripts/capture_record.py --mode login --url https://example.com/login --name example
     python scripts/capture_record.py --mode workflow --from <login-session-id>
 
 Open the printed VNC URL, drive the browser, click "Finish & export", then:
     python scripts/capture_import.py <session_id>
+
+--mode login with --name set checks Tabby for an existing App Template with a
+similar name and the same URL first; if one is found, the capture is skipped
+and a command to reuse it for the workflow is printed instead (--force to
+bypass).
 """
 
 from __future__ import annotations
@@ -17,12 +22,25 @@ import sys
 import _bootstrap  # noqa: F401  (sys.path side effect)
 
 from noui_core.capture import recording
+from noui_core.capture.template_match import find_similar_templates
 
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--mode", choices=["login", "workflow"], default="workflow")
     p.add_argument("--url", default="", help="login/start URL to open")
+    p.add_argument(
+        "--name",
+        default="",
+        help="(login) name of the app/site being captured — used to check Tabby for an "
+        "existing App Template with a similar name and the same URL before recording, "
+        "so a login already covered by a template isn't captured again",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="(login) record anyway even if a matching App Template is found",
+    )
     p.add_argument(
         "--profile",
         default="",
@@ -38,6 +56,35 @@ def main() -> int:
         "when you just recorded the login in this same flow",
     )
     args = p.parse_args()
+
+    if args.mode == "login" and args.name and args.url and not args.force:
+        try:
+            token = recording.resolve_agent_token()
+            matches = find_similar_templates(args.name, args.url, token)
+        except RuntimeError:
+            matches = []
+        if matches:
+            best = matches[0]
+            slug = best.get("profile_name_pattern", "")
+            print(
+                f"An existing App Template looks like a match for {args.name!r} at {args.url}:",
+                file=sys.stderr,
+            )
+            print(f"  name  : {best.get('name')}", file=sys.stderr)
+            print(f"  slug  : {slug}", file=sys.stderr)
+            print(f"  id    : {best.get('id')}", file=sys.stderr)
+            print(file=sys.stderr)
+            print(
+                "Skipping the login capture — reuse this profile for the workflow instead:",
+                file=sys.stderr,
+            )
+            print(
+                f"  python scripts/capture_record.py --mode workflow --url <workflow-url> "
+                f"--profile {slug}",
+                file=sys.stderr,
+            )
+            print("(pass --force to record the login anyway)", file=sys.stderr)
+            return 0
 
     # provision_live_link verifies the session can serve a viewer and refreshes a
     # stale one (restart, else re-provision) before returning — so login_url is


### PR DESCRIPTION
## Summary
- Before a `--mode login` capture, check Tabby's existing App Templates for one with the same origin (from `login_config.login_url` or `export_policy.target_urls`) **and** a similar `--name` (fuzzy match).
- On a match, skip the login recording and print the reuse command (`--mode workflow --profile <slug>`) instead of provisioning a redundant session; pass `--force` to record anyway.
- Extracted `tabby_client.list_app_templates()` for reuse, added `noui_core/capture/template_match.py`, and updated `SKILL.md` / `references/pillar-1-capture.md` with the new flow.

## Test plan
- [x] `python3 -m py_compile` on all changed/new modules
- [x] Unit-level checks of `find_similar_templates`/`_template_origins`/`_origin` against mocked template data (same-origin+similar-name matches; differing on either axis correctly excludes)
- [x] End-to-end dry run of `capture_record.py --mode login --name ... --url ...` against a mocked `tabby_client.list_app_templates`, confirming the skip message, reuse command, and clean exit (no session provisioned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)