### PR TITLE
Add Trivago hotel comparison skills

### DIFF
--- a/skills/trivago-pricing/API.md
+++ b/skills/trivago-pricing/API.md
@@ -1,0 +1,3 @@
+# Trivago Pricing API
+
+`compare_prices` accepts destination, check-in/check-out dates, adults, limit, and an optional Tabby profile slug. It returns the official source URL, normalized public records, visible prices, and a bounded page summary.

--- a/skills/trivago-pricing/SKILL.md
+++ b/skills/trivago-pricing/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: trivago-pricing
+description: Use when the user wants to compare Trivago hotel prices, inspect public accommodation results, or review publicly displayed hotel prices for a destination and stay dates.
+---
+
+# Trivago Pricing
+
+Compare Trivago public hotel offers through Tabby `POST /execute/fetch`. Browser cookies and networking remain inside the Tabby session; never use CDP, extract credentials, or fall back to direct target-site HTTP.
+
+Requires a HEALTHY `trivago` profile plus Tabby API credentials.
+
+```bash
+python operations/run.py --destination "London" --check-in 2026-08-10 --check-out 2026-08-12 --adults 2
+```
+
+Treat prices as public snapshots. Confirm taxes, fees, availability, and cancellation terms on the selected booking provider before purchase.

--- a/skills/trivago-pricing/auth_plan.json
+++ b/skills/trivago-pricing/auth_plan.json
@@ -1,0 +1,10 @@
+{
+  "profile_slug": "trivago",
+  "profile_db_id": null,
+  "strategy": "tabby_credentials",
+  "target_domains": ["trivago.com", "www.trivago.com"],
+  "required_auth": {"headers": [], "cookies": []},
+  "observed_workflow_headers": {},
+  "tabby_export": {"credential_types": {"headers": [], "cookies": []}, "runtime_identifier": "trivago"},
+  "fallbacks": []
+}

--- a/skills/trivago-pricing/manifest.json
+++ b/skills/trivago-pricing/manifest.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "1",
+  "skill_id": "trivago-pricing",
+  "app": {"name": "Trivago Pricing", "slug": "trivago-pricing"},
+  "workflow": {"id": "trivago-pricing", "name": "Trivago Pricing"},
+  "auth": {"requires_auth": true, "profile_slug": "trivago", "profile_db_id": null, "strategy": "tabby_execute", "auth_plan_file": "auth_plan.json"},
+  "runtime": {"type": "claude-code-skill", "entrypoint": "SKILL.md", "operation_style": "subprocess-cli", "transport": "execute", "python": ">=3.11"},
+  "operations": [{
+    "name": "compare_prices",
+    "description": "Search public Trivago provider offers and visible prices through Tabby execute/fetch.",
+    "module": "operations/run.py",
+    "entry": "execute",
+    "args": [
+      {"name": "query", "type": "string", "required": false, "default": ""},
+      {"name": "origin", "type": "string", "required": false, "default": ""},
+      {"name": "destination", "type": "string", "required": false, "default": ""},
+      {"name": "departure", "type": "string", "required": false, "default": ""},
+      {"name": "return_date", "type": "string", "required": false, "default": ""},
+      {"name": "check_in", "type": "string", "required": false, "default": ""},
+      {"name": "check_out", "type": "string", "required": false, "default": ""},
+      {"name": "pickup", "type": "string", "required": false, "default": ""},
+      {"name": "dropoff", "type": "string", "required": false, "default": ""},
+      {"name": "url", "type": "string", "required": false, "default": ""},
+      {"name": "adults", "type": "integer", "required": false, "default": 1},
+      {"name": "limit", "type": "integer", "required": false, "default": 20},
+      {"name": "profile_slug", "type": "string", "required": false, "default": "trivago"}
+    ]
+  }],
+  "artifacts": {"skill_file": "SKILL.md", "api_docs_file": "API.md"},
+  "generation": {"generator": "noui", "generator_version": "v2-skill-sample"}
+}

