### PR TITLE
fix(noui): kill ~60s harness recording-provision delay + generalization guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,7 @@ def create_invoice(customer_id, amount):
         method="POST",
         endpoint="/api/invoices",
         headers=session_headers,
-        json={
-            "customer_id": customer_id,
-            "amount": amount
-        }
+        json={"customer_id": customer_id, "amount": amount},
     )
 ```
 

--- a/skills/noui/noui_core/capture/recording.py
+++ b/skills/noui/noui_core/capture/recording.py
@@ -117,16 +117,30 @@ def _wait_for_pod_ready(
     startup; any non-``STARTING`` state — including a dead one — exits the loop,
     so we never hang (a dead session is then caught by minting and refreshed).
 
+    ``panel-state`` is a ``/vnc`` route authed by the stream token (query param),
+    not the Tabby bearer. In broker mode (Agent Harness sandbox) that route may
+    not be reachable if the caller omits the capability bearer — so every poll
+    would throw. Rather than burn the whole ~60s budget probing a dead endpoint,
+    bail after a few consecutive errors: the login link is still valid and the
+    viewer auto-reconnects once the pod is up.
+
     Returns the last observed state ("" if it never became readable).
     """
     state = ""
+    consecutive_errors = 0
     for _ in range(attempts):
         try:
             state = tabby_client.get_recording_panel_state(session_id, stream_token).get(
                 "state", ""
             )
+            consecutive_errors = 0
         except Exception:
             state = ""
+            consecutive_errors += 1
+            # panel-state unreachable (e.g. /vnc not proxied in broker mode) —
+            # stop polling a dead endpoint and hand back the link.
+            if consecutive_errors >= 3:
+                return state
         if state and state != "STARTING":
             return state
         time.sleep(interval)
@@ -168,7 +182,12 @@ def provision_live_link(
 
     stream_token = _stream_token(result.get("vnc_url", ""))
     sid = result.get("session_id", "")
-    if stream_token and sid:
+    # A warm-pool claim is already HEALTHY — the server only returns warm=true
+    # after atomically claiming a HEALTHY, pod-backed spare — so there is nothing
+    # to wait for. Skip the pod-startup poll entirely; it's only meaningful for a
+    # cold start (and in broker mode the /vnc panel-state probe it uses can't be
+    # reached, so waiting would just burn the full ~60s budget for nothing).
+    if not result.get("warm") and stream_token and sid:
         _wait_for_pod_ready(sid, stream_token)
 
     try:

--- a/skills/noui/noui_core/compile/harness_md_generator.py
+++ b/skills/noui/noui_core/compile/harness_md_generator.py
@@ -318,6 +318,19 @@ def _render_body(
     # Operations
     sections.append("## Operations")
     sections.append("")
+    sections.append(
+        "> **Generalize this list before relying on it.** These operations are captured "
+        "verbatim from a single recording, so alongside the real workflow API they may "
+        "include incidental requests the page happened to fire — third-party / cross-domain "
+        "calls (analytics, maps, ad & tracking pixels, CDN or static assets) and telemetry "
+        "beacons (e.g. `gen_204`, `/tr`, `get-data-layer-variables`, feature-flag fetches). "
+        "During the generalization phase (`/noui-generalize`), review each operation and "
+        "**prune the ones that aren't part of the intended task**. Do NOT blanket-drop by "
+        "domain: a workflow can legitimately span multiple hosts (e.g. an auth domain plus "
+        "an API domain), so keep cross-domain operations that are actually used. Aim for the "
+        "smallest set of operations that performs the workflow."
+    )
+    sections.append("")
     for td in tool_defs:
         sections.extend(_render_operation_card(td, profile_slug=profile_slug, auth_plan=auth_plan))
 

--- a/skills/noui/noui_core/compile/skill_md_generator.py
+++ b/skills/noui/noui_core/compile/skill_md_generator.py
@@ -280,6 +280,19 @@ def _render_body(
     # Operations
     sections.append("## Operations")
     sections.append("")
+    sections.append(
+        "> **Generalize this list before relying on it.** These operations are captured "
+        "verbatim from a single recording, so alongside the real workflow API they may "
+        "include incidental requests the page happened to fire — third-party / cross-domain "
+        "calls (analytics, maps, ad & tracking pixels, CDN or static assets) and telemetry "
+        "beacons (e.g. `gen_204`, `/tr`, `get-data-layer-variables`, feature-flag fetches). "
+        "During the generalization phase (`/noui-generalize`), review each operation and "
+        "**prune the ones that aren't part of the intended task**. Do NOT blanket-drop by "
+        "domain: a workflow can legitimately span multiple hosts (e.g. an auth domain plus "
+        "an API domain), so keep cross-domain operations that are actually used. Aim for the "
+        "smallest set of operations that performs the workflow."
+    )
+    sections.append("")
     for td in tool_defs:
         sections.extend(_render_operation_section(td, python_executable=python_executable))
 

--- a/skills/noui/noui_core/tabby_client.py
+++ b/skills/noui/noui_core/tabby_client.py
@@ -515,13 +515,25 @@ def create_short_link(session_id: str, token: str, mode: str = "") -> str:
 def _vnc_http(method: str, session_id: str, sub: str, stream_token: str, timeout: int = 15) -> dict:
     """Call a ``/vnc/{session_id}/{sub}`` endpoint.
 
-    These are authenticated by the VNC **stream token** (the JWT from the
+    Tabby authenticates these by the VNC **stream token** (the JWT from the
     ``vnc_url`` ``#token=`` fragment) passed as a ``token`` query param — NOT the
     agent bearer. Raises ``urllib.error`` on non-2xx.
+
+    Broker mode caveat: the harness control-plane broker gates EVERY forwarded
+    route on the capability bearer, including the ``/vnc`` stream-token routes it
+    allowlists (``panel-state``, ``restart``). So we must still send the
+    capability bearer here — the broker validates+strips it and injects the real
+    Tabby bearer, while the ``?token=`` query continues to satisfy Tabby's own
+    VNC-route auth. Without the bearer the broker 401s every call (which made
+    ``_wait_for_pod_ready`` burn its whole ~60s budget). Harmless in non-broker
+    mode: we only attach it when a broker token is present.
     """
     qs = urllib.parse.urlencode({"token": stream_token})
     url = f"{settings.tabby_api_host.rstrip('/')}/vnc/{session_id}/{sub}?{qs}"
-    req = urllib.request.Request(url, method=method)
+    headers: dict[str, str] = {}
+    if settings.broker_mode() and settings.broker_token:
+        headers["Authorization"] = f"Bearer {settings.broker_token}"
+    req = urllib.request.Request(url, method=method, headers=headers)
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         raw = resp.read().decode()
         return json.loads(raw) if raw else {}

--- a/skills/noui/references/pillar-1-capture.md
+++ b/skills/noui/references/pillar-1-capture.md
@@ -24,8 +24,12 @@ Implemented in `noui_core.capture.autopilot` (`AutopilotSession` for interactive
 
 ```python
 from noui_core.capture.autopilot import AutopilotSession
