### PR TITLE
NoUI: agent-driven generalization pass (prune noise + test until it works)

### DIFF
--- a/skills/noui-harness/SKILL.md
+++ b/skills/noui-harness/SKILL.md
@@ -147,9 +147,34 @@ For a **static API-key app** (Part A skipped, no profile), drop `--profile-slug`
 > --execution-mode harness` (no human VNC) — see the toolkit reference. For a brand-new
 > profile, the VNC workflow recording above is the reliable path.
 
+## Step B3 — generalize: prune the noise, then test until it works
+
+The B2 compile is a **raw** mirror of the recording — it includes calls that aren't
+part of the task (analytics / config / keepalive pings, typeahead/prefetch, third-party
+hosts) and names lifted straight from the API. **Before installing**, clean it up (this
+is an LLM-driven step you do — no script):
+
+1. **Prune noise.** Read `workbench/skills/<app>/operations.json`; remove any operation
+   that doesn't serve the workflow goal (telemetry/analytics/consent/keepalive,
+   typeahead/prefetch, duplicates, any non-app host) — delete its entry from
+   `operations.json` and its card from the skill's `SKILL.md`.
+2. **Test the survivors.** For each remaining operation, invoke the **`call_web_api`**
+   tool with its recipe from `operations.json` (pass any `${SECRET:...}` verbatim). Run
+   each **2–3 times** and confirm it returns the expected data — not just a non-error.
+   You can do this now: `call_web_api` is a catalog tool, not part of the skill.
+3. **Fix or drop.** Empty creds / 401 → the profile's session isn't healthy (recheck
+   Part A/B); 429 → retry; wrong/empty body → recompile from the saved bundle
+   (`compile_workflow.py <bundle.json> --as skill --execution-mode harness`). If an op
+   can't be made to work and isn't essential, drop it.
+4. **Make it reusable.** Rename cryptic tool/param names to natural language and
+   parameterize hardcoded recorded values, in `operations.json` + the `SKILL.md` cards.
+5. **Loop** until every remaining operation passes 2–3 clean runs. Only then install.
+
+Full playbook: `skills/noui/references/generalize.md`.
+
 ## Step C — install the skill into the harness catalog
 
-Once compiled, **install it** so it becomes a usable tool on future turns. Call the
+Once compiled **and generalized (Step B3)**, **install it** so it becomes a usable tool on future turns. Call the
 **`install_skill`** harness tool (NOT a bash command — it's a tool in your catalog)
 with the compiled directory:
 

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -26,6 +26,12 @@ NoUI records what a site's browser already does and ships it as tools your agent
 2. **Compile** (`scripts/compile_*`, also folded into `capture_import`) — turn a capture into assets: a workflow → an **MCP server** and/or a **Skill**; a login → a Tabby **App Template + ServiceProfile**.
 3. **Activate** (`scripts/activate_*`) — make assets usable: **register** a login as a tenant-wide App Template with Tabby (template-first — no promote step), **verify** auth, **install** a generated skill into any agent, and run tools through Tabby `/execute/fetch`.
 
+> Between **Compile** and **Activate**, always run **Generalize** — an LLM-driven
+> **agent** step (not a script; the compiler stays deterministic): prune the noise
+> operations and test the rest until they reliably fetch what's expected. See the
+> [Generalize](#generalize--prune-the-noise-then-test-until-it-works) section below
+> and `references/generalize.md`.
+
 ---
 
 ## Setup (one time)
@@ -62,6 +68,8 @@ Run scripts from this directory: `python scripts/<name>.py …`.
 python scripts/capture_record.py --mode workflow --url https://example.com --from <login-session-id>
 # open the printed VNC URL, drive the flow, click "Finish & export", then:
 python scripts/capture_import.py <session_id> --as both --profile-slug <login-profile>
+# GENERALIZE (agent step): prune noise ops, then test each 2-3x until it fetches
+# what's expected — see references/generalize.md. THEN:
 python scripts/activate_verify.py workbench/mcp_servers/<app>/<server_id>
 python scripts/activate_install.py workbench/skills/<app> claude-code
 ```
@@ -108,6 +116,31 @@ The default removes the old failure where a separately-recorded login looked "st
 
 ---
 
