### PR TITLE
ci: deploy NoUI skill to platform default tier on dev/prod

### DIFF
--- a/.github/workflows/deploy-skill.yml
+++ b/.github/workflows/deploy-skill.yml
@@ -16,6 +16,11 @@ name: Deploy NoUI Skill
 # (Add a required-reviewer protection rule on `prod` to gate production deploys.)
 
 on:
+  pull_request:
+    paths:
+      - "skills/noui-harness/**"
+      - "skills/noui/**"
+      - ".github/workflows/deploy-skill.yml"
   push:
     branches: [dev, prod]
     paths:
@@ -37,8 +42,34 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # PR-time check: build the bundle and validate the publish payload assembles
+  # (frontmatter, non-empty aux) without minting a token or publishing. No
+  # environment / secrets needed, so it runs on every PR.
+  dry-run:
+    name: dry-run (validate publish payload)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build bundle
+        run: python skills/noui-harness/build_bundle.py
+
+      - name: Dry-run deploy (no publish)
+        env:
+          DRY_RUN: "1"
+          SKILL_NAME: noui
+          BUNDLE_VERSION: ${{ github.sha }}
+          MIN_PLATFORM_CONTRACT: "1"
+        run: python skills/noui-harness/deploy_default_skill.py
+
   deploy:
     name: deploy (${{ github.event.inputs.environment || github.ref_name }})
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || github.ref_name }}
     steps:

--- a/.github/workflows/deploy-skill.yml
+++ b/.github/workflows/deploy-skill.yml
@@ -1,0 +1,62 @@
+name: Deploy NoUI Skill
+
+# Publishes the NoUI harness skill to the platform default ("Built-in") tier.
+#
+#   push to `dev`  -> deploys to the `dev`  GitHub Environment  (dev webui)
+#   push to `prod` -> deploys to the `prod` GitHub Environment  (api.adopt.ai)
+#
+# Each environment supplies its own base URL + service-account PAT, so the
+# workflow itself is environment-agnostic. `workflow_dispatch` allows a manual
+# deploy to either environment.
+#
+# Required per-environment config (Settings > Environments > dev|prod):
+#   var    ADOPT_BASE_URL       e.g. https://api.adopt.ai
+#   secret ADOPT_CLIENT_ID      Adopt @adopt.ai service-account PAT client id
+#   secret ADOPT_CLIENT_SECRET  matching PAT secret
+# (Add a required-reviewer protection rule on `prod` to gate production deploys.)
+
+on:
+  push:
+    branches: [dev, prod]
+    paths:
+      - "skills/noui-harness/**"
+      - "skills/noui/**"
+      - ".github/workflows/deploy-skill.yml"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        type: choice
+        options: [dev, prod]
+        required: true
+
+# Serialize deploys to the same environment so two pushes can't race the
+# content-pointer flip.
+concurrency:
+  group: deploy-skill-${{ github.event.inputs.environment || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: deploy (${{ github.event.inputs.environment || github.ref_name }})
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build bundle
+        run: python skills/noui-harness/build_bundle.py
+
+      - name: Deploy default skill
+        env:
+          ADOPT_BASE_URL: ${{ vars.ADOPT_BASE_URL }}
+          ADOPT_CLIENT_ID: ${{ secrets.ADOPT_CLIENT_ID }}
+          ADOPT_CLIENT_SECRET: ${{ secrets.ADOPT_CLIENT_SECRET }}
+          SKILL_NAME: noui
+          BUNDLE_VERSION: ${{ github.sha }}
+          MIN_PLATFORM_CONTRACT: "1"
+        run: python skills/noui-harness/deploy_default_skill.py

--- a/.github/workflows/deploy-skill.yml
+++ b/.github/workflows/deploy-skill.yml
@@ -68,7 +68,7 @@ jobs:
         run: python skills/noui-harness/deploy_default_skill.py
 
   deploy:
-    name: deploy (${{ github.event.inputs.environment || github.ref_name }})
+    name: deploy
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment || github.ref_name }}