+
 ap = AutopilotSession("<profile-slug>")
-ap.start_capture(); ap.navigate(url); ap.click("#go"); bundle = ap.finish()
+ap.start_capture()
+ap.navigate(url)
+ap.click("#go")
+bundle = ap.finish()
 ```
 
 #### Prerequisite: a HEALTHY execute session (+ login escalation)
@@ -39,10 +43,11 @@ ap.start_capture(); ap.navigate(url); ap.click("#go"); bundle = ap.finish()
 
 ```python
 from noui_core import tabby_client
+
 tabby_client.scale_sessions(app_id, 1, admin_token)
 st = tabby_client.get_session_status(profile_slug, agent_token)
 if st["hitl_active"]:
-    print("Log in here:", st["vnc_stream"]["url"])   # human completes login
+    print("Log in here:", st["vnc_stream"]["url"])  # human completes login
 # re-poll until st["state"] == "HEALTHY", then AutopilotSession(profile_slug)...
 ```
 

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -187,8 +187,6 @@ def main() -> int:
     print(f"  session_id : {session_id}")
     print(f"  login_url  : {login_url}    <-- open THIS (recording viewer, redaction-safe)")
     print()
-    print("If the viewer shows 'Disconnected' at first, the browser is still starting —")
-    print("it connects on its own within ~30-60s (no need to re-provision).")
     if args.mode == "combined":
         print(
             "Open the login_url, SIGN IN, then keep going and DRIVE THE WORKFLOW you want "


### PR DESCRIPTION
## What & why

Two NoUI recording-flow issues surfaced while debugging why the Agent Harness reported ~60s to provision a recording session even for a sub-second warm-pool claim (`warm pool: claimed a pre-warmed spare` … `61.7s total`).

### 1. ~60s provision delay in broker mode (the reported bug)
`provision_live_link` → `_wait_for_pod_ready` polls `GET /vnc/{id}/panel-state` to wait out pod startup (30 × 2s). In the harness (broker mode) every poll failed, burning the full budget.

**Root cause:** the harness control-plane broker gates *every* forwarded route on the capability bearer — including the `/vnc` stream-token routes it explicitly allowlists (`panel-state`, `restart`). `_vnc_http` sent only the `?token=` stream JWT and **no Authorization header**, so the broker 401'd every call.

**Fixes:**
- `_vnc_http` now also sends the capability bearer in broker mode (broker validates+strips it and injects the real Tabby bearer; the `?token=` query still satisfies Tabby's VNC-route auth). Unchanged in non-broker mode.
- `provision_live_link` **skips the pod-ready wait entirely for warm-pool claims** (`warm=true` means an already-HEALTHY, pod-backed spare — nothing to wait for). With the global pool this is the common path, so provisioning is sub-second.
- `_wait_for_pod_ready` bails after 3 consecutive panel-state errors instead of polling a dead endpoint (cold-path defense in depth).
- Dropped the now-stale "viewer shows Disconnected → connects in ~30-60s" hint from `capture_record.py` output.

### 2. Flag operation-list cleanup for the generalization phase
A capture records every request the page fired, so the generated operation list mixes the real workflow API with incidental cross-domain / telemetry / static-asset calls (an Airbnb "list places" capture produced 15 ops: `StaysSearch` plus Google Maps `gen_204`, a `/tr` beacon, `get-data-layer-variables`, a static banner JSON, …).

We deliberately **do not auto-filter** — a workflow can legitimately span multiple domains, so blanket pruning would drop real operations. Instead both SKILL.md generators (plain + harness) now emit a note under `## Operations` telling the agent to review and prune during `/noui-generalize`, keeping cross-domain ops that are actually used.

## Validation
- Mocked broker/direct: warm claim → 0 panel-state polls (no hang); broker mode sends the bearer + keeps `?token=`; direct mode unchanged; "Disconnected" gone; both md generators render the note.
- Real combined Airbnb capture → skill on dev ran green end to end.

## Risk
Low. `_vnc_http` bearer is only attached when a broker token is present; the warm-skip only bypasses a wait for sessions the server already reports HEALTHY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)