+## Generalize — prune the noise, then test until it works
+
+The initial compile is a **raw** mirror of the recording: it includes calls that
+aren't part of the task (analytics, config pings, prefetch, third-party hosts) and
+names lifted straight from the API. **After every compile, before install**, run the
+generalization pass — an LLM-driven **agent** step (no script; the compiler stays
+deterministic):
+
+1. **Prune noise** — remove operations that don't serve the workflow goal
+   (telemetry/analytics/consent/keepalive pings, typeahead/prefetch, duplicates, any
+   non-app host) from `operations.json` (harness) or `operations/` + `manifest.json`
+   (tabby/http).
+2. **Test the survivors** — actually run each remaining operation against the live
+   site (harness: the `call_web_api` tool with the recipe; tabby/http:
+   `python operations/<tool>.py …` or `activate_verify.py`), **2–3 times each**, and
+   confirm it returns the expected data.
+3. **Fix or drop** failures (empty creds → healthy session; 429 → browser-side
+   execute; wrong/empty body → recompile from the saved bundle), then **rename**
+   cryptic tools/params to natural language and **parameterize** hardcoded values.
+4. **Loop** until every remaining operation passes 2–3 clean runs — only then install.
+
+Full playbook: `references/generalize.md`.
+
+---
+
 ## Script reference
 
 | Script | Pillar | Purpose |
@@ -133,6 +166,7 @@ Every capture (`capture_autopilot.py` and `capture_import.py`) **persists the ra
 
 - `references/pillar-1-capture.md` — VNC vs Autopilot, bundle shape, session reuse (`--from`)
 - `references/pillar-2-compile.md` — HAR→tools, execution modes (`tabby`/`http`/`harness`), login drafts
+- `references/generalize.md` — post-compile agent pass: prune noise ops + test until they work
 - `references/pillar-3-activate.md` — register (template-first), verify, install, `/execute` runtime
 - `references/tabby-setup.md` — pointing NoUI at a local or cloud Tabby
 - `references/auth-modes.md` — `agent_token` vs `platform_jwt`

--- a/skills/noui/references/generalize.md
+++ b/skills/noui/references/generalize.md
@@ -1,0 +1,76 @@
+# Generalize — prune the noise, then test until it works
+
+**This is an agent step, not a script.** The initial compile is a faithful, *raw*
+mirror of everything the browser did during the recording. It therefore includes
+calls that aren't part of the task, and names lifted straight from the site's API.
+Generalization is the LLM-driven pass **you** (the agent that captured/compiled the
+skill) run after compile and **before** installing/delivering it: cut the workflow
+down to the operations that actually accomplish the goal, prove they work, and make
+them legible so any agent can call them.
+
+Do this every time immediately after Compile (Pillar 2). The saved capture bundle
+(`workbench/bundles/<name>.json`) is the source of truth — recompile from it for
+deep changes (`python scripts/compile_workflow.py <bundle.json> --as …`); never
+delete it.
+
+## 1. Inventory the compiled operations
+Read what compile produced:
+- **harness** skills → `workbench/skills/<app>/operations.json` (+ the operation cards in `SKILL.md`).
+- **tabby/http** skills/servers → `operations/<tool>.py` + `API.md` (+ `manifest.json`'s `operations`/`tools.json`).
+
+For each operation note: method, path, what it appears to fetch, and whether it is
+plausibly part of the user's stated workflow goal.
+
+## 2. Prune the noise (useless calls)
+Compile already drops static assets, obvious analytics paths, and redirects, but a
+raw workflow still carries calls that are **not part of the task**. Remove any
+operation that does not contribute to the goal:
+- telemetry / analytics / metrics / consent / feature-flag / session-keepalive / config pings that slipped through;
+- typeahead / autocomplete / prefetch / "suggestions" calls that aren't the end result;
+- intermediate calls whose data the final call already returns (duplicates / stepping stones);
+- anything to a host that is **not the app's own API** (third-party widgets, CDNs, ad/marketing pixels).
+
+Delete pruned operations from the asset:
+- **harness**: remove the entry from `operations.json` and its card from `SKILL.md`.
+- **tabby/http**: delete `operations/<tool>.py`, and remove it from `manifest.json` `operations` (and `tools.json` for MCP).
+
+When in doubt, keep it for now and let the test in step 3 decide — a call that
+returns nothing useful is noise.
+
+## 3. Test the survivors — a couple of times each
+**Actually run every remaining operation against the live site** and confirm it
+returns what the workflow needs (right status, non-empty, the expected fields) —
+not just that it doesn't error. Run each **2–3 times** to confirm it's stable, not a
+one-off or intermittently blocked.
+
+- **harness**: invoke the **`call_web_api`** tool with the operation's recipe from `operations.json` (you can do this before install — it's a catalog tool, not part of the skill). Pass `${SECRET:...}` placeholders verbatim; the harness substitutes them.
+- **tabby/http**: `python operations/<tool>.py <args>` (needs a HEALTHY Tabby session for the profile). Run `python scripts/activate_verify.py <server_dir>` first for a deterministic auth dry-run.
+
+## 4. Fix or drop failures
+- **Empty credentials / 401 / profile 404** → the profile/session isn't healthy or the slug is wrong; bring the session up (see `pillar-1-capture.md`) and re-test.
+- **429 / bot detection** → prefer browser-side execution (`--execution-mode tabby`, `/execute/fetch`) over `http`; retry.
+- **Wrong or empty payload** → the first compile may have dropped/duplicated a request body (e.g. a GraphQL query lost to `/graphql` dedup). Recover it from the saved bundle and recompile (`compile_workflow.py <bundle.json>`), then re-test.
+- **Can't be made to work and isn't essential** → drop it (step 2).
+
+## 5. Make it reusable (rename + parameterize)
+Once the survivors pass, give them a legible interface so any agent can call them
+without site knowledge:
+- **Rename** cryptic tool and parameter names (`get_v3_rpt`, `f_sid`, `bl`, `reqid`) to natural-language ones (`get_report`, `origin`, `destination`, `departure_date`).
+- **Parameterize** hardcoded recorded values that should be inputs (dates, ids, search terms) into named params with descriptions.
+
+Small renames can be edited in place in `operations.json` / `SKILL.md` cards (harness)
+or the operation files + `manifest.json` (tabby/http). Deeper reshaping is easiest by
+recompiling from the bundle and re-applying — the bundle is the durable source.
+
+## 6. Re-verify and loop
+After any edit, re-run step 3 for the affected operations. **Iterate until every
+remaining operation passes 2–3 consecutive clean runs** and returns the expected
+data. Only then install/deliver the skill (Pillar 3).
+
+## Definition of done
+- No operation to a non-app / tracking / telemetry host remains.
+- Every remaining operation has been run against the live site and fetched the expected data, repeatably.
+- Tool and parameter names are natural-language; task inputs are parameters, not baked-in values.
+- The saved bundle is intact (so the asset can be regenerated later).
+
+See also: [pillar-2-compile](pillar-2-compile.md), [pillar-3-activate](pillar-3-activate.md), [pillar-1-capture](pillar-1-capture.md).

