### PR TITLE
feat(noui): surface warm-pool hit/miss in capture_record output

### DIFF
--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -169,6 +169,20 @@ def main() -> int:
             file=sys.stderr,
         )
 
+    # Surface whether Tabby served this from the warm pool (sub-second claim) or
+    # cold-started a pod (~1-2min). Tabby returns `warm: true` only on the pool
+    # path; its absence means a cold start. A cold start is expected on the FIRST
+    # recording per tenant (it warms the pool for next time) or when the pool is
+    # disabled/empty — record again and the next should be warm.
+    if result.get("warm"):
+        print("(warm pool: claimed a pre-warmed spare)", file=sys.stderr)
+    else:
+        print(
+            "(warm pool: MISS — cold-started a pod. Expected on the first recording "
+            "(warms the pool); if it repeats, the pool is disabled or still filling.)",
+            file=sys.stderr,
+        )
+
     print(f"Recording session ready ({args.mode}):")
     print(f"  session_id : {session_id}")
     print(f"  login_url  : {login_url}    <-- open THIS (recording viewer, redaction-safe)")


### PR DESCRIPTION
## What

`capture_record.py` now prints whether Tabby served the recording session from the **warm pool** (sub-second claim) or **cold-started** a pod (~1-2min).

```
(warm pool: claimed a pre-warmed spare)
# or
(warm pool: MISS — cold-started a pod. Expected on the first recording
(warms the pool); if it repeats, the pool is disabled or still filling.)
```

## Why

Tabby's `POST /recording/sessions` already returns `warm: true` on the pool path (Tabby PR #127), but the NoUI client silently dropped it. That gap made a cold reprovision indistinguishable from a warm claim — the exact reason a "NoUI isn't using the warm pool" report was hard to diagnose. Surfacing the flag makes warm-vs-cold observable at capture time.

## Notes

- **Client behavior is unchanged** — NoUI is a pure passthrough to Tabby's server-side pool logic. This only exposes an existing response field on stderr.
- A cold MISS is expected on the **first** recording per tenant when `RECORDING_POOL_TENANTS=*` (wildcard tenants warm lazily; `onModuleInit` only pre-warms explicitly-listed tenants) — record again and the next is warm.

## Risk / Validation

- Risk: minimal — two `print(..., file=sys.stderr)` lines, no control-flow change.
- `python -m py_compile skills/noui/scripts/capture_record.py` passes.
- Verified the `warm` field flows server → `provision_live_link` → script output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)