--- a/skills/trivago-pricing/noui_runtime/auth.py
+++ b/skills/trivago-pricing/noui_runtime/auth.py
@@ -1,0 +1,172 @@
+"""NoUI runtime auth adapter — resolves live credentials from Tabby or static secrets.
+
+This is the Skill-output variant of the runtime. It differs from the MCP-server variant
+only in how it locates `.env`: skills can be installed at `~/.claude/skills/<skill_id>/`,
+far away from the `noui/` checkout, so the parents-index trick used by the MCP variant
+does not apply.
+
+Lookup order for `.env`:
+  1. `$NOUI_ENV_FILE` — explicit override.
+  2. Walk up from this file up to 6 parents looking for any file named `.env`
+     (covers both `skills/<skill>/noui_runtime/auth.py` in-repo and a generated tree).
+  3. `~/.config/noui/.env`, then `~/.noui/.env`.
+  4. Skip dotenv load and rely on already-exported env vars.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import httpx
+from dotenv import load_dotenv
+
+
+def _find_env_file() -> Path | None:
+    override = os.environ.get("NOUI_ENV_FILE")
+    if override:
+        p = Path(override).expanduser()
+        if p.is_file():
+            return p
+
+    here = Path(__file__).resolve()
+    for parent in [here, *here.parents][:7]:
+        candidate = parent / ".env"
+        if candidate.is_file():
+            return candidate
+
+    for fallback in (Path.home() / ".config" / "noui" / ".env", Path.home() / ".noui" / ".env"):
+        if fallback.is_file():
+            return fallback
+
+    return None
+
+
+_env_file = _find_env_file()
+if _env_file is not None:
+    load_dotenv(_env_file)
+
+TABBY_API_HOST = os.environ.get(
+    "TABBY_API_URL", os.environ.get("TABBY_API_HOST", "http://localhost:8080")
+)
+TABBY_CLIENT_ID = os.environ.get("TABBY_CLIENT_ID", "")
+TABBY_CLIENT_SECRET = os.environ.get("TABBY_CLIENT_SECRET", "")
+
+_AUTH_PLAN_PATH = Path(__file__).resolve().parent.parent / "auth_plan.json"
+
+
+def _load_auth_plan() -> dict:
+    try:
+        return json.loads(_AUTH_PLAN_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:
+        raise RuntimeError(f"Failed to read auth_plan.json: {exc}") from exc
+
+
+async def _get_agent_token() -> str:
+    if not TABBY_CLIENT_ID or not TABBY_CLIENT_SECRET:
+        raise RuntimeError(
+            "Missing TABBY_CLIENT_ID or TABBY_CLIENT_SECRET.\n"
+            "Set them in noui/.env, ~/.config/noui/.env, or export them in your shell."
+        )
+    url = f"{TABBY_API_HOST}/auth/agent-token"
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            url,
+            json={
+                "client_id": TABBY_CLIENT_ID,
+                "client_secret": TABBY_CLIENT_SECRET,
+                "grant_type": "client_credentials",
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    return data.get("access_token") or data.get("token", "")
+
+
+async def _tabby_credentials(profile_slug: str) -> dict:
+    agent_token = await _get_agent_token()
+    url = f"{TABBY_API_HOST}/credentials/request"
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            url,
+            json={"profile_id": profile_slug},
+            headers={"Authorization": f"Bearer {agent_token}"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    credentials = data.get("credentials", data)
+    headers: dict[str, str] = {}
+    for h in credentials.get("headers", []):
+        if h.get("name") and h.get("value"):
+            headers[h["name"]] = h["value"]
+    for cookie in credentials.get("cookies", []):
+        existing = headers.get("Cookie", "")
+        cname = cookie.get("name", "")
+        cval = cookie.get("value", "")
+        if cname:
+            headers["Cookie"] = f"{existing}; {cname}={cval}".lstrip("; ")
+    return headers
+
+
+def _static_secret_headers(plan: dict) -> dict:
+    headers: dict[str, str] = {}
+    for fallback in plan.get("fallbacks", []):
+        if fallback.get("type") != "static_secret_header":
+            continue
+        header_name = fallback["header"]
+        env_var = fallback["secret_env_var"]
+        value_template = fallback["value_template"]
+        secret = os.environ.get(env_var, "")
+        if not secret:
+            raise RuntimeError(
+                f"Missing required secret {env_var} for {header_name} header.\n"
+                f"Set {env_var} in noui/.env or export it in your shell."
+            )
+        placeholder = "${" + env_var + "}"
+        headers[header_name] = value_template.replace(placeholder, secret)
+    return headers
+
+
+async def resolve_auth(profile_slug_override: str | None = None) -> dict:
+    """Resolve auth headers/cookies for this skill based on auth_plan.json.
+
+    Returns a dict of {header_name: header_value} ready to pass to httpx.
+    Raises RuntimeError with a human-readable diagnostic on failure.
+
+    `profile_slug_override` lets a CLI `--profile-slug` flag take precedence over the
+    value baked into auth_plan.json — useful for testing against a non-default profile.
+    """
+    plan = _load_auth_plan()
+    strategy = plan.get("strategy", "tabby_credentials")
+
+    if strategy == "tabby_credentials":
+        profile_slug = (
+            profile_slug_override or os.environ.get("PROFILE_SLUG") or plan.get("profile_slug", "")
+        )
+        if not profile_slug:
+            raise RuntimeError(
+                "No profile_slug available. Set PROFILE_SLUG in the environment, "
+                "pass --profile-slug, or regenerate the skill with "
+                "`noui workflow export --as skill --profile-slug <slug>`."
+            )
+        creds = await _tabby_credentials(profile_slug)
+        required = plan.get("required_auth", {}).get("headers", [])
+        if required and not creds:
+            raise RuntimeError(
+                f"Tabby returned empty credentials for profile {profile_slug!r}.\n"
+                f"Required headers: {required}\n"
+                f"Verify the profile is ACTIVE and the Tabby session is live."
+            )
+        return creds
+
+    elif strategy == "static_secret_header":
+        return _static_secret_headers(plan)
+
+    else:
+        raise RuntimeError(
+            f"Unknown auth strategy {strategy!r} in auth_plan.json.\n"
+            f"Regenerate this skill with `noui workflow export --as skill`."
+        )

--- a/skills/trivago-pricing/noui_runtime/execute.py
+++ b/skills/trivago-pricing/noui_runtime/execute.py
@@ -1,0 +1,354 @@
+"""NoUI runtime execute adapter — fetch inside Tabby's authenticated browser session.
+
+Shared across MCP-server and Skill output formats. Calls the Tabby API's
+POST /execute/fetch endpoint, which routes to the worker pod and runs
+fetch() inside the real authenticated browser via page.evaluate().
+
+Why this module exists:
+  - Cookies and TLS fingerprint come from the real authenticated browser.
+  - No credential extraction on the Python side.
+  - Bypasses Akamai / Cloudflare false positives that fire on httpx requests.
+  - No WebSocket or CDP access needed — plain HTTP to the Tabby API.
+
+Auth modes (resolved from NOUI_TABBY_AUTH_MODE, else auto-detected):
+  - agent_token  : TABBY_CLIENT_ID / TABBY_CLIENT_SECRET via /auth/agent-token
+                   (local/self-host default; shared NULL-owner profile reach).
+  - platform_jwt : ADOPT_* platform credentials → platform JWT → Tabby JWT via
+                   /auth/token-exchange (cloud; carries owner_user_id, so the
+                   server resolves the caller's own profile and can auto-provision
+                   it from an App Template).
+
+Requires:
+  - A running Tabby session for the target profile.
+  - TABBY_API_URL env var (or .env) pointing to the Tabby API.
+  - agent_token mode: TABBY_CLIENT_ID / TABBY_CLIENT_SECRET.
+  - platform_jwt mode: ADOPT_API_URL / ADOPT_CLIENT_ID / ADOPT_CLIENT_SECRET.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+def _find_env_file() -> str | None:
+    """Walk up from this file to find .env, matching the auth adapter pattern."""
+    if os.environ.get("NOUI_ENV_FILE"):
+        return os.environ["NOUI_ENV_FILE"]
+    here = Path(__file__).resolve().parent
+    for _ in range(7):
+        candidate = here / ".env"
+        if candidate.exists():
+            return str(candidate)
+        here = here.parent
+    for fallback in (
+        Path.home() / ".config" / "noui" / ".env",
+        Path.home() / ".noui" / ".env",
+    ):
+        if fallback.exists():
+            return str(fallback)
+    return None
+
+
+def _load_env() -> None:
+    """Best-effort dotenv load."""
+    env_file = _find_env_file()
+    if not env_file:
+        return
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(env_file, override=False)
+    except ImportError:
+        pass
+
+
+_load_env()
+
+
+def _tabby_api_host() -> str:
+    """Resolve the Tabby API base URL from environment."""
+    return os.environ.get("TABBY_API_URL") or "http://localhost:8000"
+
+
+def _adopt_api_url() -> str:
+    return os.environ.get("ADOPT_API_URL", "").rstrip("/")
+
+
+def _resolve_auth_mode() -> str:
+    """Pick the Tabby auth flow: explicit NOUI_TABBY_AUTH_MODE wins, else auto-detect.
+
+    Auto-detect chooses platform_jwt when all three ADOPT_* credentials are
+    present, otherwise agent_token (the local/self-host default).
+    """
+    explicit = os.environ.get("NOUI_TABBY_AUTH_MODE", "").strip().lower()
+    if explicit:
+        return explicit
+    if (
+        _adopt_api_url()
+        and os.environ.get("ADOPT_CLIENT_ID")
+        and os.environ.get("ADOPT_CLIENT_SECRET")
+    ):
+        return "platform_jwt"
+    return "agent_token"
+
+
+async def _get_agent_token() -> tuple[str, int]:
+    """agent_token mode: exchange client credentials for an agent bearer token.
+
+    Reads TABBY_CLIENT_ID and TABBY_CLIENT_SECRET from env. Returns the token and
+    its TTL in seconds. This token has no owner_user_id, so the server resolves
+    only shared (NULL-owner) profiles.
+    """
+    client_id = os.environ.get("TABBY_CLIENT_ID", "")
+    client_secret = os.environ.get("TABBY_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "TABBY_CLIENT_ID and TABBY_CLIENT_SECRET must be set for agent_token mode. "
+            "Run `noui tabby setup`, set them in noui/.env, or switch to platform_jwt "
+            "mode (set ADOPT_* / NOUI_TABBY_AUTH_MODE=platform_jwt, or run "
+            "`noui tabby setup --cloud`)."
+        )
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{_tabby_api_host()}/auth/agent-token",
+            json={
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    token = data.get("access_token") or data.get("token", "")
+    if not token:
+        raise RuntimeError(f"POST /auth/agent-token returned no token: {data}")
+    return token, int(data.get("expires_in", 3600))
+
+
+async def _get_platform_jwt() -> str:
+    """platform_jwt mode step 1: exchange platform client credentials for a platform JWT.
+
+    Calls the Adopt platform proxy (POST /v1/users/api-token), which returns a
+    Frontegg-signed JWT that Tabby validates via its registered IdP.
+    """
+    adopt_api_url = _adopt_api_url()
+    if not adopt_api_url:
+        raise RuntimeError(
+            "Missing ADOPT_API_URL for platform_jwt auth mode.\n"
+            "Set ADOPT_API_URL (e.g. https://api.adopt.ai) in noui/.env "
+            "or run `noui tabby setup --cloud`."
+        )
+    client_id = os.environ.get("ADOPT_CLIENT_ID", "")
+    client_secret = os.environ.get("ADOPT_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "Missing ADOPT_CLIENT_ID or ADOPT_CLIENT_SECRET for platform_jwt auth mode.\n"
+            "Set these in noui/.env or run `noui tabby setup --cloud`."
+        )
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{adopt_api_url}/v1/users/api-token",
+            json={"client_id": client_id, "secret": client_secret},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    token = data.get("access_token", "")
+    if not token:
+        raise RuntimeError(f"Platform /v1/users/api-token returned no access_token: {data}")
+    return token
+
+
+async def _get_platform_tabby_token() -> tuple[str, int]:
+    """platform_jwt mode step 2: exchange the platform JWT for a Tabby JWT.
+
+    The exchanged Tabby JWT carries owner_user_id, so /execute/fetch resolves the
+    caller's own profile (and can trigger template auto-provisioning).
+    """
+    platform_jwt = await _get_platform_jwt()
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{_tabby_api_host()}/auth/token-exchange",
+            json={"subject_token": platform_jwt, "subject_token_type": "oidc_jwt"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    token = data.get("access_token", "")
+    if not token:
+        raise RuntimeError(f"Tabby /auth/token-exchange returned no access_token: {data}")
+    return token, int(data.get("expires_in", 3600))
+
+
+_TOKEN_REFRESH_MARGIN_SECONDS = 60
+_token_cache: dict[str, tuple[str, float]] = {}
+_token_lock = asyncio.Lock()
+
+
+async def _get_tabby_bearer() -> str:
+    """Return a valid Tabby bearer token for the active auth mode, cached in-process.
+
+    Mode is resolved from NOUI_TABBY_AUTH_MODE (explicit) or auto-detected from the
+    presence of ADOPT_* platform credentials. The token is cached per mode until
+    shortly before it expires, so repeated execute_fetch() calls reuse it instead
+    of re-running the exchange every time.
+    """
+    mode = _resolve_auth_mode()
+    async with _token_lock:
+        cached = _token_cache.get(mode)
+        if cached is not None and cached[1] > time.monotonic():
+            return cached[0]
+        if mode == "platform_jwt":
+            token, ttl = await _get_platform_tabby_token()
+        elif mode == "agent_token":
+            token, ttl = await _get_agent_token()
+        else:
+            raise RuntimeError(
+                f"Unknown NOUI_TABBY_AUTH_MODE {mode!r} — expected 'agent_token' or 'platform_jwt'."
+            )
+        _token_cache[mode] = (token, time.monotonic() + max(0, ttl - _TOKEN_REFRESH_MARGIN_SECONDS))
+        return token
+
+
+def _is_no_session(resp: httpx.Response) -> bool:
+    """True when the execute response means "there is no live session to run in".
+
+    Both 409 (session has no pod_name) and 404 (no ACTIVE/CANARY profile, or no
+    HEALTHY session for the app) mean "there is no live session". 404 is in fact
+    the *more common* case (a cold/never-started profile). Tabby phrases the 404
+    body as "No healthy session" / "No active profile" (credentials.service.ts) —
+    match on either so we don't mistake an upstream 404 from the target site
+    (which arrives wrapped in a 200 {status: 404} body) for a Tabby session gap.
+    """
+    if resp.status_code == 409:
+        return True
+    if resp.status_code == 404:
+        text = resp.text.lower()
+        return "no healthy session" in text or "no active profile" in text
+    return False
+
+
+async def _warm_up_session(profile_id: str, token: str) -> bool:
+    """Best-effort single warm-up to recover a cold/idle-shut profile.
+
+    `/execute/*` does not rescale an idle-shut app or trigger auto-provisioning;
+    `/credentials/request` does both (it catches "no healthy session", re-scales
+    the idle app to 1, and triggers autoProvisionFromTemplate). We issue exactly
+    one such request to nudge Tabby into bringing a session up, then let the
+    caller retry execute once. No polling, no loops — if the session is not ready
+    on the single retry, the normal actionable error surfaces.
+
+    Returns True if the warm-up request was accepted (so a retry is worthwhile),
+    False otherwise. Never raises: a failed warm-up must not mask the original
+    execute error.
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{_tabby_api_host()}/credentials/request",
+                json={"profile_id": profile_id},
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=30,
+            )
+    except (httpx.HTTPError, OSError):
+        return False
+    # 2xx (creds returned) or 202/409 (rescale kicked off, not ready yet) all
+    # indicate the warm-up reached Tabby and a retry may now succeed.
+    return resp.status_code < 500
+
+
+async def execute_fetch(
+    profile_id: str,
+    url: str,
+    *,
+    method: str = "GET",
+    body: Any = None,
+    headers: dict[str, str] | None = None,
+    timeout_ms: int = 30000,
+) -> Any:
+    """Execute fetch() inside the authenticated Tabby browser session.
+
+    The Tabby API resolves the profile to a healthy session, routes to the
+    worker pod, and runs page.evaluate(fetch(url, {credentials: 'include'}))
+    inside the real browser.
+
+    Args:
+        profile_id: Tabby profile slug (known at compile time from the workflow export).
+        url: Absolute URL to fetch.
+        method: HTTP method; defaults to GET.
+        body: Optional JSON-serializable body.
+        headers: Optional extra request headers.
+        timeout_ms: Timeout in milliseconds (default 30000, max 60000).
+
+    Returns:
+        Parsed JSON body on 2xx; raises RuntimeError on non-2xx or errors.
+
+    Set NOUI_EXECUTE_WARMUP=1 to opt into a single warm-up retry: on a
+    "no healthy session" 404/409 the runtime issues one POST /credentials/request
+    (which rescales an idle-shut app and triggers auto-provisioning) and retries
+    execute exactly once before surfacing the actionable error.
+    """
+    token = await _get_tabby_bearer()
+
+    request_body: dict[str, Any] = {
+        "profile_id": profile_id,
+        "url": url,
+        "method": method.upper(),
+        "timeout_ms": timeout_ms,
+    }
+    if headers:
+        request_body["headers"] = headers
+    if body is not None:
+        request_body["body"] = json.dumps(body) if not isinstance(body, str) else body
+
+    async def _post_execute() -> httpx.Response:
+        async with httpx.AsyncClient() as client:
+            return await client.post(
+                f"{_tabby_api_host()}/execute/fetch",
+                json=request_body,
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=timeout_ms / 1000 + 5,
+            )
+
+    resp = await _post_execute()
+
+    # B5: optional one-shot warm-up retry for a cold/idle-shut profile. Gated on
+    # an opt-in env var so the default path keeps its single-request latency.
+    warmup_enabled = os.environ.get("NOUI_EXECUTE_WARMUP", "").lower() in ("1", "true", "yes")
+    if warmup_enabled and _is_no_session(resp) and await _warm_up_session(profile_id, token):
+        resp = await _post_execute()
+
+    if resp.status_code == 429:
+        raise RuntimeError(f"Rate limited by Tabby API: {resp.text}")
+    if _is_no_session(resp):
+        raise RuntimeError(
+            f'No healthy Tabby session for profile "{profile_id}". '
+            "Run `tabby session ensure --profile <slug>` or check the admin UI."
+        )
+    if resp.status_code >= 400:
+        snippet = resp.text[:500]
+        raise RuntimeError(f"Tabby execute/fetch failed ({resp.status_code}): {snippet}")
+
+    data = resp.json()
+
+    # The worker returns {status, headers, body} — unwrap the response body
+    status = data.get("status", 0)
+    raw_body = data.get("body", "")
+
+    if not (200 <= status < 300):
+        snippet = (raw_body or "")[:500]
+        raise RuntimeError(f"{method.upper()} {url} -> {status}: {snippet}")
+
+    try:
+        return json.loads(raw_body) if raw_body else {}
+    except (ValueError, TypeError):
+        return {"status": status, "text": raw_body}

--- a/skills/trivago-pricing/noui_runtime/meta.py
+++ b/skills/trivago-pricing/noui_runtime/meta.py
@@ -1,0 +1,289 @@
+"""Public travel-meta discovery through Tabby execute/fetch."""
+
+from __future__ import annotations
+
+import html as html_module
+import json
+import re
+import urllib.parse
+from datetime import date
+from typing import Any
+
+from noui_runtime.execute import execute_fetch
+
+PLATFORM = "Trivago"
+BASE_URL = "https://www.trivago.com"
+PROFILE = "trivago"
+MODE = "pricing"
+ALLOWED_HOSTS = {"trivago.com", "www.trivago.com"}
+
+
+def _text(value: str) -> str:
+    value = re.sub(r"<(script|style)[^>]*>.*?</\1>", " ", value, flags=re.I | re.S)
+    value = re.sub(r"<[^>]+>", " ", value)
+    return re.sub(r"\s+", " ", html_module.unescape(value)).strip()
+
+
+def _validate_dates(start: str, end: str) -> None:
+    if start and end and date.fromisoformat(end) <= date.fromisoformat(start):
+        raise ValueError("end date must be after start date")
+
+
+def _build_url(
+    *,
+    query: str,
+    origin: str,
+    destination: str,
+    departure: str,
+    return_date: str,
+    check_in: str,
+    check_out: str,
+    pickup: str,
+    dropoff: str,
+    adults: int,
+) -> str:
+    _validate_dates(departure, return_date)
+    _validate_dates(check_in, check_out)
+    platform = PLATFORM.lower()
+    destination = destination or query
+
+    if platform == "google travel":
+        if MODE == "flights":
+            phrase = f"Flights from {origin} to {destination}"
+            if departure:
+                phrase += f" departing {departure}"
+            if return_date:
+                phrase += f" returning {return_date}"
+            return f"{BASE_URL}/travel/flights?{urllib.parse.urlencode({'q': phrase})}"
+        if MODE == "hotels":
+            phrase = f"Hotels in {destination}"
+            return f"{BASE_URL}/travel/search?{urllib.parse.urlencode({'q': phrase})}"
+        return f"{BASE_URL}/travel/explore?{urllib.parse.urlencode({'q': destination or query})}"
+
+    if platform == "momondo":
+        if MODE == "flights" and origin and destination and departure:
+            route = f"{origin.upper()}-{destination.upper()}/{departure}"
+            if return_date:
+                route += f"/{return_date}"
+            return f"{BASE_URL}/flight-search/{route}?sort=bestflight_a"
+        if MODE == "stays":
+            params = {"destination": destination, "checkin": check_in, "checkout": check_out}
+            return f"{BASE_URL}/hotels?{urllib.parse.urlencode(params)}"
+        if MODE == "cars":
+            params = {"pickup": pickup or destination, "dropoff": dropoff or pickup}
+            return f"{BASE_URL}/cars?{urllib.parse.urlencode(params)}"
+
+    if platform == "hopper":
+        tab = {"flights": "flights", "stays": "stays", "cars": "cars"}.get(MODE, MODE)
+        params = {
+            "activeTab": tab,
+            "origin": origin,
+            "destination": destination,
+            "departure": departure,
+            "return": return_date,
+            "checkIn": check_in,
+            "checkOut": check_out,
+            "pickup": pickup,
+            "dropoff": dropoff,
+            "adults": adults,
+        }
+        return f"{BASE_URL}/?{urllib.parse.urlencode({k: v for k, v in params.items() if v})}"
+
+    if platform == "tripadvisor":
+        if MODE == "reviews":
+            return f"{BASE_URL}/Search?{urllib.parse.urlencode({'q': query or destination})}"
+        params = {
+            "searchQuery": destination,
+            "checkIn": check_in,
+            "checkOut": check_out,
+            "adults": adults,
+        }
+        return f"{BASE_URL}/Hotels?{urllib.parse.urlencode({k: v for k, v in params.items() if v})}"
+
+    if platform == "trivago":
+        params = {
+            "search": destination,
+            "checkin": check_in,
+            "checkout": check_out,
+            "adults": adults,
+        }
+        return f"{BASE_URL}/en-US?{urllib.parse.urlencode({k: v for k, v in params.items() if v})}"
+
+    return f"{BASE_URL}/?{urllib.parse.urlencode({'q': query or destination})}"
+
+
+async def _fetch(url: str, profile_slug: str) -> str:
+    response = await execute_fetch(
+        profile_slug,
+        url,
+        headers={"accept": "text/html", "referer": f"{BASE_URL}/"},
+        timeout_ms=60_000,
+    )
+    status = int(response.get("status", 0)) if isinstance(response, dict) else 0
+    if status >= 400:
+        raise RuntimeError(f"{PLATFORM} returned HTTP {status} for {url}")
+    page = response.get("text", "") if isinstance(response, dict) else ""
+    if not page:
+        raise RuntimeError(f"{PLATFORM} returned an empty public page")
+    return page
+
+
+def _json_records(page: str) -> list[dict[str, Any]]:
+    found: dict[str, dict[str, Any]] = {}
+
+    def visit(value: Any) -> None:
+        if isinstance(value, list):
+            for item in value:
+                visit(item)
+            return
+        if not isinstance(value, dict):
+            return
+        kind = value.get("@type", "")
+        kinds = (
+            {str(item).lower() for item in kind} if isinstance(kind, list) else {str(kind).lower()}
+        )
+        if kinds & {
+            "hotel",
+            "lodgingbusiness",
+            "accommodation",
+            "touristattraction",
+            "flight",
+            "product",
+            "place",
+        }:
+            name = str(value.get("name") or "").strip()
+            url = urllib.parse.urljoin(BASE_URL, str(value.get("url") or value.get("@id") or ""))
+            if name:
+                key = url or name.lower()
+                rating = value.get("aggregateRating") or {}
+                offers = value.get("offers") or {}
+                if isinstance(offers, list):
+                    offers = offers[0] if offers else {}
+                found[key] = {
+                    "id": str(value.get("identifier") or key),
+                    "name": name,
+                    "url": url,
+                    "description": _text(str(value.get("description") or ""))[:500],
+                    "rating": rating.get("ratingValue") if isinstance(rating, dict) else None,
+                    "review_count": rating.get("reviewCount") if isinstance(rating, dict) else None,
+                    "price": offers.get("price") if isinstance(offers, dict) else None,
+                    "currency": offers.get("priceCurrency") if isinstance(offers, dict) else None,
+                }
+        for child in value.values():
+            if isinstance(child, (dict, list)):
+                visit(child)
+
+    for block in re.findall(
+        r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+        page,
+        flags=re.I | re.S,
+    ):
+        try:
+            visit(json.loads(html_module.unescape(block)))
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return list(found.values())
+
+
+def _link_records(page: str, query: str) -> list[dict[str, Any]]:
+    found: dict[str, dict[str, Any]] = {}
+    mode_hints = {
+        "flights": ("flight", "airport", "airline"),
+        "hotels": ("hotel", "lodging", "stay"),
+        "stays": ("hotel", "lodging", "stay"),
+        "cars": ("car", "rental"),
+        "explore": ("travel", "explore", "destination"),
+        "reviews": ("review", "hotel", "attraction", "restaurant"),
+        "pricing": ("hotel", "deal", "price"),
+        "properties": ("hotel", "property"),
+    }.get(MODE, (MODE,))
+    for href, inner in re.findall(
+        r'<a[^>]+href=["\']([^"\']+)["\'][^>]*>(.*?)</a>', page, flags=re.I | re.S
+    ):
+        label = _text(inner)
+        url = urllib.parse.urljoin(BASE_URL, html_module.unescape(href))
+        parsed = urllib.parse.urlparse(url)
+        if parsed.netloc and parsed.netloc not in ALLOWED_HOSTS:
+            continue
+        haystack = f"{label} {url}".lower()
+        if not label or len(label) > 240:
+            continue
+        matches_query = bool(query and query.lower() in haystack)
+        matches_mode = any(hint in haystack for hint in mode_hints)
+        if matches_query or (not query and matches_mode):
+            found[url] = {"id": url, "name": label, "url": url}
+    return list(found.values())
+
+
+def _prices(page: str) -> list[dict[str, Any]]:
+    text = _text(page)
+    values: dict[tuple[str, float], dict[str, Any]] = {}
+    pattern = r"(?P<currency>USD|EUR|GBP|AUD|CAD|INR|AED|₹|\$|€|£)\s*(?P<amount>[0-9][0-9,]*(?:\.\d{1,2})?)"
+    for match in re.finditer(pattern, text, flags=re.I):
+        amount = float(match.group("amount").replace(",", ""))
+        if 0 < amount < 1_000_000:
+            key = (match.group("currency").upper(), amount)
+            values[key] = {"currency": key[0], "amount": amount}
+    return sorted(values.values(), key=lambda item: item["amount"])[:50]
+
+
+async def run_public_search(
+    *,
+    query: str = "",
+    origin: str = "",
+    destination: str = "",
+    departure: str = "",
+    return_date: str = "",
+    check_in: str = "",
+    check_out: str = "",
+    pickup: str = "",
+    dropoff: str = "",
+    url: str = "",
+    adults: int = 1,
+    limit: int = 20,
+    profile_slug: str = PROFILE,
+) -> dict[str, Any]:
+    if adults < 1:
+        raise ValueError("adults must be positive")
+    if url:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in {"http", "https"} or parsed.netloc not in ALLOWED_HOSTS:
+            raise ValueError(f"url must belong to {PLATFORM}")
+        source_url = url
+    else:
+        source_url = _build_url(
+            query=query,
+            origin=origin,
+            destination=destination,
+            departure=departure,
+            return_date=return_date,
+            check_in=check_in,
+            check_out=check_out,
+            pickup=pickup,
+            dropoff=dropoff,
+            adults=adults,
+        )
+    page = await _fetch(source_url, profile_slug)
+    lookup = destination or query
+    structured = _json_records(page)
+    if lookup:
+        needle = lookup.lower()
+        structured = [
+            item
+            for item in structured
+            if needle
+            in f"{item.get('name', '')} {item.get('url', '')} {item.get('description', '')}".lower()
+        ]
+    records = structured or _link_records(page, lookup)
+    title_match = re.search(r"<title[^>]*>(.*?)</title>", page, flags=re.I | re.S)
+    return {
+        "platform": PLATFORM,
+        "mode": MODE,
+        "source_url": source_url,
+        "title": _text(title_match.group(1)) if title_match else "",
+        "results_count": len(records[: max(1, limit)]),
+        "results": records[: max(1, limit)],
+        "prices": _prices(page),
+        "public_summary": _text(page)[:2000],
+        "note": "Public meta-search prices are snapshots and may change on the booking provider.",
+    }

--- a/skills/trivago-pricing/operations/run.py
+++ b/skills/trivago-pricing/operations/run.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Search the public travel product through Tabby."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from noui_runtime.meta import run_public_search
+
+
+async def execute(**kwargs: object) -> dict:
+    profile = str(kwargs.pop("profile_slug", "") or os.environ.get("PROFILE_SLUG") or "trivago")
+    return await run_public_search(profile_slug=profile, **kwargs)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--query", default="")
+    parser.add_argument("--origin", default="")
+    parser.add_argument("--destination", default="")
+    parser.add_argument("--departure", default="")
+    parser.add_argument("--return-date", default="")
+    parser.add_argument("--check-in", default="")
+    parser.add_argument("--check-out", default="")
+    parser.add_argument("--pickup", default="")
+    parser.add_argument("--dropoff", default="")
+    parser.add_argument("--url", default="")
+    parser.add_argument("--adults", type=int, default=1)
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--profile-slug")
+    args = parser.parse_args()
+    try:
+        result = asyncio.run(
+            execute(
+                query=args.query,
+                origin=args.origin,
+                destination=args.destination,
+                departure=args.departure,
+                return_date=args.return_date,
+                check_in=args.check_in,
+                check_out=args.check_out,
+                pickup=args.pickup,
+                dropoff=args.dropoff,
+                url=args.url,
+                adults=args.adults,
+                limit=args.limit,
+                profile_slug=args.profile_slug,
+            )
+        )
+    except Exception as exc:
+        print(f"compare_prices failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/trivago-properties/API.md
+++ b/skills/trivago-properties/API.md
@@ -1,0 +1,3 @@
+# Trivago Properties API
+
+`get_property_details` accepts destination, check-in/check-out dates, adults, limit, and an optional Tabby profile slug. It returns the official source URL, normalized public records, visible prices, and a bounded page summary.

--- a/skills/trivago-properties/SKILL.md
+++ b/skills/trivago-properties/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: trivago-properties
+description: Use when the user wants to inspect Trivago properties, inspect public accommodation results, or review publicly displayed hotel prices for a destination and stay dates.
+---
+
+# Trivago Properties
+
+Inspect Trivago public property pages through Tabby `POST /execute/fetch`. Browser cookies and networking remain inside the Tabby session; never use CDP, extract credentials, or fall back to direct target-site HTTP.
+
+Requires a HEALTHY `trivago` profile plus Tabby API credentials.
+
+```bash
+python operations/run.py --destination "London" --check-in 2026-08-10 --check-out 2026-08-12 --adults 2
+```
+
+Treat prices as public snapshots. Confirm taxes, fees, availability, and cancellation terms on the selected booking provider before purchase.

--- a/skills/trivago-properties/auth_plan.json
+++ b/skills/trivago-properties/auth_plan.json
@@ -1,0 +1,10 @@
+{
+  "profile_slug": "trivago",
+  "profile_db_id": null,
+  "strategy": "tabby_credentials",
+  "target_domains": ["trivago.com", "www.trivago.com"],
+  "required_auth": {"headers": [], "cookies": []},
+  "observed_workflow_headers": {},
+  "tabby_export": {"credential_types": {"headers": [], "cookies": []}, "runtime_identifier": "trivago"},
+  "fallbacks": []
+}

--- a/skills/trivago-properties/manifest.json
+++ b/skills/trivago-properties/manifest.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "1",
+  "skill_id": "trivago-properties",
+  "app": {"name": "Trivago Properties", "slug": "trivago-properties"},
+  "workflow": {"id": "trivago-properties", "name": "Trivago Properties"},
+  "auth": {"requires_auth": true, "profile_slug": "trivago", "profile_db_id": null, "strategy": "tabby_execute", "auth_plan_file": "auth_plan.json"},
+  "runtime": {"type": "claude-code-skill", "entrypoint": "SKILL.md", "operation_style": "subprocess-cli", "transport": "execute", "python": ">=3.11"},
+  "operations": [{
+    "name": "get_property_details",
+    "description": "Search public Trivago property metadata and visible prices through Tabby execute/fetch.",
+    "module": "operations/run.py",
+    "entry": "execute",
+    "args": [
+      {"name": "query", "type": "string", "required": false, "default": ""},
+      {"name": "origin", "type": "string", "required": false, "default": ""},
+      {"name": "destination", "type": "string", "required": false, "default": ""},
+      {"name": "departure", "type": "string", "required": false, "default": ""},
+      {"name": "return_date", "type": "string", "required": false, "default": ""},
+      {"name": "check_in", "type": "string", "required": false, "default": ""},
+      {"name": "check_out", "type": "string", "required": false, "default": ""},
+      {"name": "pickup", "type": "string", "required": false, "default": ""},
+      {"name": "dropoff", "type": "string", "required": false, "default": ""},
+      {"name": "url", "type": "string", "required": false, "default": ""},
+      {"name": "adults", "type": "integer", "required": false, "default": 1},
+      {"name": "limit", "type": "integer", "required": false, "default": 20},
+      {"name": "profile_slug", "type": "string", "required": false, "default": "trivago"}
+    ]
+  }],
+  "artifacts": {"skill_file": "SKILL.md", "api_docs_file": "API.md"},
+  "generation": {"generator": "noui", "generator_version": "v2-skill-sample"}
+}

--- a/skills/trivago-properties/noui_runtime/auth.py
+++ b/skills/trivago-properties/noui_runtime/auth.py
@@ -1,0 +1,172 @@
+"""NoUI runtime auth adapter — resolves live credentials from Tabby or static secrets.
+
+This is the Skill-output variant of the runtime. It differs from the MCP-server variant
+only in how it locates `.env`: skills can be installed at `~/.claude/skills/<skill_id>/`,
+far away from the `noui/` checkout, so the parents-index trick used by the MCP variant
+does not apply.
+
+Lookup order for `.env`:
+  1. `$NOUI_ENV_FILE` — explicit override.
+  2. Walk up from this file up to 6 parents looking for any file named `.env`
+     (covers both `skills/<skill>/noui_runtime/auth.py` in-repo and a generated tree).
+  3. `~/.config/noui/.env`, then `~/.noui/.env`.
+  4. Skip dotenv load and rely on already-exported env vars.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import httpx
+from dotenv import load_dotenv
+
+
+def _find_env_file() -> Path | None:
+    override = os.environ.get("NOUI_ENV_FILE")
+    if override:
+        p = Path(override).expanduser()
+        if p.is_file():
+            return p
+
+    here = Path(__file__).resolve()
+    for parent in [here, *here.parents][:7]:
+        candidate = parent / ".env"
+        if candidate.is_file():
+            return candidate
+
+    for fallback in (Path.home() / ".config" / "noui" / ".env", Path.home() / ".noui" / ".env"):
+        if fallback.is_file():
+            return fallback
+
+    return None
+
+
+_env_file = _find_env_file()
+if _env_file is not None:
+    load_dotenv(_env_file)
+
+TABBY_API_HOST = os.environ.get(
+    "TABBY_API_URL", os.environ.get("TABBY_API_HOST", "http://localhost:8080")
+)
+TABBY_CLIENT_ID = os.environ.get("TABBY_CLIENT_ID", "")
+TABBY_CLIENT_SECRET = os.environ.get("TABBY_CLIENT_SECRET", "")
+
+_AUTH_PLAN_PATH = Path(__file__).resolve().parent.parent / "auth_plan.json"
+
+
+def _load_auth_plan() -> dict:
+    try:
+        return json.loads(_AUTH_PLAN_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:
+        raise RuntimeError(f"Failed to read auth_plan.json: {exc}") from exc
+
+
+async def _get_agent_token() -> str:
+    if not TABBY_CLIENT_ID or not TABBY_CLIENT_SECRET:
+        raise RuntimeError(
+            "Missing TABBY_CLIENT_ID or TABBY_CLIENT_SECRET.\n"
+            "Set them in noui/.env, ~/.config/noui/.env, or export them in your shell."
+        )
+    url = f"{TABBY_API_HOST}/auth/agent-token"
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            url,
+            json={
+                "client_id": TABBY_CLIENT_ID,
+                "client_secret": TABBY_CLIENT_SECRET,
+                "grant_type": "client_credentials",
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    return data.get("access_token") or data.get("token", "")
+
+
+async def _tabby_credentials(profile_slug: str) -> dict:
+    agent_token = await _get_agent_token()
+    url = f"{TABBY_API_HOST}/credentials/request"
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            url,
+            json={"profile_id": profile_slug},
+            headers={"Authorization": f"Bearer {agent_token}"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    credentials = data.get("credentials", data)
+    headers: dict[str, str] = {}
+    for h in credentials.get("headers", []):
+        if h.get("name") and h.get("value"):
+            headers[h["name"]] = h["value"]
+    for cookie in credentials.get("cookies", []):
+        existing = headers.get("Cookie", "")
+        cname = cookie.get("name", "")
+        cval = cookie.get("value", "")
+        if cname:
+            headers["Cookie"] = f"{existing}; {cname}={cval}".lstrip("; ")
+    return headers
+
+
+def _static_secret_headers(plan: dict) -> dict:
+    headers: dict[str, str] = {}
+    for fallback in plan.get("fallbacks", []):
+        if fallback.get("type") != "static_secret_header":
+            continue
+        header_name = fallback["header"]
+        env_var = fallback["secret_env_var"]
+        value_template = fallback["value_template"]
+        secret = os.environ.get(env_var, "")
+        if not secret:
+            raise RuntimeError(
+                f"Missing required secret {env_var} for {header_name} header.\n"
+                f"Set {env_var} in noui/.env or export it in your shell."
+            )
+        placeholder = "${" + env_var + "}"
+        headers[header_name] = value_template.replace(placeholder, secret)
+    return headers
+
+
+async def resolve_auth(profile_slug_override: str | None = None) -> dict:
+    """Resolve auth headers/cookies for this skill based on auth_plan.json.
+
+    Returns a dict of {header_name: header_value} ready to pass to httpx.
+    Raises RuntimeError with a human-readable diagnostic on failure.
+
+    `profile_slug_override` lets a CLI `--profile-slug` flag take precedence over the
+    value baked into auth_plan.json — useful for testing against a non-default profile.
+    """
+    plan = _load_auth_plan()
+    strategy = plan.get("strategy", "tabby_credentials")
+
+    if strategy == "tabby_credentials":
+        profile_slug = (
+            profile_slug_override or os.environ.get("PROFILE_SLUG") or plan.get("profile_slug", "")
+        )
+        if not profile_slug:
+            raise RuntimeError(
+                "No profile_slug available. Set PROFILE_SLUG in the environment, "
+                "pass --profile-slug, or regenerate the skill with "
+                "`noui workflow export --as skill --profile-slug <slug>`."
+            )
+        creds = await _tabby_credentials(profile_slug)
+        required = plan.get("required_auth", {}).get("headers", [])
+        if required and not creds:
+            raise RuntimeError(
+                f"Tabby returned empty credentials for profile {profile_slug!r}.\n"
+                f"Required headers: {required}\n"
+                f"Verify the profile is ACTIVE and the Tabby session is live."
+            )
+        return creds
+
+    elif strategy == "static_secret_header":
+        return _static_secret_headers(plan)
+
+    else:
+        raise RuntimeError(
+            f"Unknown auth strategy {strategy!r} in auth_plan.json.\n"
+            f"Regenerate this skill with `noui workflow export --as skill`."
+        )

--- a/skills/trivago-properties/noui_runtime/execute.py
+++ b/skills/trivago-properties/noui_runtime/execute.py
@@ -1,0 +1,354 @@
+"""NoUI runtime execute adapter — fetch inside Tabby's authenticated browser session.
+
+Shared across MCP-server and Skill output formats. Calls the Tabby API's
+POST /execute/fetch endpoint, which routes to the worker pod and runs
+fetch() inside the real authenticated browser via page.evaluate().
+
+Why this module exists:
+  - Cookies and TLS fingerprint come from the real authenticated browser.
+  - No credential extraction on the Python side.
+  - Bypasses Akamai / Cloudflare false positives that fire on httpx requests.
+  - No WebSocket or CDP access needed — plain HTTP to the Tabby API.
+
+Auth modes (resolved from NOUI_TABBY_AUTH_MODE, else auto-detected):
+  - agent_token  : TABBY_CLIENT_ID / TABBY_CLIENT_SECRET via /auth/agent-token
+                   (local/self-host default; shared NULL-owner profile reach).
+  - platform_jwt : ADOPT_* platform credentials → platform JWT → Tabby JWT via
+                   /auth/token-exchange (cloud; carries owner_user_id, so the
+                   server resolves the caller's own profile and can auto-provision
+                   it from an App Template).
+
+Requires:
+  - A running Tabby session for the target profile.
+  - TABBY_API_URL env var (or .env) pointing to the Tabby API.
+  - agent_token mode: TABBY_CLIENT_ID / TABBY_CLIENT_SECRET.
+  - platform_jwt mode: ADOPT_API_URL / ADOPT_CLIENT_ID / ADOPT_CLIENT_SECRET.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+def _find_env_file() -> str | None:
+    """Walk up from this file to find .env, matching the auth adapter pattern."""
+    if os.environ.get("NOUI_ENV_FILE"):
+        return os.environ["NOUI_ENV_FILE"]
+    here = Path(__file__).resolve().parent
+    for _ in range(7):
+        candidate = here / ".env"
+        if candidate.exists():
+            return str(candidate)
+        here = here.parent
+    for fallback in (
+        Path.home() / ".config" / "noui" / ".env",
+        Path.home() / ".noui" / ".env",
+    ):
+        if fallback.exists():
+            return str(fallback)
+    return None
+
+
+def _load_env() -> None:
+    """Best-effort dotenv load."""
+    env_file = _find_env_file()
+    if not env_file:
+        return
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(env_file, override=False)
+    except ImportError:
+        pass
+
+
+_load_env()
+
+
+def _tabby_api_host() -> str:
+    """Resolve the Tabby API base URL from environment."""
+    return os.environ.get("TABBY_API_URL") or "http://localhost:8000"
+
+
+def _adopt_api_url() -> str:
+    return os.environ.get("ADOPT_API_URL", "").rstrip("/")
+
+
+def _resolve_auth_mode() -> str:
+    """Pick the Tabby auth flow: explicit NOUI_TABBY_AUTH_MODE wins, else auto-detect.
+
+    Auto-detect chooses platform_jwt when all three ADOPT_* credentials are
+    present, otherwise agent_token (the local/self-host default).
+    """
+    explicit = os.environ.get("NOUI_TABBY_AUTH_MODE", "").strip().lower()
+    if explicit:
+        return explicit
+    if (
+        _adopt_api_url()
+        and os.environ.get("ADOPT_CLIENT_ID")
+        and os.environ.get("ADOPT_CLIENT_SECRET")
+    ):
+        return "platform_jwt"
+    return "agent_token"
+
+
+async def _get_agent_token() -> tuple[str, int]:
+    """agent_token mode: exchange client credentials for an agent bearer token.
+
+    Reads TABBY_CLIENT_ID and TABBY_CLIENT_SECRET from env. Returns the token and
+    its TTL in seconds. This token has no owner_user_id, so the server resolves
+    only shared (NULL-owner) profiles.
+    """
+    client_id = os.environ.get("TABBY_CLIENT_ID", "")
+    client_secret = os.environ.get("TABBY_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "TABBY_CLIENT_ID and TABBY_CLIENT_SECRET must be set for agent_token mode. "
+            "Run `noui tabby setup`, set them in noui/.env, or switch to platform_jwt "
+            "mode (set ADOPT_* / NOUI_TABBY_AUTH_MODE=platform_jwt, or run "
+            "`noui tabby setup --cloud`)."
+        )
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{_tabby_api_host()}/auth/agent-token",
+            json={
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    token = data.get("access_token") or data.get("token", "")
+    if not token:
+        raise RuntimeError(f"POST /auth/agent-token returned no token: {data}")
+    return token, int(data.get("expires_in", 3600))
+
+
+async def _get_platform_jwt() -> str:
+    """platform_jwt mode step 1: exchange platform client credentials for a platform JWT.
+
+    Calls the Adopt platform proxy (POST /v1/users/api-token), which returns a
+    Frontegg-signed JWT that Tabby validates via its registered IdP.
+    """
+    adopt_api_url = _adopt_api_url()
+    if not adopt_api_url:
+        raise RuntimeError(
+            "Missing ADOPT_API_URL for platform_jwt auth mode.\n"
+            "Set ADOPT_API_URL (e.g. https://api.adopt.ai) in noui/.env "
+            "or run `noui tabby setup --cloud`."
+        )
+    client_id = os.environ.get("ADOPT_CLIENT_ID", "")
+    client_secret = os.environ.get("ADOPT_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "Missing ADOPT_CLIENT_ID or ADOPT_CLIENT_SECRET for platform_jwt auth mode.\n"
+            "Set these in noui/.env or run `noui tabby setup --cloud`."
+        )
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{adopt_api_url}/v1/users/api-token",
+            json={"client_id": client_id, "secret": client_secret},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    token = data.get("access_token", "")
+    if not token:
+        raise RuntimeError(f"Platform /v1/users/api-token returned no access_token: {data}")
+    return token
+
+
+async def _get_platform_tabby_token() -> tuple[str, int]:
+    """platform_jwt mode step 2: exchange the platform JWT for a Tabby JWT.
+
+    The exchanged Tabby JWT carries owner_user_id, so /execute/fetch resolves the
+    caller's own profile (and can trigger template auto-provisioning).
+    """
+    platform_jwt = await _get_platform_jwt()
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{_tabby_api_host()}/auth/token-exchange",
+            json={"subject_token": platform_jwt, "subject_token_type": "oidc_jwt"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    token = data.get("access_token", "")
+    if not token:
+        raise RuntimeError(f"Tabby /auth/token-exchange returned no access_token: {data}")
+    return token, int(data.get("expires_in", 3600))
+
+
+_TOKEN_REFRESH_MARGIN_SECONDS = 60
+_token_cache: dict[str, tuple[str, float]] = {}
+_token_lock = asyncio.Lock()
+
+
+async def _get_tabby_bearer() -> str:
+    """Return a valid Tabby bearer token for the active auth mode, cached in-process.
+
+    Mode is resolved from NOUI_TABBY_AUTH_MODE (explicit) or auto-detected from the
+    presence of ADOPT_* platform credentials. The token is cached per mode until
+    shortly before it expires, so repeated execute_fetch() calls reuse it instead
+    of re-running the exchange every time.
+    """
+    mode = _resolve_auth_mode()
+    async with _token_lock:
+        cached = _token_cache.get(mode)
+        if cached is not None and cached[1] > time.monotonic():
+            return cached[0]
+        if mode == "platform_jwt":
+            token, ttl = await _get_platform_tabby_token()
+        elif mode == "agent_token":
+            token, ttl = await _get_agent_token()
+        else:
+            raise RuntimeError(
+                f"Unknown NOUI_TABBY_AUTH_MODE {mode!r} — expected 'agent_token' or 'platform_jwt'."
+            )
+        _token_cache[mode] = (token, time.monotonic() + max(0, ttl - _TOKEN_REFRESH_MARGIN_SECONDS))
+        return token
+
+
+def _is_no_session(resp: httpx.Response) -> bool:
+    """True when the execute response means "there is no live session to run in".
+
+    Both 409 (session has no pod_name) and 404 (no ACTIVE/CANARY profile, or no
+    HEALTHY session for the app) mean "there is no live session". 404 is in fact
+    the *more common* case (a cold/never-started profile). Tabby phrases the 404
+    body as "No healthy session" / "No active profile" (credentials.service.ts) —
+    match on either so we don't mistake an upstream 404 from the target site
+    (which arrives wrapped in a 200 {status: 404} body) for a Tabby session gap.
+    """
+    if resp.status_code == 409:
+        return True
+    if resp.status_code == 404:
+        text = resp.text.lower()
+        return "no healthy session" in text or "no active profile" in text
+    return False
+
+
+async def _warm_up_session(profile_id: str, token: str) -> bool:
+    """Best-effort single warm-up to recover a cold/idle-shut profile.
+
+    `/execute/*` does not rescale an idle-shut app or trigger auto-provisioning;
+    `/credentials/request` does both (it catches "no healthy session", re-scales
+    the idle app to 1, and triggers autoProvisionFromTemplate). We issue exactly
+    one such request to nudge Tabby into bringing a session up, then let the
+    caller retry execute once. No polling, no loops — if the session is not ready
+    on the single retry, the normal actionable error surfaces.
+
+    Returns True if the warm-up request was accepted (so a retry is worthwhile),
+    False otherwise. Never raises: a failed warm-up must not mask the original
+    execute error.
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{_tabby_api_host()}/credentials/request",
+                json={"profile_id": profile_id},
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=30,
+            )
+    except (httpx.HTTPError, OSError):
+        return False
+    # 2xx (creds returned) or 202/409 (rescale kicked off, not ready yet) all
+    # indicate the warm-up reached Tabby and a retry may now succeed.
+    return resp.status_code < 500
+
+
+async def execute_fetch(
+    profile_id: str,
+    url: str,
+    *,
+    method: str = "GET",
+    body: Any = None,
+    headers: dict[str, str] | None = None,
+    timeout_ms: int = 30000,
+) -> Any:
+    """Execute fetch() inside the authenticated Tabby browser session.
+
+    The Tabby API resolves the profile to a healthy session, routes to the
+    worker pod, and runs page.evaluate(fetch(url, {credentials: 'include'}))
+    inside the real browser.
+
+    Args:
+        profile_id: Tabby profile slug (known at compile time from the workflow export).
+        url: Absolute URL to fetch.
+        method: HTTP method; defaults to GET.
+        body: Optional JSON-serializable body.
+        headers: Optional extra request headers.
+        timeout_ms: Timeout in milliseconds (default 30000, max 60000).
+
+    Returns:
+        Parsed JSON body on 2xx; raises RuntimeError on non-2xx or errors.
+
+    Set NOUI_EXECUTE_WARMUP=1 to opt into a single warm-up retry: on a
+    "no healthy session" 404/409 the runtime issues one POST /credentials/request
+    (which rescales an idle-shut app and triggers auto-provisioning) and retries
+    execute exactly once before surfacing the actionable error.
+    """
+    token = await _get_tabby_bearer()
+
+    request_body: dict[str, Any] = {
+        "profile_id": profile_id,
+        "url": url,
+        "method": method.upper(),
+        "timeout_ms": timeout_ms,
+    }
+    if headers:
+        request_body["headers"] = headers
+    if body is not None:
+        request_body["body"] = json.dumps(body) if not isinstance(body, str) else body
+
+    async def _post_execute() -> httpx.Response:
+        async with httpx.AsyncClient() as client:
+            return await client.post(
+                f"{_tabby_api_host()}/execute/fetch",
+                json=request_body,
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=timeout_ms / 1000 + 5,
+            )
+
+    resp = await _post_execute()
+
+    # B5: optional one-shot warm-up retry for a cold/idle-shut profile. Gated on
+    # an opt-in env var so the default path keeps its single-request latency.
+    warmup_enabled = os.environ.get("NOUI_EXECUTE_WARMUP", "").lower() in ("1", "true", "yes")
+    if warmup_enabled and _is_no_session(resp) and await _warm_up_session(profile_id, token):
+        resp = await _post_execute()
+
+    if resp.status_code == 429:
+        raise RuntimeError(f"Rate limited by Tabby API: {resp.text}")
+    if _is_no_session(resp):
+        raise RuntimeError(
+            f'No healthy Tabby session for profile "{profile_id}". '
+            "Run `tabby session ensure --profile <slug>` or check the admin UI."
+        )
+    if resp.status_code >= 400:
+        snippet = resp.text[:500]
+        raise RuntimeError(f"Tabby execute/fetch failed ({resp.status_code}): {snippet}")
+
+    data = resp.json()
+
+    # The worker returns {status, headers, body} — unwrap the response body
+    status = data.get("status", 0)
+    raw_body = data.get("body", "")
+
+    if not (200 <= status < 300):
+        snippet = (raw_body or "")[:500]
+        raise RuntimeError(f"{method.upper()} {url} -> {status}: {snippet}")
+
+    try:
+        return json.loads(raw_body) if raw_body else {}
+    except (ValueError, TypeError):
+        return {"status": status, "text": raw_body}

--- a/skills/trivago-properties/noui_runtime/meta.py
+++ b/skills/trivago-properties/noui_runtime/meta.py
@@ -1,0 +1,289 @@
+"""Public travel-meta discovery through Tabby execute/fetch."""
+
+from __future__ import annotations
+
+import html as html_module
+import json
+import re
+import urllib.parse
+from datetime import date
+from typing import Any
+
+from noui_runtime.execute import execute_fetch
+
+PLATFORM = "Trivago"
+BASE_URL = "https://www.trivago.com"
+PROFILE = "trivago"
+MODE = "properties"
+ALLOWED_HOSTS = {"trivago.com", "www.trivago.com"}
+
+
+def _text(value: str) -> str:
+    value = re.sub(r"<(script|style)[^>]*>.*?</\1>", " ", value, flags=re.I | re.S)
+    value = re.sub(r"<[^>]+>", " ", value)
+    return re.sub(r"\s+", " ", html_module.unescape(value)).strip()
+
+
+def _validate_dates(start: str, end: str) -> None:
+    if start and end and date.fromisoformat(end) <= date.fromisoformat(start):
+        raise ValueError("end date must be after start date")
+
+
+def _build_url(
+    *,
+    query: str,
+    origin: str,
+    destination: str,
+    departure: str,
+    return_date: str,
+    check_in: str,
+    check_out: str,
+    pickup: str,
+    dropoff: str,
+    adults: int,
+) -> str:
+    _validate_dates(departure, return_date)
+    _validate_dates(check_in, check_out)
+    platform = PLATFORM.lower()
+    destination = destination or query
+
+    if platform == "google travel":
+        if MODE == "flights":
+            phrase = f"Flights from {origin} to {destination}"
+            if departure:
+                phrase += f" departing {departure}"
+            if return_date:
+                phrase += f" returning {return_date}"
+            return f"{BASE_URL}/travel/flights?{urllib.parse.urlencode({'q': phrase})}"
+        if MODE == "hotels":
+            phrase = f"Hotels in {destination}"
+            return f"{BASE_URL}/travel/search?{urllib.parse.urlencode({'q': phrase})}"
+        return f"{BASE_URL}/travel/explore?{urllib.parse.urlencode({'q': destination or query})}"
+
+    if platform == "momondo":
+        if MODE == "flights" and origin and destination and departure:
+            route = f"{origin.upper()}-{destination.upper()}/{departure}"
+            if return_date:
+                route += f"/{return_date}"
+            return f"{BASE_URL}/flight-search/{route}?sort=bestflight_a"
+        if MODE == "stays":
+            params = {"destination": destination, "checkin": check_in, "checkout": check_out}
+            return f"{BASE_URL}/hotels?{urllib.parse.urlencode(params)}"
+        if MODE == "cars":
+            params = {"pickup": pickup or destination, "dropoff": dropoff or pickup}
+            return f"{BASE_URL}/cars?{urllib.parse.urlencode(params)}"
+
+    if platform == "hopper":
+        tab = {"flights": "flights", "stays": "stays", "cars": "cars"}.get(MODE, MODE)
+        params = {
+            "activeTab": tab,
+            "origin": origin,
+            "destination": destination,
+            "departure": departure,
+            "return": return_date,
+            "checkIn": check_in,
+            "checkOut": check_out,
+            "pickup": pickup,
+            "dropoff": dropoff,
+            "adults": adults,
+        }
+        return f"{BASE_URL}/?{urllib.parse.urlencode({k: v for k, v in params.items() if v})}"
+
+    if platform == "tripadvisor":
+        if MODE == "reviews":
+            return f"{BASE_URL}/Search?{urllib.parse.urlencode({'q': query or destination})}"
+        params = {
+            "searchQuery": destination,
+            "checkIn": check_in,
+            "checkOut": check_out,
+            "adults": adults,
+        }
+        return f"{BASE_URL}/Hotels?{urllib.parse.urlencode({k: v for k, v in params.items() if v})}"
+
+    if platform == "trivago":
+        params = {
+            "search": destination,
+            "checkin": check_in,
+            "checkout": check_out,
+            "adults": adults,
+        }
+        return f"{BASE_URL}/en-US?{urllib.parse.urlencode({k: v for k, v in params.items() if v})}"
+
+    return f"{BASE_URL}/?{urllib.parse.urlencode({'q': query or destination})}"
+
+
+async def _fetch(url: str, profile_slug: str) -> str:
+    response = await execute_fetch(
+        profile_slug,
+        url,
+        headers={"accept": "text/html", "referer": f"{BASE_URL}/"},
+        timeout_ms=60_000,
+    )
+    status = int(response.get("status", 0)) if isinstance(response, dict) else 0
+    if status >= 400:
+        raise RuntimeError(f"{PLATFORM} returned HTTP {status} for {url}")
+    page = response.get("text", "") if isinstance(response, dict) else ""
+    if not page:
+        raise RuntimeError(f"{PLATFORM} returned an empty public page")
+    return page
+
+
+def _json_records(page: str) -> list[dict[str, Any]]:
+    found: dict[str, dict[str, Any]] = {}
+
+    def visit(value: Any) -> None:
+        if isinstance(value, list):
+            for item in value:
+                visit(item)
+            return
+        if not isinstance(value, dict):
+            return
+        kind = value.get("@type", "")
+        kinds = (
+            {str(item).lower() for item in kind} if isinstance(kind, list) else {str(kind).lower()}
+        )
+        if kinds & {
+            "hotel",
+            "lodgingbusiness",
+            "accommodation",
+            "touristattraction",
+            "flight",
+            "product",
+            "place",
+        }:
+            name = str(value.get("name") or "").strip()
+            url = urllib.parse.urljoin(BASE_URL, str(value.get("url") or value.get("@id") or ""))
+            if name:
+                key = url or name.lower()
+                rating = value.get("aggregateRating") or {}
+                offers = value.get("offers") or {}
+                if isinstance(offers, list):
+                    offers = offers[0] if offers else {}
+                found[key] = {
+                    "id": str(value.get("identifier") or key),
+                    "name": name,
+                    "url": url,
+                    "description": _text(str(value.get("description") or ""))[:500],
+                    "rating": rating.get("ratingValue") if isinstance(rating, dict) else None,
+                    "review_count": rating.get("reviewCount") if isinstance(rating, dict) else None,
+                    "price": offers.get("price") if isinstance(offers, dict) else None,
+                    "currency": offers.get("priceCurrency") if isinstance(offers, dict) else None,
+                }
+        for child in value.values():
+            if isinstance(child, (dict, list)):
+                visit(child)
+
+    for block in re.findall(
+        r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+        page,
+        flags=re.I | re.S,
+    ):
+        try:
+            visit(json.loads(html_module.unescape(block)))
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return list(found.values())
+
+
+def _link_records(page: str, query: str) -> list[dict[str, Any]]:
+    found: dict[str, dict[str, Any]] = {}
+    mode_hints = {
+        "flights": ("flight", "airport", "airline"),
+        "hotels": ("hotel", "lodging", "stay"),
+        "stays": ("hotel", "lodging", "stay"),
+        "cars": ("car", "rental"),
+        "explore": ("travel", "explore", "destination"),
+        "reviews": ("review", "hotel", "attraction", "restaurant"),
+        "pricing": ("hotel", "deal", "price"),
+        "properties": ("hotel", "property"),
+    }.get(MODE, (MODE,))
+    for href, inner in re.findall(
+        r'<a[^>]+href=["\']([^"\']+)["\'][^>]*>(.*?)</a>', page, flags=re.I | re.S
+    ):
+        label = _text(inner)
+        url = urllib.parse.urljoin(BASE_URL, html_module.unescape(href))
+        parsed = urllib.parse.urlparse(url)
+        if parsed.netloc and parsed.netloc not in ALLOWED_HOSTS:
+            continue
+        haystack = f"{label} {url}".lower()
+        if not label or len(label) > 240:
+            continue
+        matches_query = bool(query and query.lower() in haystack)
+        matches_mode = any(hint in haystack for hint in mode_hints)
+        if matches_query or (not query and matches_mode):
+            found[url] = {"id": url, "name": label, "url": url}
+    return list(found.values())
+
+
+def _prices(page: str) -> list[dict[str, Any]]:
+    text = _text(page)
+    values: dict[tuple[str, float], dict[str, Any]] = {}
+    pattern = r"(?P<currency>USD|EUR|GBP|AUD|CAD|INR|AED|₹|\$|€|£)\s*(?P<amount>[0-9][0-9,]*(?:\.\d{1,2})?)"
+    for match in re.finditer(pattern, text, flags=re.I):
+        amount = float(match.group("amount").replace(",", ""))
+        if 0 < amount < 1_000_000:
+            key = (match.group("currency").upper(), amount)
+            values[key] = {"currency": key[0], "amount": amount}
+    return sorted(values.values(), key=lambda item: item["amount"])[:50]
+
+
+async def run_public_search(
+    *,
+    query: str = "",
+    origin: str = "",
+    destination: str = "",
+    departure: str = "",
+    return_date: str = "",
+    check_in: str = "",
+    check_out: str = "",
+    pickup: str = "",
+    dropoff: str = "",
+    url: str = "",
+    adults: int = 1,
+    limit: int = 20,
+    profile_slug: str = PROFILE,
+) -> dict[str, Any]:
+    if adults < 1:
+        raise ValueError("adults must be positive")
+    if url:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in {"http", "https"} or parsed.netloc not in ALLOWED_HOSTS:
+            raise ValueError(f"url must belong to {PLATFORM}")
+        source_url = url
+    else:
+        source_url = _build_url(
+            query=query,
+            origin=origin,
+            destination=destination,
+            departure=departure,
+            return_date=return_date,
+            check_in=check_in,
+            check_out=check_out,
+            pickup=pickup,
+            dropoff=dropoff,
+            adults=adults,
+        )
+    page = await _fetch(source_url, profile_slug)
+    lookup = destination or query
+    structured = _json_records(page)
+    if lookup:
+        needle = lookup.lower()
+        structured = [
+            item
+            for item in structured
+            if needle
+            in f"{item.get('name', '')} {item.get('url', '')} {item.get('description', '')}".lower()
+        ]
+    records = structured or _link_records(page, lookup)
+    title_match = re.search(r"<title[^>]*>(.*?)</title>", page, flags=re.I | re.S)
+    return {
+        "platform": PLATFORM,
+        "mode": MODE,
+        "source_url": source_url,
+        "title": _text(title_match.group(1)) if title_match else "",
+        "results_count": len(records[: max(1, limit)]),
+        "results": records[: max(1, limit)],
+        "prices": _prices(page),
+        "public_summary": _text(page)[:2000],
+        "note": "Public meta-search prices are snapshots and may change on the booking provider.",
+    }

--- a/skills/trivago-properties/operations/run.py
+++ b/skills/trivago-properties/operations/run.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Search the public travel product through Tabby."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from noui_runtime.meta import run_public_search
+
+
+async def execute(**kwargs: object) -> dict:
+    profile = str(kwargs.pop("profile_slug", "") or os.environ.get("PROFILE_SLUG") or "trivago")
+    return await run_public_search(profile_slug=profile, **kwargs)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--query", default="")
+    parser.add_argument("--origin", default="")
+    parser.add_argument("--destination", default="")
+    parser.add_argument("--departure", default="")
+    parser.add_argument("--return-date", default="")
+    parser.add_argument("--check-in", default="")
+    parser.add_argument("--check-out", default="")
+    parser.add_argument("--pickup", default="")
+    parser.add_argument("--dropoff", default="")
+    parser.add_argument("--url", default="")
+    parser.add_argument("--adults", type=int, default=1)
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--profile-slug")
+    args = parser.parse_args()
+    try:
+        result = asyncio.run(
+            execute(
+                query=args.query,
+                origin=args.origin,
+                destination=args.destination,
+                departure=args.departure,
+                return_date=args.return_date,
+                check_in=args.check_in,
+                check_out=args.check_out,
+                pickup=args.pickup,
+                dropoff=args.dropoff,
+                url=args.url,
+                adults=args.adults,
+                limit=args.limit,
+                profile_slug=args.profile_slug,
+            )
+        )
+    except Exception as exc:
+        print(f"get_property_details failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/trivago-search/API.md
+++ b/skills/trivago-search/API.md
@@ -1,0 +1,3 @@
+# Trivago Search API
+
+`search_hotels` accepts destination, check-in/check-out dates, adults, limit, and an optional Tabby profile slug. It returns the official source URL, normalized public records, visible prices, and a bounded page summary.

--- a/skills/trivago-search/SKILL.md
+++ b/skills/trivago-search/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: trivago-search
+description: Use when the user wants to search Trivago hotels, inspect public accommodation results, or review publicly displayed hotel prices for a destination and stay dates.
+---
+
+# Trivago Search
+
+Search Trivago public hotel pages through Tabby `POST /execute/fetch`. Browser cookies and networking remain inside the Tabby session; never use CDP, extract credentials, or fall back to direct target-site HTTP.
+
+Requires a HEALTHY `trivago` profile plus Tabby API credentials.
+
+```bash
+python operations/run.py --destination "London" --check-in 2026-08-10 --check-out 2026-08-12 --adults 2
+```
+
+Treat prices as public snapshots. Confirm taxes, fees, availability, and cancellation terms on the selected booking provider before purchase.

--- a/skills/trivago-search/auth_plan.json
+++ b/skills/trivago-search/auth_plan.json
@@ -1,0 +1,10 @@
+{
+  "profile_slug": "trivago",
+  "profile_db_id": null,
+  "strategy": "tabby_credentials",
+  "target_domains": ["trivago.com", "www.trivago.com"],
+  "required_auth": {"headers": [], "cookies": []},
+  "observed_workflow_headers": {},
+  "tabby_export": {"credential_types": {"headers": [], "cookies": []}, "runtime_identifier": "trivago"},
+  "fallbacks": []
+}

--- a/skills/trivago-search/manifest.json
+++ b/skills/trivago-search/manifest.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "1",
+  "skill_id": "trivago-search",
+  "app": {"name": "Trivago Search", "slug": "trivago-search"},
+  "workflow": {"id": "trivago-search", "name": "Trivago Search"},
+  "auth": {"requires_auth": true, "profile_slug": "trivago", "profile_db_id": null, "strategy": "tabby_execute", "auth_plan_file": "auth_plan.json"},
+  "runtime": {"type": "claude-code-skill", "entrypoint": "SKILL.md", "operation_style": "subprocess-cli", "transport": "execute", "python": ">=3.11"},
+  "operations": [{
+    "name": "search_hotels",
+    "description": "Search public Trivago hotel results and prices through Tabby execute/fetch.",
+    "module": "operations/run.py",
+    "entry": "execute",
+    "args": [
+      {"name": "query", "type": "string", "required": false, "default": ""},
+      {"name": "origin", "type": "string", "required": false, "default": ""},
+      {"name": "destination", "type": "string", "required": false, "default": ""},
+      {"name": "departure", "type": "string", "required": false, "default": ""},
+      {"name": "return_date", "type": "string", "required": false, "default": ""},
+      {"name": "check_in", "type": "string", "required": false, "default": ""},
+      {"name": "check_out", "type": "string", "required": false, "default": ""},
+      {"name": "pickup", "type": "string", "required": false, "default": ""},
+      {"name": "dropoff", "type": "string", "required": false, "default": ""},
+      {"name": "url", "type": "string", "required": false, "default": ""},
+      {"name": "adults", "type": "integer", "required": false, "default": 1},
+      {"name": "limit", "type": "integer", "required": false, "default": 20},
+      {"name": "profile_slug", "type": "string", "required": false, "default": "trivago"}
+    ]
+  }],
+  "artifacts": {"skill_file": "SKILL.md", "api_docs_file": "API.md"},
+  "generation": {"generator": "noui", "generator_version": "v2-skill-sample"}
+}

--- a/skills/trivago-search/noui_runtime/auth.py
+++ b/skills/trivago-search/noui_runtime/auth.py
@@ -1,0 +1,172 @@
+"""NoUI runtime auth adapter — resolves live credentials from Tabby or static secrets.
+
+This is the Skill-output variant of the runtime. It differs from the MCP-server variant
+only in how it locates `.env`: skills can be installed at `~/.claude/skills/<skill_id>/`,
+far away from the `noui/` checkout, so the parents-index trick used by the MCP variant
+does not apply.
+
+Lookup order for `.env`:
+  1. `$NOUI_ENV_FILE` — explicit override.
+  2. Walk up from this file up to 6 parents looking for any file named `.env`
+     (covers both `skills/<skill>/noui_runtime/auth.py` in-repo and a generated tree).
+  3. `~/.config/noui/.env`, then `~/.noui/.env`.
+  4. Skip dotenv load and rely on already-exported env vars.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import httpx
+from dotenv import load_dotenv
+
+
+def _find_env_file() -> Path | None:
+    override = os.environ.get("NOUI_ENV_FILE")
+    if override:
+        p = Path(override).expanduser()
+        if p.is_file():
+            return p
+
+    here = Path(__file__).resolve()
+    for parent in [here, *here.parents][:7]:
+        candidate = parent / ".env"
+        if candidate.is_file():
+            return candidate
+
+    for fallback in (Path.home() / ".config" / "noui" / ".env", Path.home() / ".noui" / ".env"):
+        if fallback.is_file():
+            return fallback
+
+    return None
+
+
+_env_file = _find_env_file()
+if _env_file is not None:
+    load_dotenv(_env_file)
+
+TABBY_API_HOST = os.environ.get(
+    "TABBY_API_URL", os.environ.get("TABBY_API_HOST", "http://localhost:8080")
+)
+TABBY_CLIENT_ID = os.environ.get("TABBY_CLIENT_ID", "")
+TABBY_CLIENT_SECRET = os.environ.get("TABBY_CLIENT_SECRET", "")
+
+_AUTH_PLAN_PATH = Path(__file__).resolve().parent.parent / "auth_plan.json"
+
+
+def _load_auth_plan() -> dict:
+    try:
+        return json.loads(_AUTH_PLAN_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:
+        raise RuntimeError(f"Failed to read auth_plan.json: {exc}") from exc
+
+
+async def _get_agent_token() -> str:
+    if not TABBY_CLIENT_ID or not TABBY_CLIENT_SECRET:
+        raise RuntimeError(
+            "Missing TABBY_CLIENT_ID or TABBY_CLIENT_SECRET.\n"
+            "Set them in noui/.env, ~/.config/noui/.env, or export them in your shell."
+        )
+    url = f"{TABBY_API_HOST}/auth/agent-token"
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            url,
+            json={
+                "client_id": TABBY_CLIENT_ID,
+                "client_secret": TABBY_CLIENT_SECRET,
+                "grant_type": "client_credentials",
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    return data.get("access_token") or data.get("token", "")
+
+
+async def _tabby_credentials(profile_slug: str) -> dict:
+    agent_token = await _get_agent_token()
+    url = f"{TABBY_API_HOST}/credentials/request"
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            url,
+            json={"profile_id": profile_slug},
+            headers={"Authorization": f"Bearer {agent_token}"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    credentials = data.get("credentials", data)
+    headers: dict[str, str] = {}
+    for h in credentials.get("headers", []):
+        if h.get("name") and h.get("value"):
+            headers[h["name"]] = h["value"]
+    for cookie in credentials.get("cookies", []):
+        existing = headers.get("Cookie", "")
+        cname = cookie.get("name", "")
+        cval = cookie.get("value", "")
+        if cname:
+            headers["Cookie"] = f"{existing}; {cname}={cval}".lstrip("; ")
+    return headers
+
+
+def _static_secret_headers(plan: dict) -> dict:
+    headers: dict[str, str] = {}
+    for fallback in plan.get("fallbacks", []):
+        if fallback.get("type") != "static_secret_header":
+            continue
+        header_name = fallback["header"]
+        env_var = fallback["secret_env_var"]
+        value_template = fallback["value_template"]
+        secret = os.environ.get(env_var, "")
+        if not secret:
+            raise RuntimeError(
+                f"Missing required secret {env_var} for {header_name} header.\n"
+                f"Set {env_var} in noui/.env or export it in your shell."
+            )
+        placeholder = "${" + env_var + "}"
+        headers[header_name] = value_template.replace(placeholder, secret)
+    return headers
+
+
+async def resolve_auth(profile_slug_override: str | None = None) -> dict:
+    """Resolve auth headers/cookies for this skill based on auth_plan.json.
+
+    Returns a dict of {header_name: header_value} ready to pass to httpx.
+    Raises RuntimeError with a human-readable diagnostic on failure.
+
+    `profile_slug_override` lets a CLI `--profile-slug` flag take precedence over the
+    value baked into auth_plan.json — useful for testing against a non-default profile.
+    """
+    plan = _load_auth_plan()
+    strategy = plan.get("strategy", "tabby_credentials")
+
+    if strategy == "tabby_credentials":
+        profile_slug = (
+            profile_slug_override or os.environ.get("PROFILE_SLUG") or plan.get("profile_slug", "")
+        )
+        if not profile_slug:
+            raise RuntimeError(
+                "No profile_slug available. Set PROFILE_SLUG in the environment, "
+                "pass --profile-slug, or regenerate the skill with "
+                "`noui workflow export --as skill --profile-slug <slug>`."
+            )
+        creds = await _tabby_credentials(profile_slug)
+        required = plan.get("required_auth", {}).get("headers", [])
+        if required and not creds:
+            raise RuntimeError(
+                f"Tabby returned empty credentials for profile {profile_slug!r}.\n"
+                f"Required headers: {required}\n"
+                f"Verify the profile is ACTIVE and the Tabby session is live."
+            )
+        return creds
+
+    elif strategy == "static_secret_header":
+        return _static_secret_headers(plan)
+
+    else:
+        raise RuntimeError(
+            f"Unknown auth strategy {strategy!r} in auth_plan.json.\n"
+            f"Regenerate this skill with `noui workflow export --as skill`."
+        )

--- a/skills/trivago-search/noui_runtime/execute.py
+++ b/skills/trivago-search/noui_runtime/execute.py
@@ -1,0 +1,354 @@
+"""NoUI runtime execute adapter — fetch inside Tabby's authenticated browser session.
+
+Shared across MCP-server and Skill output formats. Calls the Tabby API's
+POST /execute/fetch endpoint, which routes to the worker pod and runs
+fetch() inside the real authenticated browser via page.evaluate().
+
+Why this module exists:
+  - Cookies and TLS fingerprint come from the real authenticated browser.
+  - No credential extraction on the Python side.
+  - Bypasses Akamai / Cloudflare false positives that fire on httpx requests.
+  - No WebSocket or CDP access needed — plain HTTP to the Tabby API.
+
+Auth modes (resolved from NOUI_TABBY_AUTH_MODE, else auto-detected):
+  - agent_token  : TABBY_CLIENT_ID / TABBY_CLIENT_SECRET via /auth/agent-token
+                   (local/self-host default; shared NULL-owner profile reach).
+  - platform_jwt : ADOPT_* platform credentials → platform JWT → Tabby JWT via
+                   /auth/token-exchange (cloud; carries owner_user_id, so the
+                   server resolves the caller's own profile and can auto-provision
+                   it from an App Template).
+
+Requires:
+  - A running Tabby session for the target profile.
+  - TABBY_API_URL env var (or .env) pointing to the Tabby API.
+  - agent_token mode: TABBY_CLIENT_ID / TABBY_CLIENT_SECRET.
+  - platform_jwt mode: ADOPT_API_URL / ADOPT_CLIENT_ID / ADOPT_CLIENT_SECRET.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+def _find_env_file() -> str | None:
+    """Walk up from this file to find .env, matching the auth adapter pattern."""
+    if os.environ.get("NOUI_ENV_FILE"):
+        return os.environ["NOUI_ENV_FILE"]
+    here = Path(__file__).resolve().parent
+    for _ in range(7):
+        candidate = here / ".env"
+        if candidate.exists():
+            return str(candidate)
+        here = here.parent
+    for fallback in (
+        Path.home() / ".config" / "noui" / ".env",
+        Path.home() / ".noui" / ".env",
+    ):
+        if fallback.exists():
+            return str(fallback)
+    return None
+
+
+def _load_env() -> None:
+    """Best-effort dotenv load."""
+    env_file = _find_env_file()
+    if not env_file:
+        return
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(env_file, override=False)
+    except ImportError:
+        pass
+
+
+_load_env()
+
+
+def _tabby_api_host() -> str:
+    """Resolve the Tabby API base URL from environment."""
+    return os.environ.get("TABBY_API_URL") or "http://localhost:8000"
+
+
+def _adopt_api_url() -> str:
+    return os.environ.get("ADOPT_API_URL", "").rstrip("/")
+
+
+def _resolve_auth_mode() -> str:
+    """Pick the Tabby auth flow: explicit NOUI_TABBY_AUTH_MODE wins, else auto-detect.
+
+    Auto-detect chooses platform_jwt when all three ADOPT_* credentials are
+    present, otherwise agent_token (the local/self-host default).
+    """
+    explicit = os.environ.get("NOUI_TABBY_AUTH_MODE", "").strip().lower()
+    if explicit:
+        return explicit
+    if (
+        _adopt_api_url()
+        and os.environ.get("ADOPT_CLIENT_ID")
+        and os.environ.get("ADOPT_CLIENT_SECRET")
+    ):
+        return "platform_jwt"
+    return "agent_token"
+
+
+async def _get_agent_token() -> tuple[str, int]:
+    """agent_token mode: exchange client credentials for an agent bearer token.
+
+    Reads TABBY_CLIENT_ID and TABBY_CLIENT_SECRET from env. Returns the token and
+    its TTL in seconds. This token has no owner_user_id, so the server resolves
+    only shared (NULL-owner) profiles.
+    """
+    client_id = os.environ.get("TABBY_CLIENT_ID", "")
+    client_secret = os.environ.get("TABBY_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "TABBY_CLIENT_ID and TABBY_CLIENT_SECRET must be set for agent_token mode. "
+            "Run `noui tabby setup`, set them in noui/.env, or switch to platform_jwt "
+            "mode (set ADOPT_* / NOUI_TABBY_AUTH_MODE=platform_jwt, or run "
+            "`noui tabby setup --cloud`)."
+        )
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{_tabby_api_host()}/auth/agent-token",
+            json={
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    token = data.get("access_token") or data.get("token", "")
+    if not token:
+        raise RuntimeError(f"POST /auth/agent-token returned no token: {data}")
+    return token, int(data.get("expires_in", 3600))
+
+
+async def _get_platform_jwt() -> str:
+    """platform_jwt mode step 1: exchange platform client credentials for a platform JWT.
+
+    Calls the Adopt platform proxy (POST /v1/users/api-token), which returns a
+    Frontegg-signed JWT that Tabby validates via its registered IdP.
+    """
+    adopt_api_url = _adopt_api_url()
+    if not adopt_api_url:
+        raise RuntimeError(
+            "Missing ADOPT_API_URL for platform_jwt auth mode.\n"
+            "Set ADOPT_API_URL (e.g. https://api.adopt.ai) in noui/.env "
+            "or run `noui tabby setup --cloud`."
+        )
+    client_id = os.environ.get("ADOPT_CLIENT_ID", "")
+    client_secret = os.environ.get("ADOPT_CLIENT_SECRET", "")
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "Missing ADOPT_CLIENT_ID or ADOPT_CLIENT_SECRET for platform_jwt auth mode.\n"
+            "Set these in noui/.env or run `noui tabby setup --cloud`."
+        )
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{adopt_api_url}/v1/users/api-token",
+            json={"client_id": client_id, "secret": client_secret},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    token = data.get("access_token", "")
+    if not token:
+        raise RuntimeError(f"Platform /v1/users/api-token returned no access_token: {data}")
+    return token
+
+
+async def _get_platform_tabby_token() -> tuple[str, int]:
+    """platform_jwt mode step 2: exchange the platform JWT for a Tabby JWT.
+
+    The exchanged Tabby JWT carries owner_user_id, so /execute/fetch resolves the
+    caller's own profile (and can trigger template auto-provisioning).
+    """
+    platform_jwt = await _get_platform_jwt()
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{_tabby_api_host()}/auth/token-exchange",
+            json={"subject_token": platform_jwt, "subject_token_type": "oidc_jwt"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    token = data.get("access_token", "")
+    if not token:
+        raise RuntimeError(f"Tabby /auth/token-exchange returned no access_token: {data}")
+    return token, int(data.get("expires_in", 3600))
+
+
+_TOKEN_REFRESH_MARGIN_SECONDS = 60
+_token_cache: dict[str, tuple[str, float]] = {}
+_token_lock = asyncio.Lock()
+
+
+async def _get_tabby_bearer() -> str:
+    """Return a valid Tabby bearer token for the active auth mode, cached in-process.
+
+    Mode is resolved from NOUI_TABBY_AUTH_MODE (explicit) or auto-detected from the
+    presence of ADOPT_* platform credentials. The token is cached per mode until
+    shortly before it expires, so repeated execute_fetch() calls reuse it instead
+    of re-running the exchange every time.
+    """
+    mode = _resolve_auth_mode()
+    async with _token_lock:
+        cached = _token_cache.get(mode)
+        if cached is not None and cached[1] > time.monotonic():
+            return cached[0]
+        if mode == "platform_jwt":
+            token, ttl = await _get_platform_tabby_token()
+        elif mode == "agent_token":
+            token, ttl = await _get_agent_token()
+        else:
+            raise RuntimeError(
+                f"Unknown NOUI_TABBY_AUTH_MODE {mode!r} — expected 'agent_token' or 'platform_jwt'."
+            )
+        _token_cache[mode] = (token, time.monotonic() + max(0, ttl - _TOKEN_REFRESH_MARGIN_SECONDS))
+        return token
+
+
+def _is_no_session(resp: httpx.Response) -> bool:
+    """True when the execute response means "there is no live session to run in".
+
+    Both 409 (session has no pod_name) and 404 (no ACTIVE/CANARY profile, or no
+    HEALTHY session for the app) mean "there is no live session". 404 is in fact
+    the *more common* case (a cold/never-started profile). Tabby phrases the 404
+    body as "No healthy session" / "No active profile" (credentials.service.ts) —
+    match on either so we don't mistake an upstream 404 from the target site
+    (which arrives wrapped in a 200 {status: 404} body) for a Tabby session gap.
+    """
+    if resp.status_code == 409:
+        return True
+    if resp.status_code == 404:
+        text = resp.text.lower()
+        return "no healthy session" in text or "no active profile" in text
+    return False
+
+
+async def _warm_up_session(profile_id: str, token: str) -> bool:
+    """Best-effort single warm-up to recover a cold/idle-shut profile.
+
+    `/execute/*` does not rescale an idle-shut app or trigger auto-provisioning;
+    `/credentials/request` does both (it catches "no healthy session", re-scales
+    the idle app to 1, and triggers autoProvisionFromTemplate). We issue exactly
+    one such request to nudge Tabby into bringing a session up, then let the
+    caller retry execute once. No polling, no loops — if the session is not ready
+    on the single retry, the normal actionable error surfaces.
+
+    Returns True if the warm-up request was accepted (so a retry is worthwhile),
+    False otherwise. Never raises: a failed warm-up must not mask the original
+    execute error.
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{_tabby_api_host()}/credentials/request",
+                json={"profile_id": profile_id},
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=30,
+            )
+    except (httpx.HTTPError, OSError):
+        return False
+    # 2xx (creds returned) or 202/409 (rescale kicked off, not ready yet) all
+    # indicate the warm-up reached Tabby and a retry may now succeed.
+    return resp.status_code < 500
+
+
+async def execute_fetch(
+    profile_id: str,
+    url: str,
+    *,
+    method: str = "GET",
+    body: Any = None,
+    headers: dict[str, str] | None = None,
+    timeout_ms: int = 30000,
+) -> Any:
+    """Execute fetch() inside the authenticated Tabby browser session.
+
+    The Tabby API resolves the profile to a healthy session, routes to the
+    worker pod, and runs page.evaluate(fetch(url, {credentials: 'include'}))
+    inside the real browser.
+
+    Args:
+        profile_id: Tabby profile slug (known at compile time from the workflow export).
+        url: Absolute URL to fetch.
+        method: HTTP method; defaults to GET.
+        body: Optional JSON-serializable body.
+        headers: Optional extra request headers.
+        timeout_ms: Timeout in milliseconds (default 30000, max 60000).
+
+    Returns:
+        Parsed JSON body on 2xx; raises RuntimeError on non-2xx or errors.
+
+    Set NOUI_EXECUTE_WARMUP=1 to opt into a single warm-up retry: on a
+    "no healthy session" 404/409 the runtime issues one POST /credentials/request
+    (which rescales an idle-shut app and triggers auto-provisioning) and retries
+    execute exactly once before surfacing the actionable error.
+    """
+    token = await _get_tabby_bearer()
+
+    request_body: dict[str, Any] = {
+        "profile_id": profile_id,
+        "url": url,
+        "method": method.upper(),
+        "timeout_ms": timeout_ms,
+    }
+    if headers:
+        request_body["headers"] = headers
+    if body is not None:
+        request_body["body"] = json.dumps(body) if not isinstance(body, str) else body
+
+    async def _post_execute() -> httpx.Response:
+        async with httpx.AsyncClient() as client:
+            return await client.post(
+                f"{_tabby_api_host()}/execute/fetch",
+                json=request_body,
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=timeout_ms / 1000 + 5,
+            )
+
+    resp = await _post_execute()
+
+    # B5: optional one-shot warm-up retry for a cold/idle-shut profile. Gated on
+    # an opt-in env var so the default path keeps its single-request latency.
+    warmup_enabled = os.environ.get("NOUI_EXECUTE_WARMUP", "").lower() in ("1", "true", "yes")
+    if warmup_enabled and _is_no_session(resp) and await _warm_up_session(profile_id, token):
+        resp = await _post_execute()
+
+    if resp.status_code == 429:
+        raise RuntimeError(f"Rate limited by Tabby API: {resp.text}")
+    if _is_no_session(resp):
+        raise RuntimeError(
+            f'No healthy Tabby session for profile "{profile_id}". '
+            "Run `tabby session ensure --profile <slug>` or check the admin UI."
+        )
+    if resp.status_code >= 400:
+        snippet = resp.text[:500]
+        raise RuntimeError(f"Tabby execute/fetch failed ({resp.status_code}): {snippet}")
+
+    data = resp.json()
+
+    # The worker returns {status, headers, body} — unwrap the response body
+    status = data.get("status", 0)
+    raw_body = data.get("body", "")
+
+    if not (200 <= status < 300):
+        snippet = (raw_body or "")[:500]
+        raise RuntimeError(f"{method.upper()} {url} -> {status}: {snippet}")
+
+    try:
+        return json.loads(raw_body) if raw_body else {}
+    except (ValueError, TypeError):
+        return {"status": status, "text": raw_body}

--- a/skills/trivago-search/noui_runtime/meta.py
+++ b/skills/trivago-search/noui_runtime/meta.py
@@ -1,0 +1,289 @@
+"""Public travel-meta discovery through Tabby execute/fetch."""
+
+from __future__ import annotations
+
+import html as html_module
+import json
+import re
+import urllib.parse
+from datetime import date
+from typing import Any
+
+from noui_runtime.execute import execute_fetch
+
+PLATFORM = "Trivago"
+BASE_URL = "https://www.trivago.com"
+PROFILE = "trivago"
+MODE = "hotels"
+ALLOWED_HOSTS = {"trivago.com", "www.trivago.com"}
+
+
+def _text(value: str) -> str:
+    value = re.sub(r"<(script|style)[^>]*>.*?</\1>", " ", value, flags=re.I | re.S)
+    value = re.sub(r"<[^>]+>", " ", value)
+    return re.sub(r"\s+", " ", html_module.unescape(value)).strip()
+
+
+def _validate_dates(start: str, end: str) -> None:
+    if start and end and date.fromisoformat(end) <= date.fromisoformat(start):
+        raise ValueError("end date must be after start date")
+
+
+def _build_url(
+    *,
+    query: str,
+    origin: str,
+    destination: str,
+    departure: str,
+    return_date: str,
+    check_in: str,
+    check_out: str,
+    pickup: str,
+    dropoff: str,
+    adults: int,
+) -> str:
+    _validate_dates(departure, return_date)
+    _validate_dates(check_in, check_out)
+    platform = PLATFORM.lower()
+    destination = destination or query
+
+    if platform == "google travel":
+        if MODE == "flights":
+            phrase = f"Flights from {origin} to {destination}"
+            if departure:
+                phrase += f" departing {departure}"
+            if return_date:
+                phrase += f" returning {return_date}"
+            return f"{BASE_URL}/travel/flights?{urllib.parse.urlencode({'q': phrase})}"
+        if MODE == "hotels":
+            phrase = f"Hotels in {destination}"
+            return f"{BASE_URL}/travel/search?{urllib.parse.urlencode({'q': phrase})}"
+        return f"{BASE_URL}/travel/explore?{urllib.parse.urlencode({'q': destination or query})}"
+
+    if platform == "momondo":
+        if MODE == "flights" and origin and destination and departure:
+            route = f"{origin.upper()}-{destination.upper()}/{departure}"
+            if return_date:
+                route += f"/{return_date}"
+            return f"{BASE_URL}/flight-search/{route}?sort=bestflight_a"
+        if MODE == "stays":
+            params = {"destination": destination, "checkin": check_in, "checkout": check_out}
+            return f"{BASE_URL}/hotels?{urllib.parse.urlencode(params)}"
+        if MODE == "cars":
+            params = {"pickup": pickup or destination, "dropoff": dropoff or pickup}
+            return f"{BASE_URL}/cars?{urllib.parse.urlencode(params)}"
+
+    if platform == "hopper":
+        tab = {"flights": "flights", "stays": "stays", "cars": "cars"}.get(MODE, MODE)
+        params = {
+            "activeTab": tab,
+            "origin": origin,
+            "destination": destination,
+            "departure": departure,
+            "return": return_date,
+            "checkIn": check_in,
+            "checkOut": check_out,
+            "pickup": pickup,
+            "dropoff": dropoff,
+            "adults": adults,
+        }
+        return f"{BASE_URL}/?{urllib.parse.urlencode({k: v for k, v in params.items() if v})}"
+
+    if platform == "tripadvisor":
+        if MODE == "reviews":
+            return f"{BASE_URL}/Search?{urllib.parse.urlencode({'q': query or destination})}"
+        params = {
+            "searchQuery": destination,
+            "checkIn": check_in,
+            "checkOut": check_out,
+            "adults": adults,
+        }
+        return f"{BASE_URL}/Hotels?{urllib.parse.urlencode({k: v for k, v in params.items() if v})}"
+
+    if platform == "trivago":
+        params = {
+            "search": destination,
+            "checkin": check_in,
+            "checkout": check_out,
+            "adults": adults,
+        }
+        return f"{BASE_URL}/en-US?{urllib.parse.urlencode({k: v for k, v in params.items() if v})}"
+
+    return f"{BASE_URL}/?{urllib.parse.urlencode({'q': query or destination})}"
+
+
+async def _fetch(url: str, profile_slug: str) -> str:
+    response = await execute_fetch(
+        profile_slug,
+        url,
+        headers={"accept": "text/html", "referer": f"{BASE_URL}/"},
+        timeout_ms=60_000,
+    )
+    status = int(response.get("status", 0)) if isinstance(response, dict) else 0
+    if status >= 400:
+        raise RuntimeError(f"{PLATFORM} returned HTTP {status} for {url}")
+    page = response.get("text", "") if isinstance(response, dict) else ""
+    if not page:
+        raise RuntimeError(f"{PLATFORM} returned an empty public page")
+    return page
+
+
+def _json_records(page: str) -> list[dict[str, Any]]:
+    found: dict[str, dict[str, Any]] = {}
+
+    def visit(value: Any) -> None:
+        if isinstance(value, list):
+            for item in value:
+                visit(item)
+            return
+        if not isinstance(value, dict):
+            return
+        kind = value.get("@type", "")
+        kinds = (
+            {str(item).lower() for item in kind} if isinstance(kind, list) else {str(kind).lower()}
+        )
+        if kinds & {
+            "hotel",
+            "lodgingbusiness",
+            "accommodation",
+            "touristattraction",
+            "flight",
+            "product",
+            "place",
+        }:
+            name = str(value.get("name") or "").strip()
+            url = urllib.parse.urljoin(BASE_URL, str(value.get("url") or value.get("@id") or ""))
+            if name:
+                key = url or name.lower()
+                rating = value.get("aggregateRating") or {}
+                offers = value.get("offers") or {}
+                if isinstance(offers, list):
+                    offers = offers[0] if offers else {}
+                found[key] = {
+                    "id": str(value.get("identifier") or key),
+                    "name": name,
+                    "url": url,
+                    "description": _text(str(value.get("description") or ""))[:500],
+                    "rating": rating.get("ratingValue") if isinstance(rating, dict) else None,
+                    "review_count": rating.get("reviewCount") if isinstance(rating, dict) else None,
+                    "price": offers.get("price") if isinstance(offers, dict) else None,
+                    "currency": offers.get("priceCurrency") if isinstance(offers, dict) else None,
+                }
+        for child in value.values():
+            if isinstance(child, (dict, list)):
+                visit(child)
+
+    for block in re.findall(
+        r'<script[^>]+type=["\']application/ld\+json["\'][^>]*>(.*?)</script>',
+        page,
+        flags=re.I | re.S,
+    ):
+        try:
+            visit(json.loads(html_module.unescape(block)))
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return list(found.values())
+
+
+def _link_records(page: str, query: str) -> list[dict[str, Any]]:
+    found: dict[str, dict[str, Any]] = {}
+    mode_hints = {
+        "flights": ("flight", "airport", "airline"),
+        "hotels": ("hotel", "lodging", "stay"),
+        "stays": ("hotel", "lodging", "stay"),
+        "cars": ("car", "rental"),
+        "explore": ("travel", "explore", "destination"),
+        "reviews": ("review", "hotel", "attraction", "restaurant"),
+        "pricing": ("hotel", "deal", "price"),
+        "properties": ("hotel", "property"),
+    }.get(MODE, (MODE,))
+    for href, inner in re.findall(
+        r'<a[^>]+href=["\']([^"\']+)["\'][^>]*>(.*?)</a>', page, flags=re.I | re.S
+    ):
+        label = _text(inner)
+        url = urllib.parse.urljoin(BASE_URL, html_module.unescape(href))
+        parsed = urllib.parse.urlparse(url)
+        if parsed.netloc and parsed.netloc not in ALLOWED_HOSTS:
+            continue
+        haystack = f"{label} {url}".lower()
+        if not label or len(label) > 240:
+            continue
+        matches_query = bool(query and query.lower() in haystack)
+        matches_mode = any(hint in haystack for hint in mode_hints)
+        if matches_query or (not query and matches_mode):
+            found[url] = {"id": url, "name": label, "url": url}
+    return list(found.values())
+
+
+def _prices(page: str) -> list[dict[str, Any]]:
+    text = _text(page)
+    values: dict[tuple[str, float], dict[str, Any]] = {}
+    pattern = r"(?P<currency>USD|EUR|GBP|AUD|CAD|INR|AED|₹|\$|€|£)\s*(?P<amount>[0-9][0-9,]*(?:\.\d{1,2})?)"
+    for match in re.finditer(pattern, text, flags=re.I):
+        amount = float(match.group("amount").replace(",", ""))
+        if 0 < amount < 1_000_000:
+            key = (match.group("currency").upper(), amount)
+            values[key] = {"currency": key[0], "amount": amount}
+    return sorted(values.values(), key=lambda item: item["amount"])[:50]
+
+
+async def run_public_search(
+    *,
+    query: str = "",
+    origin: str = "",
+    destination: str = "",
+    departure: str = "",
+    return_date: str = "",
+    check_in: str = "",
+    check_out: str = "",
+    pickup: str = "",
+    dropoff: str = "",
+    url: str = "",
+    adults: int = 1,
+    limit: int = 20,
+    profile_slug: str = PROFILE,
+) -> dict[str, Any]:
+    if adults < 1:
+        raise ValueError("adults must be positive")
+    if url:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.scheme not in {"http", "https"} or parsed.netloc not in ALLOWED_HOSTS:
+            raise ValueError(f"url must belong to {PLATFORM}")
+        source_url = url
+    else:
+        source_url = _build_url(
+            query=query,
+            origin=origin,
+            destination=destination,
+            departure=departure,
+            return_date=return_date,
+            check_in=check_in,
+            check_out=check_out,
+            pickup=pickup,
+            dropoff=dropoff,
+            adults=adults,
+        )
+    page = await _fetch(source_url, profile_slug)
+    lookup = destination or query
+    structured = _json_records(page)
+    if lookup:
+        needle = lookup.lower()
+        structured = [
+            item
+            for item in structured
+            if needle
+            in f"{item.get('name', '')} {item.get('url', '')} {item.get('description', '')}".lower()
+        ]
+    records = structured or _link_records(page, lookup)
+    title_match = re.search(r"<title[^>]*>(.*?)</title>", page, flags=re.I | re.S)
+    return {
+        "platform": PLATFORM,
+        "mode": MODE,
+        "source_url": source_url,
+        "title": _text(title_match.group(1)) if title_match else "",
+        "results_count": len(records[: max(1, limit)]),
+        "results": records[: max(1, limit)],
+        "prices": _prices(page),
+        "public_summary": _text(page)[:2000],
+        "note": "Public meta-search prices are snapshots and may change on the booking provider.",
+    }

--- a/skills/trivago-search/operations/run.py
+++ b/skills/trivago-search/operations/run.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Search the public travel product through Tabby."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from noui_runtime.meta import run_public_search
+
+
+async def execute(**kwargs: object) -> dict:
+    profile = str(kwargs.pop("profile_slug", "") or os.environ.get("PROFILE_SLUG") or "trivago")
+    return await run_public_search(profile_slug=profile, **kwargs)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--query", default="")
+    parser.add_argument("--origin", default="")
+    parser.add_argument("--destination", default="")
+    parser.add_argument("--departure", default="")
+    parser.add_argument("--return-date", default="")
+    parser.add_argument("--check-in", default="")
+    parser.add_argument("--check-out", default="")
+    parser.add_argument("--pickup", default="")
+    parser.add_argument("--dropoff", default="")
+    parser.add_argument("--url", default="")
+    parser.add_argument("--adults", type=int, default=1)
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--profile-slug")
+    args = parser.parse_args()
+    try:
+        result = asyncio.run(
+            execute(
+                query=args.query,
+                origin=args.origin,
+                destination=args.destination,
+                departure=args.departure,
+                return_date=args.return_date,
+                check_in=args.check_in,
+                check_out=args.check_out,
+                pickup=args.pickup,
+                dropoff=args.dropoff,
+                url=args.url,
+                adults=args.adults,
+                limit=args.limit,
+                profile_slug=args.profile_slug,
+            )
+        )
+    except Exception as exc:
+        print(f"search_hotels failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary
- Adds Trivago skills for search, pricing, and properties.
- Uses Tabby-routed /execute/fetch; no CDP, token extraction, booking submission, or payment action.

Validation
- Ruff check passed for skills/trivago-search skills/trivago-pricing skills/trivago-properties.
- Ruff format --check passed for the same skill directories.
- compileall passed for the same skill directories.

Live E2E
- Not run; requires a live HEALTHY trivago Tabby profile/session.