--- a/skills/noui-harness/deploy_default_skill.py
+++ b/skills/noui-harness/deploy_default_skill.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Deploy a harness skill to the platform **default** ("Built-in") tier.
+
+CI counterpart to ``build_bundle.py`` + ``publish_bundle.py``. Unlike
+``publish_bundle.py`` (which uploads an *org*-scoped copy via a pre-minted
+org-admin JWT), this targets the platform-wide default tier:
+
+    POST {base}/v1/end-user/agent-harness/default-skills
+
+That endpoint is gated by ``require_adopt_user`` (any ``@adopt.ai`` JWT), so
+this script mints the JWT itself from an Adopt service-account PAT
+(client_id/secret) via ``POST {base}/v1/users/api-token`` -- the exact flow a
+CI job uses. The token is never printed or written to disk.
+
+Env vars (all overridable by the matching flag):
+
+    ADOPT_BASE_URL         webui base, e.g. https://api.adopt.ai            (required)
+    ADOPT_CLIENT_ID        Adopt service-account PAT client id              (required)
+    ADOPT_CLIENT_SECRET    Adopt service-account PAT secret                 (required)
+    SKILL_NAME             catalog slug (default: noui)
+    BUNDLE_VERSION         CI label recorded on the pointer (default: "dev")
+    MIN_PLATFORM_CONTRACT  runtime contract the bundle needs (default: 1)
+    SKILL_MD               path to SKILL.md (default: this folder's SKILL.md)
+    AUX                    ':'-separated aux files as 'arcname=path' or 'path'
+                           (default: this folder's noui-bundle.zip)
+
+Publish is idempotent for identical bytes (content-addressed ``v=<hash>/``); a
+re-run with an unchanged bundle is a safe no-op pointer confirm. Exits non-zero
+on any HTTP error or if the post-publish verify does not report the skill live.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+
+
+def _env(name: str, default: str | None = None, *, required: bool = False) -> str:
+    val = os.environ.get(name, default)
+    if required and not val:
+        raise SystemExit(f"missing required env var: {name}")
+    return val or ""
+
+
+def _post_json(url: str, payload: dict, headers: dict) -> dict:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json", **headers},
+        method="POST",
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _get_json(url: str, headers: dict) -> dict:
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _mint_token(base: str, client_id: str, secret: str) -> str:
+    """Exchange a service-account PAT for a short-lived bearer JWT.
+
+    Returns the raw access_token; the caller must never log it."""
+    body = _post_json(
+        f"{base}/v1/users/api-token",
+        {"client_id": client_id, "secret": secret},
+        headers={},
+    )
+    token = body.get("access_token")
+    if not token:
+        raise SystemExit("token mint succeeded but response had no access_token")
+    return token
+
+
+def _load_aux(spec: str | None) -> list[dict]:
+    if not spec:
+        specs = [f"noui-bundle.zip={_HERE / 'noui-bundle.zip'}"]
+    else:
+        specs = [s for s in spec.split(":") if s]
+    aux: list[dict] = []
+    for item in specs:
+        arcname, _, path = item.partition("=")
+        if not path:  # bare path -> arcname is the basename
+            path, arcname = arcname, Path(arcname).name
+        aux.append(
+            {"path": arcname, "content_b64": base64.b64encode(Path(path).read_bytes()).decode()}
+        )
+    return aux
+
+
+def main() -> int:
+    base = _env("ADOPT_BASE_URL", required=True).rstrip("/")
+    client_id = _env("ADOPT_CLIENT_ID", required=True)
+    client_secret = _env("ADOPT_CLIENT_SECRET", required=True)
+    skill_name = _env("SKILL_NAME", "noui")
+    bundle_version = _env("BUNDLE_VERSION", "dev")
+    min_contract = int(_env("MIN_PLATFORM_CONTRACT", "1"))
+    skill_md_path = Path(_env("SKILL_MD", str(_HERE / "SKILL.md")))
+    aux = _load_aux(os.environ.get("AUX"))
+
+    skill_md = skill_md_path.read_bytes()
+    if not skill_md.lstrip().startswith(b"---"):
+        raise SystemExit(f"refusing to publish: {skill_md_path} has no YAML frontmatter")
+
+    print(
+        f"deploy '{skill_name}' -> {base} (default tier) "
+        f"[bundle_version={bundle_version}, min_platform_contract={min_contract}, "
+        f"SKILL.md {len(skill_md)}B, {len(aux)} aux]"
+    )
+
+    try:
+        token = _mint_token(base, client_id, client_secret)
+        auth = {"Authorization": f"Bearer {token}"}
+
+        payload = {
+            "skill_name": skill_name,
+            "skill_md_b64": base64.b64encode(skill_md).decode(),
+            "aux_files": aux,
+            "bundle_version": bundle_version,
+            "min_platform_contract": min_contract,
+        }
+        result = _post_json(
+            f"{base}/v1/end-user/agent-harness/default-skills", payload, auth
+        )
+        print(f"published content_dir={result.get('content_dir')}:")
+        for k in result.get("keys", []):
+            print("  ", k)
+
+        pointer = _get_json(
+            f"{base}/v1/end-user/agent-harness/default-skills/{skill_name}", auth
+        )
+    except urllib.error.HTTPError as e:
+        # Surface the upstream reason (409 min_platform_contract / 422 bad bundle),
+        # never the request auth header.
+        print(f"deploy failed: HTTP {e.code}: {e.read().decode()}", file=sys.stderr)
+        return 1
+
+    if not pointer.get("published"):
+        print(f"verify FAILED: skill not live after publish: {pointer}", file=sys.stderr)
+        return 1
+    print(
+        f"verified live: published={pointer.get('published')} "
+        f"bundle_version={pointer.get('bundle_version')} "
+        f"content_dir={pointer.get('content_dir')}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/noui-harness/deploy_default_skill.py
+++ b/skills/noui-harness/deploy_default_skill.py
@@ -23,6 +23,9 @@ Env vars (all overridable by the matching flag):
     SKILL_MD               path to SKILL.md (default: this folder's SKILL.md)
     AUX                    ':'-separated aux files as 'arcname=path' or 'path'
                            (default: this folder's noui-bundle.zip)
+    DRY_RUN                if truthy, validate + assemble the payload and exit
+                           without minting a token or publishing (PR-time check;
+                           needs no base URL or credentials)
 
 Publish is idempotent for identical bytes (content-addressed ``v=<hash>/``); a
 re-run with an unchanged bundle is a safe no-op pointer confirm. Exits non-zero
@@ -98,9 +101,7 @@ def _load_aux(spec: str | None) -> list[dict]:
 
 
 def main() -> int:
-    base = _env("ADOPT_BASE_URL", required=True).rstrip("/")
-    client_id = _env("ADOPT_CLIENT_ID", required=True)
-    client_secret = _env("ADOPT_CLIENT_SECRET", required=True)
+    dry_run = _env("DRY_RUN", "").lower() in ("1", "true", "yes")
     skill_name = _env("SKILL_NAME", "noui")
     bundle_version = _env("BUNDLE_VERSION", "dev")
     min_contract = int(_env("MIN_PLATFORM_CONTRACT", "1"))
@@ -111,33 +112,45 @@ def main() -> int:
     if not skill_md.lstrip().startswith(b"---"):
         raise SystemExit(f"refusing to publish: {skill_md_path} has no YAML frontmatter")
 
+    payload = {
+        "skill_name": skill_name,
+        "skill_md_b64": base64.b64encode(skill_md).decode(),
+        "aux_files": aux,
+        "bundle_version": bundle_version,
+        "min_platform_contract": min_contract,
+    }
+
     print(
-        f"deploy '{skill_name}' -> {base} (default tier) "
-        f"[bundle_version={bundle_version}, min_platform_contract={min_contract}, "
-        f"SKILL.md {len(skill_md)}B, {len(aux)} aux]"
+        f"skill='{skill_name}' bundle_version={bundle_version} "
+        f"min_platform_contract={min_contract} SKILL.md={len(skill_md)}B "
+        f"aux={[(a['path'], len(base64.b64decode(a['content_b64']))) for a in aux]}"
     )
+
+    if dry_run:
+        # PR-time safety check: prove the bundle is publishable (frontmatter,
+        # non-empty aux, payload assembles) WITHOUT minting a token or writing
+        # anything. Needs no base URL or credentials, so it runs on every PR.
+        for a in aux:
+            if not a["content_b64"]:
+                raise SystemExit(f"aux file {a['path']!r} is empty")
+        approx = len(payload["skill_md_b64"]) + sum(len(a["content_b64"]) for a in aux)
+        print(f"DRY RUN OK: payload assembles (~{approx}B base64); skipping mint + publish.")
+        return 0
+
+    base = _env("ADOPT_BASE_URL", required=True).rstrip("/")
+    client_id = _env("ADOPT_CLIENT_ID", required=True)
+    client_secret = _env("ADOPT_CLIENT_SECRET", required=True)
+    print(f"publishing to {base} (default tier)")
 
     try:
         token = _mint_token(base, client_id, client_secret)
         auth = {"Authorization": f"Bearer {token}"}
-
-        payload = {
-            "skill_name": skill_name,
-            "skill_md_b64": base64.b64encode(skill_md).decode(),
-            "aux_files": aux,
-            "bundle_version": bundle_version,
-            "min_platform_contract": min_contract,
-        }
-        result = _post_json(
-            f"{base}/v1/end-user/agent-harness/default-skills", payload, auth
-        )
+        result = _post_json(f"{base}/v1/end-user/agent-harness/default-skills", payload, auth)
         print(f"published content_dir={result.get('content_dir')}:")
         for k in result.get("keys", []):
             print("  ", k)
 
-        pointer = _get_json(
-            f"{base}/v1/end-user/agent-harness/default-skills/{skill_name}", auth
-        )
+        pointer = _get_json(f"{base}/v1/end-user/agent-harness/default-skills/{skill_name}", auth)
     except urllib.error.HTTPError as e:
         # Surface the upstream reason (409 min_platform_contract / 422 bad bundle),
         # never the request auth header.

--- a/skills/noui-harness/deploy_default_skill.py
+++ b/skills/noui-harness/deploy_default_skill.py
@@ -112,9 +112,10 @@ def main() -> int:
     if not skill_md.lstrip().startswith(b"---"):
         raise SystemExit(f"refusing to publish: {skill_md_path} has no YAML frontmatter")
 
+    skill_md_b64 = base64.b64encode(skill_md).decode()
     payload = {
         "skill_name": skill_name,
-        "skill_md_b64": base64.b64encode(skill_md).decode(),
+        "skill_md_b64": skill_md_b64,
         "aux_files": aux,
         "bundle_version": bundle_version,
         "min_platform_contract": min_contract,
@@ -133,7 +134,7 @@ def main() -> int:
         for a in aux:
             if not a["content_b64"]:
                 raise SystemExit(f"aux file {a['path']!r} is empty")
-        approx = len(payload["skill_md_b64"]) + sum(len(a["content_b64"]) for a in aux)
+        approx = len(skill_md_b64) + sum(len(a["content_b64"]) for a in aux)
         print(f"DRY RUN OK: payload assembles (~{approx}B base64); skipping mint + publish.")
         return 0
 


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow + stdlib deploy script that publishes the NoUI harness skill to the platform **default ("Built-in") tier**, per environment.

- **`skills/noui-harness/deploy_default_skill.py`** — mints a bearer JWT from an Adopt service-account PAT (`POST /v1/users/api-token`), then POSTs `SKILL.md` + a freshly built `noui-bundle.zip` to `POST /v1/end-user/agent-harness/default-skills` and verifies the live pointer (`GET .../default-skills/noui`). Stdlib-only (mirrors the existing `publish_bundle.py`); the token is never logged.
- **`.github/workflows/deploy-skill.yml`** — push to `dev` → deploys to the `dev` GitHub Environment; push to `prod` → deploys to the `prod` Environment (`api.adopt.ai`). Path-filtered to skill changes, `workflow_dispatch` for manual runs, concurrency-gated per environment.

## Why

Replaces the manual, out-of-band default-tier publish (curl-by-hand / direct bucket writes) with a repeatable per-environment CI deploy. The default tier is shared by all tenants, so a hand-run publish is exactly the step that should be automated and gated.

## Environment config required before this deploys (Settings → Environments)

| Environment | `ADOPT_BASE_URL` (var) | `ADOPT_CLIENT_ID` / `ADOPT_CLIENT_SECRET` (secrets) |
|---|---|---|
| `dev` | `REDACTED` | dev service-account PAT |
| `prod` | `REDACTED` | prod service-account PAT |

Recommend a required-reviewer protection rule on `prod`. A `prod` branch must exist (carrying this workflow) for prod deploys to trigger.

## Risk

Low-to-moderate. The default tier is platform-wide, but: publish is content-addressed and **idempotent** for identical bundle bytes; the endpoint validates the bundle and enforces `min_platform_contract` (409 on mismatch); the pointer flip is atomic; and prod is gated behind its own Environment + protection rule. No secrets are committed — all creds live in GitHub Environment secrets.

## Validation

- `py_compile` + YAML parse pass.
- Script pure-logic unit checks pass (aux loading, multi-aux/arcname parsing, frontmatter guard, zip integrity).
- The publish + verify endpoints this calls were exercised live against **both dev and prod** during setup (default `noui` currently published on both). The mint→publish path first runs for real in CI (local run is blocked by the sandbox credential guard, by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)