### PR TITLE
release: surface warm-pool hit/miss in capture_record (dev → prod)

### DIFF
--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -169,6 +169,20 @@ def main() -> int:
             file=sys.stderr,
         )
 
+    # Surface whether Tabby served this from the warm pool (sub-second claim) or
+    # cold-started a pod (~1-2min). Tabby returns `warm: true` only on the pool
+    # path; its absence means a cold start. A cold start is expected on the FIRST
+    # recording per tenant (it warms the pool for next time) or when the pool is
+    # disabled/empty — record again and the next should be warm.
+    if result.get("warm"):
+        print("(warm pool: claimed a pre-warmed spare)", file=sys.stderr)
+    else:
+        print(
+            "(warm pool: MISS — cold-started a pod. Expected on the first recording "
+            "(warms the pool); if it repeats, the pool is disabled or still filling.)",
+            file=sys.stderr,
+        )
+
     print(f"Recording session ready ({args.mode}):")
     print(f"  session_id : {session_id}")
     print(f"  login_url  : {login_url}    <-- open THIS (recording viewer, redaction-safe)")


### PR DESCRIPTION
Promotes #119 to prod (api.adopt.ai).

## What ships
`capture_record.py` now prints whether Tabby served the recording session from the **warm pool** (sub-second claim) or **cold-started** a pod:

```
(warm pool: claimed a pre-warmed spare)
# or
(warm pool: MISS — cold-started a pod. Expected on the first recording
(warms the pool); if it repeats, the pool is disabled or still filling.)
```

## Why
Tabby's `POST /recording/sessions` already returns `warm: true` on the pool path, but the NoUI client dropped it — so a cold reprovision was indistinguishable from a warm claim. This surfaces the existing flag so warm-vs-cold is observable at capture time. **No client behavior change** — NoUI is a pure passthrough; whether the pool is used is decided server-side by Tabby (already live with `RECORDING_POOL_TENANTS=*`).

## Risk / Validation
- Risk: minimal — two `print(..., file=sys.stderr)` lines, no control-flow change.
- `py_compile` passes; verified the `warm` field flows server → `provision_live_link` → output.
- Diff vs prod is exactly #119 (1 file, +14/-0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)