--- a/skills/noui/references/pillar-2-compile.md
+++ b/skills/noui/references/pillar-2-compile.md
@@ -36,4 +36,6 @@ How the app authenticates is **declared** at compile, not inferred from the HAR:
 
 Re-compile a saved bundle without re-recording: `scripts/compile_workflow.py` / `scripts/compile_login.py`.
 
-See also: [pillar-3-activate](pillar-3-activate.md).
+The compile output is a **raw** mirror of the recording. Next, run the agent-driven **[generalize](generalize.md)** pass — prune noise operations and test the rest until they work — before activating.
+
+See also: [generalize](generalize.md), [pillar-3-activate](pillar-3-activate.md).


### PR DESCRIPTION
## What & why
After the initial compile, a NoUI skill is a **raw** mirror of the recording — it includes calls that aren't part of the task (analytics/config/keepalive pings, typeahead/prefetch, duplicates, third-party hosts) and names lifted straight from the API. This adds an **agent-driven generalization pass** the installing agent runs after compile and before install.

It's **instructions, not code** — an LLM/agent step. The compiler stays deterministic (no LLM, no `ANTHROPIC_API_KEY`).

## Changes (docs-only)
- **`references/generalize.md`** — the playbook: inventory ops → **prune noise** → **test each survivor 2–3× against the live site** and confirm it fetches the expected data → **fix-or-drop** failures → **rename + parameterize** for reuse → **loop until all pass**, then install. Ties testing to the real runtime (harness: `call_web_api` with the operation recipe; tabby/http: `operations/<tool>.py` / `activate_verify.py`); recompile from the saved bundle for deep changes.
- **`noui` SKILL.md** — added to the pillars framing, a "Generalize" section, a quick-flow note, and the reference list.
- **`noui-harness` SKILL.md** — new **Step B3** between compile (B2) and install (Step C); testing via `call_web_api` before install.
- **`pillar-2-compile.md`** — cross-linked into the pass.

## Risk / testing
Docs-only — no code paths change; CI (ruff/mypy/pytest) unaffected. All cross-references resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)