### PR TITLE
feat(noui): --residential-proxy for recording capture

### DIFF
--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -62,6 +62,14 @@ Run scripts from this directory: `python scripts/<name>.py …`.
 
 ## Quick flows
 
+> ⚠️ **Banks / financial institutions → always add `--residential-proxy`.** Bank
+> and other financial portals routinely block or fraud-flag datacenter IPs, so a
+> login/workflow recorded (or an App Template captured) without it will fail, get
+> challenged, or trip the account's fraud controls. For any bank, brokerage,
+> card, or lender site, pass `--residential-proxy` on `capture_record.py` (routes
+> the recorded browser through a US residential IP). See
+> `references/pillar-1-capture.md` → *Residential proxy egress*.
+
 **Record a workflow → MCP + Skill (authenticated):**
 
 ```bash

--- a/skills/noui/noui_core/capture/recording.py
+++ b/skills/noui/noui_core/capture/recording.py
@@ -88,7 +88,11 @@ def start(
         raise ValueError(f"mode must be 'login' or 'workflow', got {mode!r}")
     token = resolve_agent_token()
     return tabby_client.create_recording_session(
-        mode, url, token, profile, source_session_id=from_session,
+        mode,
+        url,
+        token,
+        profile,
+        source_session_id=from_session,
         residential_proxy=residential,
     )
 

--- a/skills/noui/noui_core/capture/recording.py
+++ b/skills/noui/noui_core/capture/recording.py
@@ -64,6 +64,7 @@ def start(
     *,
     profile: str = "",
     from_session: str = "",
+    residential: bool = False,
 ) -> dict:
     """Provision a Tabby VNC recording session.
 
@@ -77,6 +78,9 @@ def start(
         from_session: (workflow) seed cookies from a prior login recording (its
             session id) just captured in this same flow — session reuse, no
             stored credentials. Use --profile instead when a profile already exists.
+        residential: route the recorded browser's egress through Tabby's
+            residential proxy (US residential IP) instead of datacenter egress.
+            Use for sites that block datacenter IPs (e.g. bank portals).
 
     Returns the Tabby payload: {session_id, app_id, recording_mode, vnc_url, ...}.
     """
@@ -84,7 +88,8 @@ def start(
         raise ValueError(f"mode must be 'login' or 'workflow', got {mode!r}")
     token = resolve_agent_token()
     return tabby_client.create_recording_session(
-        mode, url, token, profile, source_session_id=from_session
+        mode, url, token, profile, source_session_id=from_session,
+        residential_proxy=residential,
     )
 
 
@@ -130,6 +135,7 @@ def provision_live_link(
     *,
     profile: str = "",
     from_session: str = "",
+    residential: bool = False,
 ) -> dict:
     """Provision a recording session and return its payload with a ``login_url``
     that is **verified live** — never a stale/dead link, and never handed over
@@ -154,7 +160,7 @@ def provision_live_link(
     ``"restart"`` | ``"reprovision"`` when a refresh was needed).
     """
     token = resolve_agent_token()
-    result = start(mode, url, profile=profile, from_session=from_session)
+    result = start(mode, url, profile=profile, from_session=from_session, residential=residential)
 
     stream_token = _stream_token(result.get("vnc_url", ""))
     sid = result.get("session_id", "")
@@ -176,7 +182,7 @@ def provision_live_link(
             pass  # restart didn't revive it → fall through to a fresh session.
 
     # Restart unavailable or ineffective → provision a brand-new session.
-    result = start(mode, url, profile=profile, from_session=from_session)
+    result = start(mode, url, profile=profile, from_session=from_session, residential=residential)
     result["login_url"] = tabby_client.create_short_link(
         result.get("session_id", ""), token, mode="recording"
     )

--- a/skills/noui/noui_core/tabby_client.py
+++ b/skills/noui/noui_core/tabby_client.py
@@ -201,6 +201,7 @@ def create_recording_session(
     agent_token: str,
     profile_id: str = "",
     source_session_id: str = "",
+    residential_proxy: bool = False,
 ) -> dict:
     """
     POST /recording/sessions (agent bearer) — provision a recording-shell
@@ -210,6 +211,11 @@ def create_recording_session(
     by a prior login recording (session reuse), so the human starts already
     authenticated without stored credentials.
 
+    ``residential_proxy`` routes the recording session's egress through Tabby's
+    residential proxy (a US residential IP) instead of the datacenter egress —
+    use for sites that block datacenter IPs (e.g. bank portals). Omitted from the
+    request when False so the recording-shell app default applies.
+
     Returns {session_id, app_id, recording_mode, vnc_url, expires_at}.
     Raises RuntimeError on failure.
     """
@@ -218,6 +224,8 @@ def create_recording_session(
         body["profile_id"] = profile_id
     if source_session_id:
         body["source_session_id"] = source_session_id
+    if residential_proxy:
+        body["residential_proxy"] = True
     # Provisioning blocks server-side until the worker session row exists (worker
     # scheduling can take >15s under load), so allow a generous client timeout.
     resp = _tabby_http("POST", "/recording/sessions", body=body, token=agent_token, timeout=90)

--- a/skills/noui/references/pillar-1-capture.md
+++ b/skills/noui/references/pillar-1-capture.md
@@ -57,6 +57,23 @@ python scripts/capture_record.py --mode workflow --url https://example.com --fro
 
 Tabby pulls the source recording's cookies server-side; they never pass through NoUI.
 
+## Residential proxy egress (`--residential-proxy`)
+Route the recorded browser's egress through Tabby's residential proxy (a US residential IP) instead of the default datacenter egress. Use for sites that block or challenge datacenter IPs — e.g. bank portals.
+
+> ⚠️ **Future agents: for any bank / financial institution, ALWAYS use `--residential-proxy`.**
+> This applies to every capture that becomes a bank App Template or recording —
+> logins, workflows, and combined sessions alike. Banks, brokerages, card issuers,
+> and lenders routinely block datacenter IPs or treat a datacenter-IP login as
+> fraud (extra challenges, step-up MFA, account locks). Recording such a site
+> without the residential proxy is unreliable and can jeopardize the real account.
+> When in doubt about whether a site is "financial enough", default to using it.
+
+```bash
+python scripts/capture_record.py --mode login --url https://www.pnc.com --residential-proxy
+```
+
+Works with any mode (`login`/`workflow`/`combined`) and combines with `--from`/`--profile`. The flag flows to Tabby's `POST /recording/sessions` as `residential_proxy: true`; omitted by default so the recording-shell app default applies. Requires the residential proxy to be configured on Tabby (`EGRESS_UPSTREAM_PROXY_URL` on the egress-proxy) — otherwise egress stays datacenter.
+
 ## Combined login + workflow in one session (`--mode combined`)
 Capture the login **and** the authenticated workflow in a **single** VNC session — no separate login recording, no `--from` seeding.
 

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -151,7 +151,10 @@ def main() -> int:
     tabby_mode = "login" if args.mode == "combined" else args.mode
     try:
         result = recording.provision_live_link(
-            tabby_mode, args.url, profile=args.profile, from_session=args.from_session,
+            tabby_mode,
+            args.url,
+            profile=args.profile,
+            from_session=args.from_session,
             residential=args.residential_proxy,
         )
     except (RuntimeError, ValueError) as exc:

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -79,6 +79,15 @@ def main() -> int:
         help="(workflow) seed cookies from a prior LOGIN recording (its session id), "
         "when you just recorded the login in this same flow",
     )
+    p.add_argument(
+        "--residential-proxy",
+        dest="residential_proxy",
+        action="store_true",
+        help="route the recorded browser through Tabby's residential proxy (a US "
+        "residential IP) instead of datacenter egress. Use for sites that block "
+        "datacenter IPs, e.g. bank portals. Requires the residential proxy to be "
+        "configured on Tabby; otherwise the recording-shell app default applies.",
+    )
     args = p.parse_args()
 
     # Static API-key app: there is no session to record. Skip the login capture
@@ -142,7 +151,8 @@ def main() -> int:
     tabby_mode = "login" if args.mode == "combined" else args.mode
     try:
         result = recording.provision_live_link(
-            tabby_mode, args.url, profile=args.profile, from_session=args.from_session
+            tabby_mode, args.url, profile=args.profile, from_session=args.from_session,
+            residential=args.residential_proxy,
         )
     except (RuntimeError, ValueError) as exc:
         print(f"Provisioning failed: {exc}", file=sys.stderr)

--- a/tests/test_tabby_sessions.py
+++ b/tests/test_tabby_sessions.py
@@ -52,3 +52,31 @@ def test_get_session_status_healthy(monkeypatch):
     st = tabby_client.get_session_status("expedia-e2e2", "agent-tok")
     assert st["state"] == "HEALTHY"
     assert st["vnc_stream"] is None
+
+
+def test_create_recording_session_residential_proxy(monkeypatch):
+    captured = {}
+
+    def fake_http(method, path, body=None, token=None, timeout=15):
+        captured.update(method=method, path=path, body=body)
+        return {"session_id": "s1", "vnc_url": "https://t/vnc/s1#token=x"}
+
+    monkeypatch.setattr(tabby_client, "_tabby_http", fake_http)
+    tabby_client.create_recording_session(
+        "login", "https://www.pnc.com", "agent-tok", residential_proxy=True
+    )
+    assert captured["path"] == "/recording/sessions"
+    assert captured["body"]["residential_proxy"] is True
+
+
+def test_create_recording_session_omits_residential_proxy_by_default(monkeypatch):
+    captured = {}
+
+    def fake_http(method, path, body=None, token=None, timeout=15):
+        captured.update(body=body)
+        return {"session_id": "s1", "vnc_url": "https://t/vnc/s1#token=x"}
+
+    monkeypatch.setattr(tabby_client, "_tabby_http", fake_http)
+    tabby_client.create_recording_session("login", "https://example.com", "agent-tok")
+    # Omitted (not False) so the recording-shell app default applies server-side.
+    assert "residential_proxy" not in captured["body"]


### PR DESCRIPTION
## What & why

Lets NoUI capture request **residential-proxy egress** when it provisions a VNC recording link. Some sites — bank/financial portals especially — block or fraud-flag datacenter IPs, so a login/workflow recorded over datacenter egress fails, gets challenged (step-up MFA), or trips the real account's fraud controls. Recording those needs a residential IP.

Pairs with Tabby **PR #127** (which adds the residential warm pool + honors `residential_proxy` on `POST /recording/sessions`).

## Changes

- **`tabby_client.create_recording_session`** — new `residential_proxy: bool = False` arg, added to the `POST /recording/sessions` body **only when true** (omitted otherwise, so the recording-shell app default applies — no behavior change for existing callers).
- **`recording.start` / `recording.provision_live_link`** — thread a keyword-only `residential` param through (both the initial and the reprovision `start()` calls).
- **`scripts/capture_record.py`** — `--residential-proxy` CLI flag; works with every mode (`login`/`workflow`/`combined`) and composes with `--from`/`--profile`.
- **Docs** — `SKILL.md` (Quick flows) and `references/pillar-1-capture.md` (Residential proxy egress section) warn future agents to **always** use `--residential-proxy` for bank / financial App Templates and recordings, placed at capture-time since residential egress can't be retrofitted at compile.

```bash
python scripts/capture_record.py --mode login --url https://www.pnc.com --residential-proxy
```

## Validation

- **9 tests pass** (`test_tabby_sessions.py` + `test_recording_provision.py`), including 2 new cases: `residential_proxy: true` present in the request body when the flag is on, and omitted by default.
- `capture_record.py --help` lists `--residential-proxy`.
- End-to-end: the flag emits exactly the `residential_proxy: true` body that was verified live against Tabby — that request produced `residential CONNECT established … www.pnc.com:443` through the residential upstream.

## Risk

Low — off by default and omitted from the request when off, so existing captures are unchanged. Requires the residential proxy configured on Tabby (`EGRESS_UPSTREAM_PROXY_URL`); without it, egress stays datacenter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
