### PR TITLE
fix(noui): four harness-authoring friction fixes (mode stamping, transport resilience, bundle inspect, activation sign-in)

### DIFF
--- a/skills/noui-harness/SKILL.md
+++ b/skills/noui-harness/SKILL.md
@@ -197,10 +197,34 @@ nothing about secrets.**
 Then report the deliverable: the profile slug, the compiled skill path, and the
 installed skill name — plus the required secret(s) only if `install_skill` returned any.
 
+## Diagnosing a surprising compile — `bundle_inspect.py`
+
+If an import produces the wrong kind of asset, or operations you didn't expect, **don't
+write a throwaway script** — inspect the bundle:
+
+```bash
+cd /workspace/noui
+python scripts/bundle_inspect.py workbench/bundles/<name>.json
+```
+
+It prints the **mode block** (Tabby's `recording_mode` vs NoUI's classification vs the
+mode the session was provisioned as, with a warning on any mismatch), the URL timeline
+with the login boundary marked, credential interactions (roles + redaction only), and the
+API endpoint table built with the compiler's own filter and naming — i.e. a preview of the
+operation set, useful for the B3 prune.
+
+**On modes:** Tabby's `recording_mode` is unreliable (a warm-pool session always reports
+`login`), and NoUI ignores it. `capture_import.py` decides from `--mode` → the provision
+ledger written by `capture_record.py` → the capture's content, and prints which won. If it
+ever picks wrong, pass `--mode {login,workflow,combined}` explicitly.
+
 ## Troubleshooting
 
 - **`login_required` / session not healthy on import** — the login wasn't completed; have
   the user redo the VNC sign-in and click *Finish & export*.
+- **The compiled asset is the wrong kind** (a workflow recording registered as an App
+  Template, or vice versa) — run `bundle_inspect.py` on the saved bundle and re-import
+  with an explicit `--mode`.
 - **403 from Tabby** — the profile isn't owned by / reachable for this user; re-record so
   it's created under the user's identity.
 - **VNC link won't load** — it expires; re-run the `capture_record.py` step to get a fresh

--- a/skills/noui-harness/SKILL.md
+++ b/skills/noui-harness/SKILL.md
@@ -94,9 +94,14 @@ confirms.
 ### A2. Import the login → App Template (after the user confirms)
 ```bash
 cd /workspace/noui
-python scripts/capture_import.py <login_session_id> --name "<app-name>"
+python scripts/capture_import.py <login_session_id> --name "<app-name>" --activate-session
 # same-origin apps: add --post-login-url-pattern '<glob the logged-in URL matches>'
 ```
+
+`--activate-session` brings the profile's **own** per-user session up and prints a sign-in
+link if it needs one. **Expect it to need one** — see *Three sessions, up to three sign-ins*
+below. Surface that link to the user in the same turn as the Part B recording link so they
+do both sign-ins in one sitting, instead of hitting `login_required` during B3 testing.
 Registration is **template-first**: this creates a tenant-wide **App Template**
 only — it does NOT create an App/ServiceProfile directly. Tabby auto-provisions a
 private, per-user App+Profile (straight to ACTIVE) on each member's first
@@ -147,6 +152,33 @@ For a **static API-key app** (Part A skipped, no profile), drop `--profile-slug`
 > --execution-mode harness` (no human VNC) — see the toolkit reference. For a brand-new
 > profile, the VNC workflow recording above is the reliable path.
 
+## Three sessions, up to three sign-ins (tell the user this up front)
+
+Authoring involves three **different** browser sessions, and only the first two are the
+ones the human drove:
+
+1. the **login recording** session (Part A),
+2. the **workflow recording** session (Part B — usually cookie-seeded from #1),
+3. the **profile's own session** — the one `call_web_api` resolves at runtime. Tabby
+   auto-provisions it per user from the App Template, on first use.
+
+Session #3 starts `LOGIN_NEEDED` because the template stores nothing
+(`credential_ref: manual:`). The recording's cookies are deliberately not reused for it:
+the template is tenant-wide, so seeding them would share the recorder's live session with
+every member of the org. That is why a user who *just signed in twice* still gets one more
+prompt — it is correct, not a bug.
+
+Handle it explicitly rather than letting it ambush the B3 test loop:
+
+```bash
+cd /workspace/noui
+python scripts/activate_session.py <profile-slug>
+```
+
+It prints a sign-in link (show it to the user as a markdown link, same as a recording link)
+or confirms the session is already HEALTHY. Say plainly: *"this is your app's own session —
+sign in once here and every future call uses it; nothing is stored."*
+
 ## Step B3 — generalize: prune the noise, then test until it works
 
 The B2 compile is a **raw** mirror of the recording — it includes calls that aren't
@@ -162,8 +194,9 @@ is an LLM-driven step you do — no script):
    tool with its recipe from `operations.json` (pass any `${SECRET:...}` verbatim). Run
    each **2–3 times** and confirm it returns the expected data — not just a non-error.
    You can do this now: `call_web_api` is a catalog tool, not part of the skill.
-3. **Fix or drop.** Empty creds / 401 → the profile's session isn't healthy (recheck
-   Part A/B); 429 → retry; wrong/empty body → recompile from the saved bundle
+3. **Fix or drop.** `login_required` / empty creds / 401 → the profile's own session needs
+   its activation sign-in: run `python scripts/activate_session.py <profile-slug>` and
+   surface the link it prints; 429 → retry; wrong/empty body → recompile from the saved bundle
    (`compile_workflow.py <bundle.json> --as skill --execution-mode harness`). If an op
    can't be made to work and isn't essential, drop it.
 4. **Make it reusable.** Rename cryptic tool/param names to natural language and
@@ -220,6 +253,10 @@ ever picks wrong, pass `--mode {login,workflow,combined}` explicitly.
 
 ## Troubleshooting
 
+- **`login_required` on the first live `call_web_api`** — expected, not a failure: the
+  profile's own session needs its one activation sign-in (see *Three sessions* above). Run
+  `python scripts/activate_session.py <profile-slug>` and surface the link. Only if that
+  reports the session already HEALTHY is something actually wrong.
 - **`login_required` / session not healthy on import** — the login wasn't completed; have
   the user redo the VNC sign-in and click *Finish & export*.
 - **The compiled asset is the wrong kind** (a workflow recording registered as an App

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -160,6 +160,7 @@ Full playbook: `references/generalize.md`.
 | `compile_workflow.py` | 2 | Re-compile a saved workflow bundle → MCP/Skill |
 | `compile_login.py` | 2 | Compile a saved login bundle → App/ServiceProfile drafts |
 | `activate_register.py` | 3 | Register a compiled login result with Tabby as a tenant-wide App Template |
+| `activate_session.py` | 3 | Bring a profile's own per-user session up; print its sign-in link if needed |
 | `activate_verify.py` | 3 | Deterministic auth dry-run on a generated MCP server |
 | `activate_install.py` | 3 | Install a generated skill into an agent (agnostic) |
 

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -156,11 +156,35 @@ Full playbook: `references/generalize.md`.
 | `capture_record.py` | 1 | Provision a VNC recording session; prints the viewer URL |
 | `capture_autopilot.py` | 1→2 | Drive a profile's session via `/execute/browser` (scripted steps); synthesize a bundle + compile |
 | `capture_import.py` | 1→2→3 | Drain the bundle; compile (workflow) or compile+register (login) |
+| `bundle_inspect.py` | 1 | Summarise a saved bundle: mode block, URL timeline, endpoint/tool table |
 | `compile_workflow.py` | 2 | Re-compile a saved workflow bundle → MCP/Skill |
 | `compile_login.py` | 2 | Compile a saved login bundle → App/ServiceProfile drafts |
 | `activate_register.py` | 3 | Register a compiled login result with Tabby as a tenant-wide App Template |
 | `activate_verify.py` | 3 | Deterministic auth dry-run on a generated MCP server |
 | `activate_install.py` | 3 | Install a generated skill into an agent (agnostic) |
+
+---
+
+## Inspect a bundle when a compile surprises you
+
+```bash
+python scripts/bundle_inspect.py workbench/bundles/<name>.json
+python scripts/bundle_inspect.py --session <session_id>    # drain from Tabby first
+```
+
+Prints, in one pass: the **mode block** (Tabby's `recording_mode`, NoUI's own
+classification, and the mode the session was *provisioned* as — side by side, with a
+warning when they disagree), the URL timeline with the login boundary marked, credential
+interactions (roles + redaction only, never values), and the **API endpoint table** built
+with the compiler's own filter and naming — so it previews the operation set compile will
+emit. Reach for it first whenever an import produced the wrong kind of asset or an
+operation you didn't expect.
+
+**NoUI never routes on Tabby's `recording_mode`.** The field is unreliable — a
+warm-pool recording session always reports `login` regardless of what was provisioned.
+`capture_import.py` decides from, in order: `--mode`, the provision ledger
+(`<workbench>/sessions/<session_id>.json`, written by `capture_record.py`), then the
+capture's content. It prints which source won.
 
 ---
 

--- a/skills/noui/noui_core/activate/session.py
+++ b/skills/noui/noui_core/activate/session.py
@@ -1,0 +1,148 @@
+"""Bring a profile's own Tabby session up, and surface the sign-in if it needs one.
+
+**Three sessions are involved in authoring a skill**, and confusing them is the
+single most surprising thing about the flow:
+
+1. the **login recording** session (a recording-shell app the human drives),
+2. the **workflow recording** session (a second recording-shell app, usually
+   cookie-seeded from #1),
+3. the **profile's own session** — the one `call_web_api` / `/execute/fetch`
+   resolve at runtime. Tabby auto-provisions it per user from the tenant-wide App
+   Template, on first use.
+
+Session #3 is a different browser from the two the human just drove, and the App
+Template registers `credential_ref: manual:` — nothing stored — so it starts
+`LOGIN_NEEDED` and needs one interactive sign-in before the first live call.
+
+That sign-in is **correct and stays**. The alternative would be seeding the
+recording's cookies into the template, but the template is tenant-wide: that
+would hand the recorder's live session to every member of the org. Per-user auth
+with nothing stored costs one sign-in.
+
+What was wrong is only that nothing announced it — a harness session finished
+compiling, went straight into generalize-testing, and got `login_required` at the
+worst possible moment. So: provoke the provisioning *at import time*, find out
+whether a sign-in is needed, and hand over the link before anyone starts testing.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from noui_core import tabby_client
+from noui_core.capture.recording import resolve_agent_token
+
+# States that will never become healthy on their own.
+_TERMINAL_STATES = frozenset({"FAILED", "TERMINATED"})
+
+
+def _login_link(session_id: str, token: str, status: dict[str, Any]) -> str:
+    """A link the human can open to complete the sign-in.
+
+    Prefers the short code (``.../s/<id>``): the raw ``vnc_url`` embeds a JWT in
+    its ``#token=`` fragment that the harness secret-redactor strips, which breaks
+    the link. Mode is deliberately the default resolve panel ("Mark as Resolved"),
+    NOT ``recording`` — this is a HITL login, not a capture.
+    """
+    if session_id:
+        try:
+            return tabby_client.create_short_link(session_id, token)
+        except RuntimeError:
+            pass
+    return ((status.get("vnc_stream") or {}) or {}).get("url", "") or ""
+
+
+def ensure_session(
+    profile_slug: str, *, wait_seconds: int = 45, poll_interval: float = 3.0
+) -> dict[str, Any]:
+    """Make sure the profile has a usable session; report what a human must do.
+
+    Returns ``{profile_slug, state, session_id, needs_login, login_url,
+    credentials_ready, timed_out}``. ``needs_login`` is True when a sign-in link
+    is waiting, False when the session is already HEALTHY, and None when we
+    couldn't tell within the budget (still provisioning, or terminal) — never a
+    false green.
+    """
+    token = resolve_agent_token()
+
+    # POST /credentials/request is what triggers Tabby's per-user auto-provisioning
+    # from the App Template. It may 404 or come back empty before the profile
+    # exists — that's expected; the status poll below is the source of truth.
+    credentials_ready = False
+    try:
+        creds = tabby_client.request_credentials(profile_slug, token)
+        credentials_ready = bool(creds.get("headers") or creds.get("cookies"))
+    except RuntimeError:
+        pass
+
+    result: dict[str, Any] = {
+        "profile_slug": profile_slug,
+        "state": "",
+        "session_id": "",
+        "needs_login": None,
+        "login_url": "",
+        "credentials_ready": credentials_ready,
+        "timed_out": False,
+    }
+
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        status: dict[str, Any] = {}
+        try:
+            status = tabby_client.get_session_status(profile_slug, token)
+        except RuntimeError:
+            # 404 while the profile/session row is still being created.
+            status = {}
+
+        result["state"] = status.get("state", "") or result["state"]
+        result["session_id"] = status.get("session_id", "") or result["session_id"]
+
+        if status.get("hitl_active"):
+            result["needs_login"] = True
+            result["login_url"] = _login_link(result["session_id"], token, status)
+            return result
+        if result["state"] == "HEALTHY":
+            result["needs_login"] = False
+            return result
+        if result["state"] in _TERMINAL_STATES:
+            return result
+        if time.monotonic() >= deadline:
+            result["timed_out"] = True
+            return result
+        time.sleep(poll_interval)
+
+
+def format_activation_notice(result: dict[str, Any]) -> str:
+    """The operator-facing message for an ensure_session result.
+
+    Shared by ``capture_import.py --activate-session`` and
+    ``scripts/activate_session.py`` so the wording can't drift.
+    """
+    slug = result["profile_slug"]
+    if result["needs_login"] is True:
+        link = result["login_url"] or "(no viewer link available — check Tabby)"
+        return (
+            f"Activation sign-in required for profile '{slug}' (one time, per user):\n"
+            f"  {link}\n"
+            "This is the app's OWN Tabby session — a different browser from the recording "
+            "sessions you just drove, which is why signing in there doesn't carry over. "
+            "Nothing is stored: the session belongs to this user only. Sign in once, then "
+            "run your live tests."
+        )
+    if result["needs_login"] is False:
+        return (
+            f"Profile '{slug}' already has a HEALTHY session — no activation sign-in needed. "
+            "Live calls should work now."
+        )
+    if result["state"] in _TERMINAL_STATES:
+        return (
+            f"Profile '{slug}' session is {result['state']} — it will not recover on its own. "
+            "Re-run this activation, or re-record the login if it keeps failing."
+        )
+    state = result["state"] or "not created yet"
+    return (
+        f"Profile '{slug}' is still provisioning (state: {state}). Retry in a moment with:\n"
+        f"  python scripts/activate_session.py {slug}\n"
+        "The first live call will also trigger it — expect one sign-in prompt then."
+    )

--- a/skills/noui/noui_core/capture/bundle.py
+++ b/skills/noui/noui_core/capture/bundle.py
@@ -4,7 +4,8 @@ A Tabby recording bundle has the shape::
 
     {
       "session_id": "...",
-      "recording_mode": "login" | "workflow",
+      "recording_mode": "login" | "workflow",   # IGNORED by NoUI — unreliable,
+                                                # see noui_core.capture.classify
       "started_at": "...", "stopped_at": "...",
       "har": {"log": {...}},
       "click_events": [ {event_type, tag_name, selector, value, field_role, ...}, ... ],
@@ -49,8 +50,6 @@ _CLICK_FIELDS = (
     "timestamp",
 )
 
-_VALID_MODES = ("login", "workflow")
-
 
 def save_bundle(bundle: dict[str, Any], name: str, output_root: str | None = None) -> Path:
     """Persist a capture bundle to ``<workbench>/bundles/<name>-<session>.json``.
@@ -72,15 +71,20 @@ def save_bundle(bundle: dict[str, Any], name: str, output_root: str | None = Non
     return path
 
 
-def validate_bundle(bundle: dict[str, Any]) -> str:
-    """Return the session_type ('login'|'workflow') or raise ValueError."""
-    mode = bundle.get("recording_mode")
-    if mode not in _VALID_MODES:
-        raise ValueError(f"bundle.recording_mode must be one of {_VALID_MODES}, got {mode!r}")
+def validate_bundle(bundle: dict[str, Any]) -> None:
+    """Validate the bundle's SHAPE. Raises ValueError if it isn't usable.
+
+    Deliberately not a classifier: it used to return ``bundle["recording_mode"]``
+    as the session type, which made Tabby's (unreliable) stamp decide how the
+    capture was compiled. Deciding what a bundle is now lives in
+    ``noui_core.capture.classify`` — see that module for why the field can't be
+    trusted. Here we only check that there is a HAR to compile.
+    """
+    if not isinstance(bundle, dict):
+        raise ValueError(f"bundle must be a JSON object, got {type(bundle).__name__}")
     har = bundle.get("har")
     if not isinstance(har, dict) or "log" not in har:
         raise ValueError("bundle.har must be an object with a 'log' key (HAR 1.2)")
-    return mode
 
 
 def click_payloads(

--- a/skills/noui/noui_core/capture/classify.py
+++ b/skills/noui/noui_core/capture/classify.py
@@ -1,0 +1,110 @@
+"""Decide what a capture bundle actually **is**: a login, a workflow, or both.
+
+``bundle["recording_mode"]`` is deliberately **never read here**. Tabby's stamp
+cannot be trusted:
+
+* A **combined** capture (sign in, then drive the workflow in one session) is
+  provisioned as ``login`` on purpose — see ``split.py``.
+* Worse, a session served from Tabby's **warm recording pool** always reports
+  ``login`` whatever the client declared: the pool's shared shell app hardcodes
+  ``browser_policy.recording_mode: 'login'``, and the worker reads that policy
+  once at pod boot. A warm claim rebinds the running pod to the request's own
+  shell app but never re-reads it, so the mode the caller asked for is lost by
+  drain time (the HTTP provision response still reports it correctly, which is
+  why the divergence only shows up at import). This silently routed a workflow
+  recording into the login/App-Template path.
+
+So NoUI classifies from the capture's **content** instead. Callers combine this
+with two stronger signals — an explicit ``--mode`` flag and the provision
+ledger (``noui_core.capture.ledger``, what the operator actually asked for) —
+and fall back here only when neither is available.
+
+The signal for "a login happened" is credential-field interaction, the same one
+``split.find_login_boundary`` uses. The signal for "and then a workflow
+happened" is the human continuing to *drive* after the login landed — a click,
+or at least two stable navigations — **plus** real API traffic there.
+
+Both halves of that test are deliberately conservative, because a false
+"combined" splits a pure login capture and registers a truncated App Template:
+
+* Post-login API traffic alone means nothing — a login lands on a dashboard that
+  fires plenty of XHRs by itself (a real Airbnb login capture: 21 of them, zero
+  interaction).
+* A single post-login navigation means nothing either — logins settle through
+  one last bounce (a real Expedia login capture ends
+  ``/onboarding?originUrl=…`` → ``/?challengeReferer=noref``). Two or more
+  stable navigations, or any click, is a human going somewhere on purpose.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from noui_core.capture.split import CREDENTIAL_FIELD_ROLES, find_login_boundary, split_bundle
+from noui_core.compile.login_assets import _is_redirect_hop
+
+# The three shapes a capture can have. "combined" holds both halves and is split
+# at import (`capture_import.py --mode combined`).
+LOGIN = "login"
+WORKFLOW = "workflow"
+COMBINED = "combined"
+MODES = (LOGIN, WORKFLOW, COMBINED)
+
+
+def _api_call_count(bundle: dict[str, Any]) -> int:
+    """HAR entries the compiler would consider real API calls.
+
+    Uses the compiler's own filter so this count can't drift from what compile
+    actually emits.
+    """
+    from noui_core.compile.har_to_tools import _is_api_call
+
+    entries = ((bundle.get("har") or {}).get("log") or {}).get("entries") or []
+    return sum(1 for e in entries if isinstance(e, dict) and _is_api_call(e))
+
+
+def bundle_signals(bundle: dict[str, Any]) -> dict[str, Any]:
+    """Content signals behind the classification (also surfaced by bundle_inspect)."""
+    clicks = [c for c in (bundle.get("click_events") or []) if isinstance(c, dict)]
+    credential_events = sum(1 for c in clicks if c.get("field_role") in CREDENTIAL_FIELD_ROLES)
+    boundary = find_login_boundary(bundle)
+
+    signals: dict[str, Any] = {
+        "credential_events": credential_events,
+        "login_boundary": boundary,
+        "api_calls_total": _api_call_count(bundle),
+        "post_login_clicks": 0,
+        "post_login_url_events": 0,
+        "post_login_stable_navs": 0,
+        "post_login_api_calls": 0,
+    }
+    if boundary is None:
+        return signals
+
+    parts = split_bundle(bundle)
+    if parts is None:  # pragma: no cover — boundary implies a split
+        return signals
+    _, workflow_slice = parts
+    url_events = [u for u in (workflow_slice.get("url_events") or []) if isinstance(u, dict)]
+    signals["post_login_clicks"] = len(workflow_slice.get("click_events") or [])
+    signals["post_login_url_events"] = len(url_events)
+    signals["post_login_stable_navs"] = sum(
+        1
+        for u in url_events
+        if u.get("to_url") and not _is_redirect_hop(u.get("from_url", "") or "", u["to_url"])
+    )
+    signals["post_login_api_calls"] = _api_call_count(workflow_slice)
+    return signals
+
+
+def classify_bundle(bundle: dict[str, Any]) -> str:
+    """Return ``"login"``, ``"workflow"`` or ``"combined"`` from the capture's content."""
+    signals = bundle_signals(bundle)
+    if signals["login_boundary"] is None:
+        return WORKFLOW
+    # "The human kept driving after signing in": a click, or a second stable
+    # navigation (the first one is the login settling — see the module docstring).
+    kept_driving = signals["post_login_clicks"] >= 1 or signals["post_login_stable_navs"] >= 2
+    if kept_driving and signals["post_login_api_calls"]:
+        return COMBINED
+    return LOGIN

--- a/skills/noui/noui_core/capture/inspect.py
+++ b/skills/noui/noui_core/capture/inspect.py
@@ -95,6 +95,10 @@ def _url_timeline(bundle: dict[str, Any], boundary: str | None) -> list[dict[str
     made hand-rolled inspection scripts report empty timelines.
     """
     out: list[dict[str, Any]] = []
+    # Collapse "no boundary" (None) and an empty boundary into one falsy string, so
+    # the comparisons below are plain str-to-str and an empty boundary can't mark
+    # every navigation as post-login.
+    bound = boundary or ""
     for ev in bundle.get("url_events") or []:
         if not isinstance(ev, dict) or not ev.get("to_url"):
             continue
@@ -104,8 +108,8 @@ def _url_timeline(bundle: dict[str, Any], boundary: str | None) -> list[dict[str
                 "timestamp": ts,
                 "from_url": ev.get("from_url") or "",
                 "to_url": ev["to_url"],
-                "is_login_boundary": bool(boundary) and ts == boundary,
-                "post_login": bool(boundary) and bool(ts) and ts > boundary,
+                "is_login_boundary": bool(bound) and ts == bound,
+                "post_login": bool(bound) and bool(ts) and ts > bound,
             }
         )
     return out

--- a/skills/noui/noui_core/capture/inspect.py
+++ b/skills/noui/noui_core/capture/inspect.py
@@ -1,0 +1,168 @@
+"""Summarise a capture bundle: what's in it, and what compile would make of it.
+
+Pure (no I/O): ``summarize()`` returns a dict; ``scripts/bundle_inspect.py``
+renders it. Two jobs:
+
+1. **Answer "is this bundle what I think it is?"** — the mode block puts Tabby's
+   stamp, NoUI's classification and the provisioned (ledger) mode side by side,
+   so a mismatch is a one-line read instead of an ad-hoc script.
+2. **Preview the operation set** — the endpoint table is built with the
+   *compiler's own* filter, path templating and tool naming
+   (``compile.har_to_tools``), so it cannot drift into being a second opinion
+   about what compile will emit.
+
+Never emits recorded values — only field roles and redaction status — so it is
+safe to run on any bundle and paste the output.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlparse
+
+from noui_core.capture.bundle import count_sensitive_unredacted
+from noui_core.capture.classify import bundle_signals, classify_bundle
+from noui_core.capture.split import CREDENTIAL_FIELD_ROLES
+
+# Deliberately the compiler's own internals: the table must mirror compile, not
+# re-implement it. If these move, this preview should move with them.
+from noui_core.compile.har_to_tools import _is_api_call, _path_template, _tool_name
+
+
+def _response_size(resp: dict[str, Any]) -> int:
+    """Bytes of response body actually captured.
+
+    Tabby's HAR carries ``content.text`` but no ``content.size``, so trusting
+    ``size`` alone reports 0 for every entry — which reads as "empty response"
+    when the body is right there. Measure the text, then fall back to bodySize.
+    A genuine 0 is useful signal: nothing was captured for that call.
+    """
+    content = resp.get("content") or {}
+    size = content.get("size") or 0
+    if size:
+        return int(size)
+    text = content.get("text")
+    if isinstance(text, str):
+        return len(text)
+    return max(int(resp.get("bodySize") or 0), 0)
+
+
+def _endpoints(bundle: dict[str, Any]) -> list[dict[str, Any]]:
+    """The operations compile would emit, in recording order.
+
+    Same filter + dedup key + naming as ``har_to_tools.har_to_tool_defs``:
+    ``(method, base_url, path_template)``, first occurrence wins.
+    """
+    entries = ((bundle.get("har") or {}).get("log") or {}).get("entries") or []
+    seen: dict[tuple[str, str, str], dict[str, Any]] = {}
+    used_names: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict) or not _is_api_call(entry):
+            continue
+        req = entry.get("request") or {}
+        resp = entry.get("response") or {}
+        parsed = urlparse(req.get("url", ""))
+        method = (req.get("method") or "GET").upper()
+        base_url = f"{parsed.scheme}://{parsed.netloc}"
+        path_template, path_params = _path_template(parsed.path)
+        key = (method, base_url, path_template)
+        if key in seen:
+            seen[key]["occurrences"] += 1
+            continue
+        content = resp.get("content") or {}
+        name = _tool_name(method, path_template, used_names)
+        used_names.add(name)
+        seen[key] = {
+            "method": method,
+            "host": parsed.netloc,
+            "path_template": path_template,
+            "path_params": path_params,
+            "status": resp.get("status", 0),
+            "mime": (content.get("mimeType") or "").split(";")[0],
+            "size": _response_size(resp),
+            "has_request_body": bool((req.get("postData") or {}).get("text")),
+            "tool_name": name,
+            "occurrences": 1,
+        }
+    return list(seen.values())
+
+
+def _url_timeline(bundle: dict[str, Any], boundary: str | None) -> list[dict[str, Any]]:
+    """Navigations in order, with the login boundary marked.
+
+    Reads the real field names (``url_events`` carry ``from_url``/``to_url``,
+    unlike ``click_events`` which carry a flat ``url``) — the exact trap that
+    made hand-rolled inspection scripts report empty timelines.
+    """
+    out: list[dict[str, Any]] = []
+    for ev in bundle.get("url_events") or []:
+        if not isinstance(ev, dict) or not ev.get("to_url"):
+            continue
+        ts = ev.get("timestamp") or ""
+        out.append(
+            {
+                "timestamp": ts,
+                "from_url": ev.get("from_url") or "",
+                "to_url": ev["to_url"],
+                "is_login_boundary": bool(boundary) and ts == boundary,
+                "post_login": bool(boundary) and bool(ts) and ts > boundary,
+            }
+        )
+    return out
+
+
+def _credential_events(bundle: dict[str, Any]) -> list[dict[str, Any]]:
+    """Credential-field interactions by role. Counts and redaction only, never values."""
+    roles: dict[str, dict[str, int]] = {}
+    for ev in bundle.get("click_events") or []:
+        if not isinstance(ev, dict):
+            continue
+        role = ev.get("field_role")
+        if role not in CREDENTIAL_FIELD_ROLES:
+            continue
+        bucket = roles.setdefault(str(role), {"count": 0, "redacted": 0})
+        bucket["count"] += 1
+        if ev.get("is_redacted"):
+            bucket["redacted"] += 1
+    return [{"field_role": r, **counts} for r, counts in sorted(roles.items())]
+
+
+def summarize(
+    bundle: dict[str, Any], *, ledger_entry: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Everything ``bundle_inspect.py`` prints, as data."""
+    signals = bundle_signals(bundle)
+    classification = classify_bundle(bundle)
+    stamped = bundle.get("recording_mode")
+    declared = (ledger_entry or {}).get("declared_mode", "")
+    har_entries = ((bundle.get("har") or {}).get("log") or {}).get("entries") or []
+    endpoints = _endpoints(bundle)
+
+    return {
+        "session_id": bundle.get("session_id", ""),
+        "started_at": bundle.get("started_at", ""),
+        "stopped_at": bundle.get("stopped_at", ""),
+        "mode": {
+            "tabby_reported": stamped,
+            "noui_classification": classification,
+            "ledger_declared": declared,
+            # Tabby's stamp is expected to disagree for combined and warm-pool
+            # captures; worth surfacing, never worth trusting.
+            "tabby_disagrees": bool(stamped) and stamped != classification,
+            "ledger_disagrees": bool(declared) and declared != classification,
+        },
+        "counts": {
+            "har_entries": len(har_entries),
+            "api_calls": signals["api_calls_total"],
+            "operations": len(endpoints),
+            "click_events": len(bundle.get("click_events") or []),
+            "url_events": len(bundle.get("url_events") or []),
+            "cookies": len(bundle.get("cookies") or []),
+        },
+        "signals": signals,
+        "url_timeline": _url_timeline(bundle, signals["login_boundary"]),
+        "credential_events": _credential_events(bundle),
+        "endpoints": endpoints,
+        "unredacted_secrets": count_sensitive_unredacted(bundle),
+        "ledger": ledger_entry or None,
+    }

--- a/skills/noui/noui_core/capture/ledger.py
+++ b/skills/noui/noui_core/capture/ledger.py
@@ -1,0 +1,86 @@
+"""Local record of what each recording session was **provisioned as**.
+
+``capture_record.py`` writes one small JSON file per provisioned session, so
+``capture_import.py`` can later ask "what did the operator actually ask for?"
+instead of trusting the mode Tabby stamps on the drained bundle (which is
+unreliable — see ``noui_core.capture.classify``).
+
+This is intentionally a flat file next to the bundles rather than server state:
+the declared mode is a *client* fact, and keeping it client-side is what makes
+NoUI independent of whether Tabby reports the mode correctly.
+
+Entries are advisory. A missing ledger (an old session, a bundle copied from
+another machine, a session provisioned outside NoUI) is normal, and callers fall
+back to content classification.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from noui_core.capture.classify import MODES
+
+
+def _root() -> Path:
+    from noui_core.config import settings
+
+    return Path(settings.workbench_dir) / "sessions"
+
+
+def path_for(session_id: str) -> Path:
+    return _root() / f"{session_id}.json"
+
+
+def record(
+    session_id: str,
+    *,
+    declared_mode: str,
+    url: str = "",
+    profile: str = "",
+    from_session: str = "",
+    residential: bool = False,
+) -> Path:
+    """Persist what this session was provisioned as. Returns the written path."""
+    if declared_mode not in MODES:
+        raise ValueError(f"declared_mode must be one of {MODES}, got {declared_mode!r}")
+    root = _root()
+    root.mkdir(parents=True, exist_ok=True)
+    path = path_for(session_id)
+    path.write_text(
+        json.dumps(
+            {
+                "session_id": session_id,
+                "declared_mode": declared_mode,
+                "url": url,
+                "profile": profile,
+                "from_session": from_session,
+                "residential": residential,
+                "created_at": datetime.now(UTC).isoformat(),
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    return path
+
+
+def lookup(session_id: str) -> dict[str, Any] | None:
+    """Return the ledger entry for a session, or None if there isn't one."""
+    if not session_id:
+        return None
+    path = path_for(session_id)
+    try:
+        entry = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    return entry if isinstance(entry, dict) else None
+
+
+def declared_mode(session_id: str) -> str:
+    """The mode this session was provisioned as, or "" when unknown/unusable."""
+    entry = lookup(session_id) or {}
+    mode = entry.get("declared_mode", "")
+    return mode if mode in MODES else ""

--- a/skills/noui/noui_core/capture/recording.py
+++ b/skills/noui/noui_core/capture/recording.py
@@ -16,6 +16,7 @@ import urllib.parse
 
 from noui_core import tabby_client
 from noui_core.capture.bundle import count_sensitive_unredacted, validate_bundle
+from noui_core.capture.classify import classify_bundle
 from noui_core.config import settings
 
 _MISSING_CREDS = (
@@ -216,15 +217,21 @@ def provision_live_link(
 def fetch_bundle(session_id: str) -> tuple[str, dict]:
     """Drain and validate a recording bundle from Tabby.
 
-    Returns (session_type, bundle) where session_type is "login" or "workflow".
+    Returns ``(classification, bundle)`` where classification is "login",
+    "workflow" or "combined", derived from the capture's **content** by
+    ``noui_core.capture.classify`` — never from ``bundle["recording_mode"]``,
+    which Tabby stamps unreliably (warm-pool sessions always report "login").
+    The classification is advisory: callers should prefer an explicit ``--mode``
+    or the provision ledger when either is available.
+
     Raises ValueError on an invalid bundle, RuntimeError on unredacted secrets.
     """
     token = resolve_agent_token()
     bundle = tabby_client.get_recording_bundle(session_id, token)
-    session_type = validate_bundle(bundle)  # raises ValueError on bad shape
+    validate_bundle(bundle)  # raises ValueError on bad shape
     leaks = count_sensitive_unredacted(bundle)
     if leaks:
         raise RuntimeError(
             f"Refusing to import: {leaks} password/OTP value(s) were not redacted in the bundle."
         )
-    return session_type, bundle
+    return classify_bundle(bundle), bundle

--- a/skills/noui/noui_core/tabby_client.py
+++ b/skills/noui/noui_core/tabby_client.py
@@ -56,11 +56,7 @@ def _unreachable_error(
     base = settings.tabby_api_host.rstrip("/")
     mode = settings.tabby_auth_mode or "agent_token"
     who = "control-plane broker" if settings.broker_mode() else "Tabby API"
-    tried = (
-        f" Retried {attempts} time(s) over {elapsed:.0f}s."
-        if attempts > 1
-        else " Not retried (non-idempotent request)."
-    )
+    tried = f" Retried {attempts} time(s) over {elapsed:.0f}s." if attempts > 1 else " Not retried."
     return RuntimeError(
         f"Cannot reach the {who} at {base} ({mode} mode) for {method} {path}: {detail}."
         f"{tried} This is an upstream/network failure, not an auth problem — a rejected "
@@ -200,6 +196,10 @@ def get_agent_token(client_id: str, client_secret: str) -> str:
             "Missing TABBY_CLIENT_ID or TABBY_CLIENT_SECRET — "
             "run `noui tabby setup` to provision agent credentials"
         )
+    # Retried: minting a fresh short-lived token is safe to repeat, and in
+    # agent_token mode this is the FIRST call of every command — so without a
+    # retry here a brief control-plane blip fails the run before it starts, and
+    # the error names /auth/agent-token rather than the work the caller wanted.
     resp = _tabby_http(
         "POST",
         "/auth/agent-token",
@@ -208,6 +208,7 @@ def get_agent_token(client_id: str, client_secret: str) -> str:
             "client_secret": client_secret,
             "grant_type": "client_credentials",
         },
+        retries=3,
     )
     if not isinstance(resp, dict):
         raise RuntimeError(f"Unexpected response from POST /auth/agent-token: {type(resp)}")
@@ -260,10 +261,13 @@ def get_platform_tabby_token(adopt_api_url: str, client_id: str, client_secret: 
     Returns the Tabby bearer token string. Raises RuntimeError on failure.
     """
     platform_jwt = get_platform_jwt(adopt_api_url, client_id, client_secret)
+    # Retried for the same reason as get_agent_token: a token exchange is safe to
+    # repeat and sits in front of every platform_jwt-mode command.
     resp = _tabby_http(
         "POST",
         "/auth/token-exchange",
         body={"subject_token": platform_jwt, "subject_token_type": "oidc_jwt"},
+        retries=3,
     )
     if not isinstance(resp, dict):
         raise RuntimeError(f"Unexpected response from POST /auth/token-exchange: {type(resp)}")

--- a/skills/noui/noui_core/tabby_client.py
+++ b/skills/noui/noui_core/tabby_client.py
@@ -15,6 +15,7 @@ Configuration is read from noui_core.config.settings:
 
 from __future__ import annotations
 
+import http.client
 import json
 import time
 import urllib.error
@@ -28,6 +29,44 @@ from noui_core.config import settings
 # Internal HTTP helper
 # ---------------------------------------------------------------------------
 
+# Upstream statuses worth retrying. In broker mode the harness control-plane
+# broker answers 502 for both "tabby upstream error" and a failed per-user
+# bearer resolution (see adoptai-workflows noui_broker.forward) — transient in
+# both cases. 401/403/4xx are NOT retried: they are answers, not outages.
+_RETRY_STATUSES = frozenset({502, 503, 504})
+
+# Transport-level failures: nothing was listening, the connection dropped, DNS
+# failed, or the socket timed out. urllib.error.URLError and HTTPError are both
+# OSError subclasses, so HTTPError MUST be caught before this tuple.
+_TRANSPORT_ERRORS = (OSError, http.client.HTTPException)
+
+
+def _unreachable_error(
+    method: str, path: str, detail: str, attempts: int, elapsed: float
+) -> RuntimeError:
+    """Build the error raised when we could not get an answer out of Tabby.
+
+    Deliberately verbose: this is the failure an agent sees when the control
+    plane is down mid-flow (often *after* a human already drove a recording), and
+    the previous bare urllib traceback named neither the URL nor the auth mode —
+    which led to it being misdiagnosed as an auth/bearer problem. Say plainly
+    what was unreachable, that the bearer is not implicated, and how hard we
+    tried, so the next step is obvious rather than exploratory.
+    """
+    base = settings.tabby_api_host.rstrip("/")
+    mode = settings.tabby_auth_mode or "agent_token"
+    who = "control-plane broker" if settings.broker_mode() else "Tabby API"
+    tried = (
+        f" Retried {attempts} time(s) over {elapsed:.0f}s."
+        if attempts > 1
+        else " Not retried (non-idempotent request)."
+    )
+    return RuntimeError(
+        f"Cannot reach the {who} at {base} ({mode} mode) for {method} {path}: {detail}."
+        f"{tried} This is an upstream/network failure, not an auth problem — a rejected "
+        f"bearer answers with HTTP 401/403. Check that the {who} is up, then re-run."
+    )
+
 
 def _tabby_http(
     method: str,
@@ -35,11 +74,19 @@ def _tabby_http(
     body: dict[str, Any] | None = None,
     token: str | None = None,
     timeout: int = 15,
+    retries: int = 0,
 ) -> dict[str, Any] | list[Any]:
     """
     Make an HTTP request to the Tabby API.
 
-    Raises RuntimeError on non-2xx responses.
+    Always raises ``RuntimeError`` on failure — including transport-level
+    failures (connection refused/reset, DNS, socket timeout), which urllib
+    raises as ``OSError`` subclasses and which therefore used to escape every
+    ``except RuntimeError`` handler in the scripts as a raw traceback.
+
+    ``retries`` (0 = none) retries transport failures and _RETRY_STATUSES with
+    exponential backoff (1-2-4-8-16s). Only for requests that are safe to repeat
+    — a caller that creates or mutates server-side state must leave it at 0.
     """
     url = settings.tabby_api_host.rstrip("/") + path
     data = json.dumps(body).encode() if body is not None else b""
@@ -47,12 +94,43 @@ def _tabby_http(
     if token:
         headers["Authorization"] = f"Bearer {token}"
     req = urllib.request.Request(url, data=data, method=method, headers=headers)
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode())
-    except urllib.error.HTTPError as exc:
-        body_text = exc.read().decode(errors="replace")
-        raise RuntimeError(f"HTTP {exc.code} from {method} {path}: {body_text}") from exc
+
+    attempts = max(1, retries + 1)
+    started = time.monotonic()
+    delay = 1.0
+    for attempt in range(1, attempts + 1):
+        last = attempt == attempts
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode())
+        except urllib.error.HTTPError as exc:
+            body_text = exc.read().decode(errors="replace")
+            if exc.code in _RETRY_STATUSES and not last:
+                time.sleep(delay)
+                delay *= 2
+                continue
+            suffix = (
+                f" (after {attempt} attempt(s) over {time.monotonic() - started:.0f}s)"
+                if attempt > 1
+                else ""
+            )
+            raise RuntimeError(
+                f"HTTP {exc.code} from {method} {path}{suffix}: {body_text}"
+            ) from exc
+        except _TRANSPORT_ERRORS as exc:
+            if not last:
+                time.sleep(delay)
+                delay *= 2
+                continue
+            raise _unreachable_error(
+                method,
+                path,
+                f"{type(exc).__name__}: {exc}",
+                attempts,
+                time.monotonic() - started,
+            ) from exc
+    # Unreachable: the loop either returns or raises on its final attempt.
+    raise RuntimeError(f"{method} {path} exhausted {attempts} attempt(s) without a response")
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +306,9 @@ def create_recording_session(
         body["residential_proxy"] = True
     # Provisioning blocks server-side until the worker session row exists (worker
     # scheduling can take >15s under load), so allow a generous client timeout.
+    # Deliberately NOT retried: each call creates a shell app (and can claim or
+    # cold-start a pod), so a retry after an ambiguous transport failure would
+    # leak recording sessions. Fail fast and let the operator re-run.
     resp = _tabby_http("POST", "/recording/sessions", body=body, token=agent_token, timeout=90)
     if not isinstance(resp, dict) or "vnc_url" not in resp:
         raise RuntimeError(f"POST /recording/sessions returned an unexpected payload: {resp}")
@@ -241,13 +322,19 @@ def get_recording_bundle(session_id: str, agent_token: str) -> dict:
     Returns the drained VNC recording bundle (HAR + click_events + url_events)
     that the worker captured and the API persisted on "Finish & export".
     Raises RuntimeError if the bundle is missing or the response is malformed.
+
+    Retried generously (5 retries ≈ 31s): a drained bundle is immutable, so
+    re-reading it is free, and by the time we get here a human has already spent
+    minutes driving the recording — a few seconds of control-plane unavailability
+    must not throw that away.
     """
     resp = _tabby_http(
         "GET",
         f"/recording/sessions/{session_id}/bundle",
         token=agent_token,
+        retries=5,
     )
-    if not isinstance(resp, dict) or "recording_mode" not in resp:
+    if not isinstance(resp, dict) or "har" not in resp:
         raise RuntimeError(
             f"GET /recording/sessions/{session_id}/bundle returned an unexpected payload: {resp}"
         )
@@ -261,11 +348,15 @@ def request_credentials(profile_slug: str, agent_token: str) -> dict:
     Returns the credentials dict with "headers" and "cookies" lists.
     Raises RuntimeError on failure.
     """
+    # Safe to repeat: it reads credentials for a profile (and, on first call for a
+    # member, triggers Tabby's idempotent auto-provisioning from the App Template
+    # — which already handles the concurrent-provision race server-side).
     resp = _tabby_http(
         "POST",
         "/credentials/request",
         body={"profile_id": profile_slug},
         token=agent_token,
+        retries=2,
     )
     if not isinstance(resp, dict):
         raise RuntimeError(f"Unexpected response from POST /credentials/request: {type(resp)}")
@@ -281,7 +372,7 @@ def get_service_profile_by_slug(profile_slug: str, token: str) -> dict | None:
     Raises RuntimeError on API errors.
     """
     try:
-        resp = _tabby_http("GET", "/admin/profiles", token=token)
+        resp = _tabby_http("GET", "/admin/profiles", token=token, retries=2)
     except RuntimeError:
         return None
     if isinstance(resp, list):
@@ -382,7 +473,7 @@ def get_app_template(template_id: str, token: str) -> dict | None:
     on other API errors.
     """
     try:
-        resp = _tabby_http("GET", f"/admin/app-templates/{template_id}", token=token)
+        resp = _tabby_http("GET", f"/admin/app-templates/{template_id}", token=token, retries=2)
     except RuntimeError as exc:
         if "HTTP 404" in str(exc):
             return None
@@ -426,7 +517,7 @@ def list_app_templates(token: str) -> list[dict]:
     Returns the list of template dicts (``[]`` if the API returns none).
     Raises RuntimeError on API errors.
     """
-    resp = _tabby_http("GET", "/admin/app-templates", token=token)
+    resp = _tabby_http("GET", "/admin/app-templates", token=token, retries=2)
     if isinstance(resp, list):
         return resp
     if isinstance(resp, dict):
@@ -483,7 +574,7 @@ def get_session_status(profile_slug: str, token: str) -> dict:
     ``vnc_stream: {url, expires_at}`` — the URL a human opens to complete login.
     Returns the status dict (session_id, state, hitl_active, vnc_stream, ...).
     """
-    resp = _tabby_http("GET", f"/agent/session-status/{profile_slug}", token=token)
+    resp = _tabby_http("GET", f"/agent/session-status/{profile_slug}", token=token, retries=3)
     if not isinstance(resp, dict):
         raise RuntimeError(
             f"Unexpected response from GET /agent/session-status/{profile_slug}: {type(resp)}"
@@ -504,7 +595,12 @@ def create_short_link(session_id: str, token: str, mode: str = "") -> str:
     secret-redactor strips (breaking the link), whereas the short code is redaction-safe.
     """
     body = {"mode": mode} if mode else None
-    resp = _tabby_http("POST", f"/sessions/{session_id}/short-link", body=body, token=token)
+    # Safe to repeat: mints a fresh short code for the same session (no other
+    # server-side effect), and a transport blip here would otherwise be read as
+    # "this session is dead" by provision_live_link's liveness check.
+    resp = _tabby_http(
+        "POST", f"/sessions/{session_id}/short-link", body=body, token=token, retries=2
+    )
     if not isinstance(resp, dict) or "short_url" not in resp:
         raise RuntimeError(
             f"POST /sessions/{session_id}/short-link returned an unexpected payload: {resp}"

--- a/skills/noui/references/generalize.md
+++ b/skills/noui/references/generalize.md
@@ -37,6 +37,34 @@ Delete pruned operations from the asset:
 When in doubt, keep it for now and let the test in step 3 decide — a call that
 returns nothing useful is noise.
 
+## Before you test: three sessions, up to three sign-ins
+
+Testing hits a **different browser session** from the ones you just recorded. Three are
+involved:
+
+1. the **login recording** session (the human drove it),
+2. the **workflow recording** session (a second one, usually cookie-seeded from #1),
+3. the **profile's own session** — what `call_web_api` / `/execute/fetch` actually resolve.
+   Tabby auto-provisions it per user from the App Template, on first use.
+
+Session #3 starts `LOGIN_NEEDED`: the template registers `credential_ref: manual:`, so
+nothing is stored. Recording cookies are deliberately **not** reused for it — the template
+is tenant-wide, so seeding them would hand the recorder's live session to every member of
+the org. Per-user auth with nothing stored costs one sign-in.
+
+So expect **one activation sign-in** before the first live call, even though the human just
+signed in during capture. Get it out of the way before step 3 rather than discovering it as
+a `login_required` mid-test:
+
+```bash
+python scripts/activate_session.py <profile-slug>
+# or, at import time:
+python scripts/capture_import.py <session_id> --name <app> --activate-session
+```
+
+Either prints a sign-in link when one is needed, or confirms the session is already
+HEALTHY.
+
 ## 3. Test the survivors — a couple of times each
 **Actually run every remaining operation against the live site** and confirm it
 returns what the workflow needs (right status, non-empty, the expected fields) —
@@ -47,7 +75,10 @@ one-off or intermittently blocked.
 - **tabby/http**: `python operations/<tool>.py <args>` (needs a HEALTHY Tabby session for the profile). Run `python scripts/activate_verify.py <server_dir>` first for a deterministic auth dry-run.
 
 ## 4. Fix or drop failures
-- **Empty credentials / 401 / profile 404** → the profile/session isn't healthy or the slug is wrong; bring the session up (see `pillar-1-capture.md`) and re-test.
+- **`login_required` / empty credentials / 401 / profile 404** → the profile's own session
+  needs its one activation sign-in (see the section above) or the slug is wrong. Run
+  `python scripts/activate_session.py <profile-slug>`, have the human open the link it
+  prints, then re-test.
 - **429 / bot detection** → prefer browser-side execution (`--execution-mode tabby`, `/execute/fetch`) over `http`; retry.
 - **Wrong or empty payload** → the first compile may have dropped/duplicated a request body (e.g. a GraphQL query lost to `/graphql` dedup). Recover it from the saved bundle and recompile (`compile_workflow.py <bundle.json>`), then re-test.
 - **Can't be made to work and isn't essential** → drop it (step 2).
@@ -68,6 +99,7 @@ remaining operation passes 2–3 consecutive clean runs** and returns the expect
 data. Only then install/deliver the skill (Pillar 3).
 
 ## Definition of done
+- The profile's own session is HEALTHY (its activation sign-in is done).
 - No operation to a non-app / tracking / telemetry host remains.
 - Every remaining operation has been run against the live site and fetched the expected data, repeatably.
 - Tool and parameter names are natural-language; task inputs are parameters, not baked-in values.

--- a/skills/noui/scripts/activate_session.py
+++ b/skills/noui/scripts/activate_session.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Bring a profile's own Tabby session up; print the sign-in link if it needs one.
+
+    python scripts/activate_session.py <profile-slug>
+
+Run this after registering a login App Template (or any time a live call comes
+back `login_required`). The profile's session is a DIFFERENT browser from the
+recording sessions the human drove during capture — Tabby auto-provisions it per
+user, with nothing stored — so it needs one interactive sign-in before the first
+live call. `capture_import.py --activate-session` does this for you at import
+time; this script is for doing it later, or again.
+
+Exit codes: 0 = resolved (healthy, or a sign-in link is printed), 1 = the session
+is terminal or still provisioning.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import _bootstrap  # noqa: F401
+
+from noui_core.activate.session import ensure_session, format_activation_notice
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("profile_slug", help="Tabby profile slug (e.g. the slug capture_import printed)")
+    p.add_argument(
+        "--wait-seconds",
+        type=int,
+        default=45,
+        help="how long to wait for the session to leave STARTING (default 45)",
+    )
+    args = p.parse_args()
+
+    try:
+        result = ensure_session(args.profile_slug, wait_seconds=args.wait_seconds)
+    except RuntimeError as exc:
+        print(f"Could not check profile '{args.profile_slug}': {exc}", file=sys.stderr)
+        return 1
+
+    print(format_activation_notice(result))
+    return 0 if result["needs_login"] is not None else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/noui/scripts/bundle_inspect.py
+++ b/skills/noui/scripts/bundle_inspect.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Summarise a capture bundle — what it holds, and what compile would make of it.
+
+    python scripts/bundle_inspect.py workbench/bundles/<name>.json
+    python scripts/bundle_inspect.py --session <session_id>     # drain from Tabby first
+    python scripts/bundle_inspect.py <bundle.json> --json       # machine-readable
+
+Use it whenever a compile produced something unexpected. The mode block shows
+Tabby's stamp, NoUI's own classification and the mode the session was
+provisioned as, side by side — a mismatch there explains most "why did my
+workflow become an App Template?" surprises. The endpoint table is built with
+the compiler's own filter and naming, so it previews the operation set compile
+will emit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+
+from noui_core.capture import ledger, recording
+from noui_core.capture.bundle import save_bundle
+from noui_core.capture.inspect import summarize
+
+_MAX_URL = 78
+_MAX_PATH = 52
+
+
+def _short(value: str, limit: int) -> str:
+    return value if len(value) <= limit else value[: limit - 1] + "…"
+
+
+def _render_mode(summary: dict) -> list[str]:
+    mode = summary["mode"]
+    lines = [
+        "",
+        "MODE",
+        f"  recording_mode (Tabby, IGNORED) : {mode['tabby_reported'] or '—'}",
+        f"  NoUI classification            : {mode['noui_classification']}",
+        f"  ledger (declared at provision) : {mode['ledger_declared'] or '— (no ledger entry)'}",
+    ]
+    if mode["tabby_disagrees"]:
+        lines += [
+            f"  ⚠ Tabby reports '{mode['tabby_reported']}' but the content says "
+            f"'{mode['noui_classification']}'. That field is known-unreliable — warm-pool",
+            "    recording sessions always report 'login' — and NoUI does not route on it.",
+        ]
+    if mode["ledger_disagrees"]:
+        lines += [
+            f"  ⚠ This session was provisioned as '{mode['ledger_declared']}' but its content "
+            f"looks like '{mode['noui_classification']}'.",
+            f"    capture_import.py will honour the ledger ('{mode['ledger_declared']}'); pass "
+            f"--mode {mode['noui_classification']} to override.",
+        ]
+    return lines
+
+
+def _render_timeline(summary: dict) -> list[str]:
+    timeline = summary["url_timeline"]
+    if not timeline:
+        return ["", "URL TIMELINE", "  (no url_events recorded)"]
+    lines = ["", f"URL TIMELINE ({len(timeline)} navigation(s))"]
+    for ev in timeline:
+        marker = "  "
+        if ev["is_login_boundary"]:
+            marker = "→ "  # login completes here; everything after is workflow
+        elif ev["post_login"]:
+            marker = "· "
+        lines.append(f"{marker}{_short(ev['from_url'] or '(start)', _MAX_URL)}")
+        lines.append(f"    → {_short(ev['to_url'], _MAX_URL)}")
+        if ev["is_login_boundary"]:
+            lines.append("    ^^ login boundary (login slice ends here)")
+    return lines
+
+
+def _render_credentials(summary: dict) -> list[str]:
+    creds = summary["credential_events"]
+    if not creds:
+        return ["", "CREDENTIAL INTERACTIONS", "  none — no login segment in this capture"]
+    lines = ["", "CREDENTIAL INTERACTIONS (roles + redaction only, never values)"]
+    for c in creds:
+        lines.append(f"  {c['field_role']:<20} {c['count']} event(s), {c['redacted']} redacted")
+    return lines
+
+
+def _render_endpoints(summary: dict) -> list[str]:
+    endpoints = summary["endpoints"]
+    counts = summary["counts"]
+    lines = [
+        "",
+        f"API ENDPOINTS — {counts['operations']} operation(s) from {counts['api_calls']} API "
+        f"call(s) of {counts['har_entries']} HAR entries",
+        "  (compile's own filter, dedup and naming — this is the operation set it will emit)",
+        "",
+        f"  {'METHOD':<7} {'PATH':<{_MAX_PATH}} {'STATUS':>6} {'SIZE':>8}  {'×':>3}  TOOL",
+    ]
+    if not endpoints:
+        lines.append("  (none — nothing here looks like an API call)")
+        return lines
+    for e in endpoints:
+        body = "*" if e["has_request_body"] else " "
+        lines.append(
+            f"  {e['method']:<7}{body}{_short(e['path_template'], _MAX_PATH):<{_MAX_PATH}} "
+            f"{e['status']:>6} {e['size']:>8}  {e['occurrences']:>3}  {e['tool_name']}"
+        )
+    hosts = sorted({e["host"] for e in endpoints})
+    lines += ["", f"  hosts: {', '.join(hosts)}", "  (* = request carries a body)"]
+    return lines
+
+
+def render(summary: dict) -> str:
+    counts = summary["counts"]
+    lines = [
+        f"BUNDLE {summary['session_id'] or '(no session_id)'}",
+        f"  captured : {summary['started_at'] or '?'} → {summary['stopped_at'] or '?'}",
+        f"  contents : {counts['har_entries']} HAR entries, {counts['click_events']} clicks, "
+        f"{counts['url_events']} url events, {counts['cookies']} cookies",
+    ]
+    lines += _render_mode(summary)
+    lines += _render_timeline(summary)
+    lines += _render_credentials(summary)
+    lines += _render_endpoints(summary)
+    if summary["unredacted_secrets"]:
+        lines += [
+            "",
+            f"⚠ {summary['unredacted_secrets']} password/OTP value(s) are NOT redacted — "
+            "capture_import will refuse this bundle.",
+        ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("bundle", nargs="?", default="", help="path to a saved bundle JSON")
+    p.add_argument(
+        "--session",
+        default="",
+        help="drain this recording session from Tabby and inspect it (also saves the bundle)",
+    )
+    p.add_argument("--json", action="store_true", help="emit the summary as JSON")
+    args = p.parse_args()
+
+    if not args.bundle and not args.session:
+        p.error("give a bundle path or --session <session_id>")
+
+    session_id = args.session
+    if args.session:
+        print(f"Fetching recording bundle from Tabby ({args.session}) …", file=sys.stderr)
+        try:
+            _, bundle = recording.fetch_bundle(args.session)
+        except (RuntimeError, ValueError) as exc:
+            print(f"Fetch failed: {exc}", file=sys.stderr)
+            return 1
+        print(f"Saved capture bundle → {save_bundle(bundle, args.session)}", file=sys.stderr)
+    else:
+        path = Path(args.bundle)
+        try:
+            bundle = json.loads(path.read_text())
+        except (OSError, ValueError) as exc:
+            print(f"Could not read bundle {path}: {exc}", file=sys.stderr)
+            return 1
+        if not isinstance(bundle, dict):
+            print(f"{path} does not contain a bundle object", file=sys.stderr)
+            return 1
+        session_id = str(bundle.get("session_id") or "")
+
+    summary = summarize(bundle, ledger_entry=ledger.lookup(session_id))
+    print(json.dumps(summary, indent=2) if args.json else render(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -78,6 +78,30 @@ def _report_mode(mode: str, source: str, inferred: str, bundle: dict) -> None:
         )
 
 
+def _maybe_activate_session(args: argparse.Namespace, profile_slug: str) -> None:
+    """Surface the profile's activation sign-in now, not mid-test.
+
+    The registered template auto-provisions a per-user session on first use, and
+    that session — a different browser from the ones just recorded, with nothing
+    stored — starts LOGIN_NEEDED. Finding that out during the generalize test loop
+    reads as a bug ("I just signed in twice!"); finding out here is a step.
+    Never fatal: the import already succeeded.
+    """
+    if not args.activate_session or not profile_slug:
+        return
+    from noui_core.activate.session import ensure_session, format_activation_notice
+
+    print(f"Activating the session for profile '{profile_slug}' …", file=sys.stderr)
+    try:
+        print(format_activation_notice(ensure_session(profile_slug)), file=sys.stderr)
+    except RuntimeError as exc:
+        print(
+            f"(could not check the session for '{profile_slug}': {exc} — run "
+            f"`python scripts/activate_session.py {profile_slug}` before testing.)",
+            file=sys.stderr,
+        )
+
+
 def _credential_flags(credential_mode: str) -> tuple[bool, bool | None]:
     manual_takeover = credential_mode == "takeover"
     manual_credentials = {"takeover": True, "manual": True, "stored": False, "auto": None}[
@@ -175,6 +199,7 @@ def _run_combined(args: argparse.Namespace, bundle: dict) -> int:
 
     profile_slug = prov.get("profile_id", "")
     print(f"Registered login App Template → profile slug '{profile_slug}'.", file=sys.stderr)
+    _maybe_activate_session(args, profile_slug)
 
     # The login compile ran on the login SLICE (not the workflow hosts), so its
     # target_urls won't cover the workflow's hosts — passing its declared headers
@@ -257,6 +282,16 @@ def main() -> int:
         "at the login boundary, register the login App Template, then compile the "
         "workflow (--auth-type session) bound to that profile. Uses the login options "
         "below for the login half. If no login segment is found, compiles workflow-only.",
+    )
+    p.add_argument(
+        "--activate-session",
+        dest="activate_session",
+        action="store_true",
+        help="(login/combined) after registering, bring the profile's OWN per-user "
+        "Tabby session up and print its sign-in link if it needs one. That session is "
+        "a different browser from the ones just recorded (nothing is stored), so it "
+        "needs one interactive sign-in before the first live call — this surfaces it "
+        "now instead of during your first test.",
     )
     # login options
     p.add_argument(
@@ -369,6 +404,7 @@ def main() -> int:
         "first request — no promote needed.",
         file=sys.stderr,
     )
+    _maybe_activate_session(args, prov.get("profile_id", ""))
     return 0
 
 

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -7,6 +7,11 @@ Workflow recording → MCP and/or Skill:
 Login recording → Tabby App Template (per-user auto-provisioning blueprint):
     python scripts/capture_import.py <session_id> --name <app-name>
 
+How the login/workflow/combined decision is made: --mode wins, else the mode
+capture_record.py recorded when it provisioned the session, else the capture's
+content. Tabby's own ``recording_mode`` is never consulted — it is unreliable
+(warm-pool sessions always report 'login'). See noui_core.capture.classify.
+
 End to end, no NoUI backend round-trip: Tabby captured the bundle server-side.
 """
 
@@ -19,11 +24,58 @@ import sys
 import _bootstrap  # noqa: F401
 
 from noui_core.activate import register
-from noui_core.capture import recording
+from noui_core.capture import ledger, recording
 from noui_core.capture.bundle import save_bundle
+from noui_core.capture.classify import COMBINED, LOGIN, WORKFLOW
 from noui_core.capture.split import split_bundle
 from noui_core.compile.login import compile_login_bundle
 from noui_core.compile.workflow import compile_workflow_bundle
+
+
+def _resolve_mode(args: argparse.Namespace, inferred: str) -> tuple[str, str]:
+    """Decide how to treat this capture, and say where the decision came from.
+
+    Precedence — strongest declaration wins, and Tabby's ``recording_mode`` is
+    not in the list at all (it is unreliable: a warm-pool session always reports
+    ``login`` regardless of what was provisioned, which used to route workflow
+    recordings into the login/App-Template path):
+
+      1. ``--mode`` / ``--combined`` — the operator said so explicitly.
+      2. the provision ledger — what ``capture_record.py`` actually asked Tabby for.
+      3. content classification (``classify_bundle``) — the fallback for captures
+         with no ledger entry (older sessions, bundles from another machine).
+    """
+    if args.mode != "auto":
+        return args.mode, "--mode flag"
+    if args.combined:
+        return COMBINED, "--combined flag"
+    declared = ledger.declared_mode(args.session_id)
+    if declared:
+        return declared, "provision ledger"
+    return inferred, "bundle content"
+
+
+def _report_mode(mode: str, source: str, inferred: str, bundle: dict) -> None:
+    """Tell the operator what we decided, and flag any disagreement."""
+    print(f"Treating this capture as '{mode}' (source: {source}).", file=sys.stderr)
+    stamped = bundle.get("recording_mode")
+    if stamped and stamped != mode:
+        print(
+            f"(Tabby stamped recording_mode='{stamped}' — ignored. That field is "
+            "unreliable: warm-pool recording sessions always report 'login'.)",
+            file=sys.stderr,
+        )
+    if inferred != mode:
+        hint = {
+            COMBINED: "pass --mode combined to split it into a login + a workflow asset",
+            LOGIN: "pass --mode login to register it as an App Template",
+            WORKFLOW: "pass --mode workflow to compile it as a workflow asset",
+        }[inferred]
+        print(
+            f"(Content looks like '{inferred}' instead — honouring '{mode}'. "
+            f"If that's wrong, {hint}.)",
+            file=sys.stderr,
+        )
 
 
 def _credential_flags(credential_mode: str) -> tuple[bool, bool | None]:
@@ -188,9 +240,20 @@ def main() -> int:
         "(default: Authorization). Emitted as a ${SECRET:name} placeholder.",
     )
     p.add_argument(
+        "--mode",
+        choices=["auto", "login", "workflow", "combined"],
+        default="auto",
+        help="how to treat this capture. auto (default): use the mode "
+        "capture_record.py recorded at provision time, else infer it from the "
+        "capture's content. Tabby's own recording_mode is never used — it is "
+        "unreliable (warm-pool sessions always report 'login'). Pass an explicit "
+        "value to override both.",
+    )
+    p.add_argument(
         "--combined",
         action="store_true",
-        help="one recording that captured BOTH the login and the workflow: split it "
+        help="(alias for --mode combined) "
+        "one recording that captured BOTH the login and the workflow: split it "
         "at the login boundary, register the login App Template, then compile the "
         "workflow (--auth-type session) bound to that profile. Uses the login options "
         "below for the login half. If no login segment is found, compiles workflow-only.",
@@ -234,7 +297,7 @@ def main() -> int:
 
     print(f"Fetching recording bundle from Tabby ({args.session_id}) …", file=sys.stderr)
     try:
-        session_type, bundle = recording.fetch_bundle(args.session_id)
+        inferred, bundle = recording.fetch_bundle(args.session_id)
     except (RuntimeError, ValueError) as exc:
         print(f"Fetch failed: {exc}", file=sys.stderr)
         return 1
@@ -244,11 +307,14 @@ def main() -> int:
     bundle_path = save_bundle(bundle, args.name or args.session_id)
     print(f"Saved capture bundle → {bundle_path}", file=sys.stderr)
 
+    mode, source = _resolve_mode(args, inferred)
+    _report_mode(mode, source, inferred, bundle)
+
     # One capture holding both login and workflow → split and do both.
-    if args.combined:
+    if mode == COMBINED:
         return _run_combined(args, bundle)
 
-    if session_type == "workflow":
+    if mode == WORKFLOW:
         try:
             result = compile_workflow_bundle(
                 session_id=args.session_id,

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -21,7 +21,7 @@ import sys
 
 import _bootstrap  # noqa: F401  (sys.path side effect)
 
-from noui_core.capture import recording
+from noui_core.capture import ledger, recording
 from noui_core.capture.template_match import find_similar_templates
 
 
@@ -163,6 +163,28 @@ def main() -> int:
 
     session_id = result.get("session_id", "")
     login_url = result.get("login_url", "")
+
+    # Record what we ASKED for. Tabby's own recording_mode is unreliable at drain
+    # time (a warm-pool claim always reports 'login'), so capture_import reads this
+    # ledger instead of the bundle's stamp. Advisory: never fail a provision that
+    # already succeeded because a local file couldn't be written.
+    if session_id:
+        try:
+            ledger.record(
+                session_id,
+                declared_mode=args.mode,
+                url=args.url,
+                profile=args.profile,
+                from_session=args.from_session,
+                residential=args.residential_proxy,
+            )
+        except (OSError, ValueError) as exc:
+            print(
+                f"(warning: could not record the declared mode for {session_id}: {exc}. "
+                f"Pass --mode {args.mode} to capture_import.py to be explicit.)",
+                file=sys.stderr,
+            )
+
     if result.get("refreshed"):
         print(
             f"(note: initial session was stale; refreshed via {result['refreshed']})",

--- a/skills/noui/workbench/sessions/.gitignore
+++ b/skills/noui/workbench/sessions/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!.gitkeep

--- a/tests/test_activate_session.py
+++ b/tests/test_activate_session.py
@@ -1,0 +1,193 @@
+"""ensure_session: surface the profile's activation sign-in before anyone tests.
+
+A profile's own session (the one call_web_api resolves) is a different browser
+from the recording sessions the human drove, and starts LOGIN_NEEDED because
+nothing is stored. Finding that out mid-test reads as a bug; finding out at
+import time is a step.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from noui_core import tabby_client
+from noui_core.activate import session as act
+from noui_core.config import settings
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+for _p in (_NOUI_ROOT / "skills" / "noui", _NOUI_ROOT / "skills" / "noui" / "scripts"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import capture_import as ci  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def broker(monkeypatch):
+    """Broker mode so token resolution needs no Tabby client creds."""
+    monkeypatch.setattr(settings, "tabby_auth_mode", "broker")
+    monkeypatch.setattr(settings, "broker_token", "cap-tok")
+    monkeypatch.setattr(act.time, "sleep", lambda *_a: None)
+
+
+@pytest.fixture
+def creds_empty():
+    with patch.object(tabby_client, "request_credentials", return_value={}) as m:
+        yield m
+
+
+class TestNeedsLogin:
+    def test_login_needed_returns_a_short_link(self, creds_empty):
+        status = {"session_id": "s-1", "state": "LOGIN_NEEDED", "hitl_active": True}
+        with (
+            patch.object(tabby_client, "get_session_status", return_value=status),
+            patch.object(tabby_client, "create_short_link", return_value="https://t/s/abc123"),
+        ):
+            result = act.ensure_session("acme")
+        assert result["needs_login"] is True
+        assert result["login_url"] == "https://t/s/abc123"
+        assert result["state"] == "LOGIN_NEEDED"
+
+    def test_short_link_uses_the_resolve_panel_not_the_recording_viewer(self, creds_empty):
+        status = {"session_id": "s-1", "state": "LOGIN_NEEDED", "hitl_active": True}
+        with (
+            patch.object(tabby_client, "get_session_status", return_value=status),
+            patch.object(tabby_client, "create_short_link", return_value="https://t/s/x") as link,
+        ):
+            act.ensure_session("acme")
+        # mode="recording" would give the capture toolbar; this is a HITL login.
+        assert link.call_args.kwargs.get("mode", "") == ""
+
+    def test_falls_back_to_the_stream_url_when_short_link_fails(self, creds_empty):
+        status = {
+            "session_id": "s-1",
+            "state": "LOGIN_IN_PROGRESS",
+            "hitl_active": True,
+            "vnc_stream": {"url": "https://t/vnc/s-1#token=x"},
+        }
+        with (
+            patch.object(tabby_client, "get_session_status", return_value=status),
+            patch.object(tabby_client, "create_short_link", side_effect=RuntimeError("nope")),
+        ):
+            result = act.ensure_session("acme")
+        assert result["login_url"] == "https://t/vnc/s-1#token=x"
+
+    def test_notice_explains_why_a_third_sign_in_is_needed(self, creds_empty):
+        status = {"session_id": "s-1", "state": "LOGIN_NEEDED", "hitl_active": True}
+        with (
+            patch.object(tabby_client, "get_session_status", return_value=status),
+            patch.object(tabby_client, "create_short_link", return_value="https://t/s/abc"),
+        ):
+            notice = act.format_activation_notice(act.ensure_session("acme"))
+        assert "https://t/s/abc" in notice
+        assert "OWN Tabby session" in notice
+        assert "different browser" in notice
+        assert "Nothing is stored" in notice
+
+
+class TestHealthy:
+    def test_healthy_session_needs_no_sign_in(self):
+        with (
+            patch.object(tabby_client, "request_credentials", return_value={"headers": [{}]}),
+            patch.object(
+                tabby_client,
+                "get_session_status",
+                return_value={"session_id": "s-1", "state": "HEALTHY"},
+            ),
+        ):
+            result = act.ensure_session("acme")
+        assert result["needs_login"] is False
+        assert result["credentials_ready"] is True
+        assert "no activation sign-in needed" in act.format_activation_notice(result)
+
+    def test_provisioning_is_provoked_before_polling(self):
+        """POST /credentials/request is what makes Tabby clone the per-user profile."""
+        with (
+            patch.object(tabby_client, "request_credentials", return_value={}) as req,
+            patch.object(tabby_client, "get_session_status", return_value={"state": "HEALTHY"}),
+        ):
+            act.ensure_session("acme")
+        assert req.call_args.args[0] == "acme"
+
+
+class TestNoFalseGreen:
+    def test_starting_then_login_needed(self, creds_empty):
+        states = [
+            {"state": "STARTING"},
+            {"state": "STARTING"},
+            {"session_id": "s-1", "state": "LOGIN_NEEDED", "hitl_active": True},
+        ]
+        with (
+            patch.object(tabby_client, "get_session_status", side_effect=states),
+            patch.object(tabby_client, "create_short_link", return_value="https://t/s/z"),
+        ):
+            result = act.ensure_session("acme", wait_seconds=30, poll_interval=0)
+        assert result["needs_login"] is True
+
+    def test_timeout_is_unknown_not_healthy(self, creds_empty):
+        with patch.object(tabby_client, "get_session_status", return_value={"state": "STARTING"}):
+            result = act.ensure_session("acme", wait_seconds=0, poll_interval=0)
+        assert result["needs_login"] is None
+        assert result["timed_out"] is True
+        notice = act.format_activation_notice(result)
+        assert "still provisioning" in notice
+        assert "activate_session.py acme" in notice
+
+    def test_terminal_state_is_reported_as_unrecoverable(self, creds_empty):
+        with patch.object(tabby_client, "get_session_status", return_value={"state": "FAILED"}):
+            result = act.ensure_session("acme", wait_seconds=0, poll_interval=0)
+        assert result["needs_login"] is None
+        assert "will not recover" in act.format_activation_notice(result)
+
+    def test_missing_profile_keeps_polling_then_times_out(self, creds_empty):
+        """A 404 while the profile is being cloned must not look like a failure."""
+        with patch.object(
+            tabby_client, "get_session_status", side_effect=RuntimeError("HTTP 404 …")
+        ):
+            result = act.ensure_session("acme", wait_seconds=0, poll_interval=0)
+        assert result["needs_login"] is None
+        assert result["state"] == ""
+
+
+class TestCaptureImportIntegration:
+    def _args(self, activate: bool):
+        return SimpleNamespace(activate_session=activate)
+
+    def test_flag_off_does_nothing(self, capsys):
+        with patch.object(act, "ensure_session") as ensure:
+            ci._maybe_activate_session(self._args(False), "acme")
+        ensure.assert_not_called()
+        assert capsys.readouterr().err == ""
+
+    def test_flag_on_prints_the_notice(self, capsys):
+        result = {
+            "profile_slug": "acme",
+            "state": "LOGIN_NEEDED",
+            "session_id": "s-1",
+            "needs_login": True,
+            "login_url": "https://t/s/abc",
+            "credentials_ready": False,
+            "timed_out": False,
+        }
+        with patch.object(act, "ensure_session", return_value=result):
+            ci._maybe_activate_session(self._args(True), "acme")
+        err = capsys.readouterr().err
+        assert "Activating the session for profile 'acme'" in err
+        assert "https://t/s/abc" in err
+
+    def test_never_fails_the_import(self, capsys):
+        """The template is already registered — a session check must not undo that."""
+        with patch.object(act, "ensure_session", side_effect=RuntimeError("broker down")):
+            ci._maybe_activate_session(self._args(True), "acme")
+        err = capsys.readouterr().err
+        assert "could not check the session" in err
+        assert "activate_session.py acme" in err
+
+    def test_skipped_without_a_profile_slug(self, capsys):
+        with patch.object(act, "ensure_session") as ensure:
+            ci._maybe_activate_session(self._args(True), "")
+        ensure.assert_not_called()

--- a/tests/test_broker_mode.py
+++ b/tests/test_broker_mode.py
@@ -84,7 +84,7 @@ class TestControlPlaneRoutesCapabilityToBroker:
         monkeypatch.setattr(settings, "tabby_api_host", "http://broker.local")
         seen = {}
 
-        def fake_http(method, path, body=None, token=None, timeout=15):
+        def fake_http(method, path, body=None, token=None, timeout=15, retries=0):
             seen.update(method=method, path=path, token=token)
             return {"session_id": "s1", "vnc_url": "https://vnc"}
 
@@ -96,7 +96,7 @@ class TestControlPlaneRoutesCapabilityToBroker:
     def test_execute_browser_sends_capability_bearer(self, broker, monkeypatch):
         seen = {}
 
-        def fake_http(method, path, body=None, token=None, timeout=15):
+        def fake_http(method, path, body=None, token=None, timeout=15, retries=0):
             seen.update(path=path, token=token)
             return {"success": True, "data": {}}
 

--- a/tests/test_bundle_classification.py
+++ b/tests/test_bundle_classification.py
@@ -1,0 +1,270 @@
+"""NoUI classifies captures from content — Tabby's recording_mode is ignored.
+
+Regression cover for the harness failure where a workflow recording provisioned
+with ``--mode workflow`` came back stamped ``recording_mode: "login"`` (every
+warm-pool session does) and was therefore registered as a login App Template
+instead of compiled into a skill. The HAR was fine; only the label lied.
+"""
+
+from __future__ import annotations
+
+import pytest
+from noui_core.capture.bundle import validate_bundle
+from noui_core.capture.classify import bundle_signals, classify_bundle
+
+T = {k: f"2026-01-01T00:00:{k:02d}.000Z" for k in range(12)}
+
+
+def _entry(ts: str, url: str, mime: str = "application/json") -> dict:
+    return {
+        "startedDateTime": ts,
+        "request": {"method": "GET", "url": url},
+        "response": {"status": 200, "content": {"mimeType": mime, "size": 12}},
+    }
+
+
+def _bundle(*, stamped: str = "login", clicks=None, urls=None, entries=None) -> dict:
+    return {
+        "session_id": "sess-1",
+        "recording_mode": stamped,
+        "click_events": clicks or [],
+        "url_events": urls or [],
+        "har": {"log": {"entries": entries or []}},
+    }
+
+
+def _login_clicks() -> list[dict]:
+    return [
+        {"timestamp": T[1], "tag_name": "input", "field_role": "username"},
+        {"timestamp": T[2], "tag_name": "input", "field_role": "password", "is_redacted": True},
+    ]
+
+
+class TestWorkflowMisstampedAsLogin:
+    """The exact production case: a workflow capture Tabby labelled 'login'."""
+
+    def _workflow_capture(self) -> dict:
+        return _bundle(
+            stamped="login",  # warm-pool session: always reports 'login'
+            clicks=[{"timestamp": T[3], "tag_name": "button", "text_content": "Listings"}],
+            urls=[
+                {
+                    "timestamp": T[2],
+                    "from_url": "https://airbnb.test/",
+                    "to_url": "https://airbnb.test/hosting/listings",
+                }
+            ],
+            entries=[_entry(T[4], "https://airbnb.test/api/v3/UnifiedListOfListingsQuery")],
+        )
+
+    def test_classified_as_workflow_despite_the_stamp(self):
+        assert classify_bundle(self._workflow_capture()) == "workflow"
+
+    def test_stamp_value_never_changes_the_answer(self):
+        bundle = self._workflow_capture()
+        answers = set()
+        for stamped in ("login", "workflow", "combined", None, "nonsense"):
+            bundle["recording_mode"] = stamped
+            answers.add(classify_bundle(bundle))
+        assert answers == {"workflow"}
+
+    def test_stamp_may_be_absent_entirely(self):
+        bundle = self._workflow_capture()
+        del bundle["recording_mode"]
+        assert classify_bundle(bundle) == "workflow"
+
+
+class TestLogin:
+    def test_credential_entry_then_landing_is_login(self):
+        bundle = _bundle(
+            clicks=_login_clicks(),
+            urls=[
+                {
+                    "timestamp": T[3],
+                    "from_url": "https://app.test/login",
+                    "to_url": "https://app.test/home",
+                }
+            ],
+            entries=[_entry(T[4], "https://app.test/api/me")],
+        )
+        # Post-login dashboard XHRs alone must NOT make this look 'combined' —
+        # otherwise a plain login capture gets wrongly split at import.
+        assert classify_bundle(bundle) == "login"
+
+    def test_many_post_login_api_calls_still_login_without_driving(self):
+        bundle = _bundle(
+            clicks=_login_clicks(),
+            urls=[
+                {
+                    "timestamp": T[3],
+                    "from_url": "https://app.test/login",
+                    "to_url": "https://app.test/home",
+                }
+            ],
+            entries=[_entry(T[i], f"https://app.test/api/widget/{i}") for i in (4, 5, 6, 7)],
+        )
+        assert classify_bundle(bundle) == "login"
+
+
+class TestRealLoginCaptureShapes:
+    """Shapes taken from bundles NoUI actually captured — both must stay 'login'.
+
+    A false 'combined' is the expensive mistake: it splits a pure login capture
+    and registers a truncated App Template.
+    """
+
+    def test_login_that_settles_through_one_final_bounce(self):
+        """Expedia: /enterpassword → /onboarding (boundary) → / , 37 XHRs, no clicks."""
+        bundle = _bundle(
+            clicks=_login_clicks(),
+            urls=[
+                {
+                    "timestamp": T[3],
+                    "from_url": "https://www.expedia.test/enterpassword?redirectTo=%2F",
+                    "to_url": "https://www.expedia.test/onboarding?originUrl=%2F",
+                },
+                {
+                    "timestamp": T[4],
+                    "from_url": "https://www.expedia.test/onboarding?originUrl=%2F",
+                    "to_url": "https://www.expedia.test/?challengeReferer=noref",
+                },
+            ],
+            entries=[
+                _entry(T[i], f"https://www.expedia.test/api/bootstrap/{i}") for i in (5, 6, 7)
+            ],
+        )
+        assert classify_bundle(bundle) == "login"
+
+    def test_login_landing_on_a_busy_dashboard(self):
+        """Airbnb: lands on a search page that fires 21 XHRs, no post-login events."""
+        bundle = _bundle(
+            clicks=_login_clicks(),
+            urls=[
+                {
+                    "timestamp": T[3],
+                    "from_url": "https://www.airbnb.test/",
+                    "to_url": "https://www.airbnb.test/s/San-Francisco--CA/homes",
+                }
+            ],
+            entries=[
+                _entry(T[i], f"https://www.airbnb.test/api/v3/Query{i}") for i in (4, 5, 6, 7)
+            ],
+        )
+        assert classify_bundle(bundle) == "login"
+
+
+class TestCombined:
+    def test_login_then_driving_is_combined(self):
+        bundle = _bundle(
+            clicks=[
+                *_login_clicks(),
+                {"timestamp": T[6], "tag_name": "button", "text_content": "Search"},
+            ],
+            urls=[
+                {
+                    "timestamp": T[3],
+                    "from_url": "https://app.test/login",
+                    "to_url": "https://app.test/home",
+                },
+                {
+                    "timestamp": T[5],
+                    "from_url": "https://app.test/home",
+                    "to_url": "https://app.test/reports",
+                },
+            ],
+            entries=[_entry(T[7], "https://app.test/api/reports")],
+        )
+        assert classify_bundle(bundle) == "combined"
+
+
+class TestAutopilotBundles:
+    def test_synthesized_workflow_bundle(self):
+        """capture/autopilot builds bundles with no timestamps and no credentials."""
+        bundle = {
+            "recording_mode": "workflow",
+            "har": {"log": {"entries": [_entry(T[1], "https://app.test/api/search")]}},
+            "click_events": [{"event_type": "click", "selector": "#go"}],
+            "url_events": [{"from_url": "", "to_url": "https://app.test/search"}],
+        }
+        assert classify_bundle(bundle) == "workflow"
+
+
+class TestSignals:
+    def test_signals_expose_the_reasoning(self):
+        sig = bundle_signals(
+            _bundle(
+                clicks=[
+                    *_login_clicks(),
+                    {"timestamp": T[6], "tag_name": "a", "text_content": "Reports"},
+                ],
+                urls=[
+                    {
+                        "timestamp": T[3],
+                        "from_url": "https://app.test/login",
+                        "to_url": "https://app.test/home",
+                    },
+                    {
+                        "timestamp": T[5],
+                        "from_url": "https://app.test/home",
+                        "to_url": "https://app.test/reports",
+                    },
+                ],
+                entries=[_entry(T[7], "https://app.test/api/reports")],
+            )
+        )
+        assert sig["credential_events"] == 2
+        assert sig["login_boundary"] == T[3]
+        assert sig["post_login_clicks"] == 1
+        assert sig["post_login_url_events"] == 1
+        assert sig["post_login_stable_navs"] == 1
+        assert sig["post_login_api_calls"] == 1
+
+    def test_two_stable_navigations_count_as_driving(self):
+        """No clicks recorded (some sites swallow them) but the human moved twice."""
+        bundle = _bundle(
+            clicks=_login_clicks(),
+            urls=[
+                {
+                    "timestamp": T[3],
+                    "from_url": "https://app.test/login",
+                    "to_url": "https://app.test/home",
+                },
+                {
+                    "timestamp": T[5],
+                    "from_url": "https://app.test/home",
+                    "to_url": "https://app.test/reports",
+                },
+                {
+                    "timestamp": T[6],
+                    "from_url": "https://app.test/reports",
+                    "to_url": "https://app.test/reports/42",
+                },
+            ],
+            entries=[_entry(T[7], "https://app.test/api/reports/42")],
+        )
+        assert bundle_signals(bundle)["post_login_stable_navs"] == 2
+        assert classify_bundle(bundle) == "combined"
+
+    def test_analytics_calls_do_not_count_as_api_traffic(self):
+        """The count mirrors the compiler's own filter, so noise can't tip a verdict."""
+        sig = bundle_signals(
+            _bundle(entries=[_entry(T[1], "https://app.test/analytics/collect?x=1")])
+        )
+        assert sig["api_calls_total"] == 0
+
+
+class TestValidateBundleIsShapeOnly:
+    def test_no_longer_returns_a_mode(self):
+        assert validate_bundle(_bundle(entries=[_entry(T[1], "https://app.test/api/x")])) is None
+
+    @pytest.mark.parametrize("stamped", ["nonsense", None, "", "workflow"])
+    def test_any_stamp_passes_validation(self, stamped):
+        validate_bundle(_bundle(stamped=stamped))
+
+    def test_missing_har_still_rejected(self):
+        with pytest.raises(ValueError, match="bundle.har"):
+            validate_bundle({"recording_mode": "login", "har": {}})
+
+    def test_non_dict_rejected(self):
+        with pytest.raises(ValueError, match="JSON object"):
+            validate_bundle([])  # type: ignore[arg-type]

--- a/tests/test_bundle_inspect.py
+++ b/tests/test_bundle_inspect.py
@@ -1,0 +1,279 @@
+"""bundle_inspect: summarise a capture without writing an ad-hoc script.
+
+Two properties matter. The mode block must make a stamp/classification mismatch
+obvious (that is the whole reason this command exists), and the endpoint table
+must agree with what the compiler would actually emit — a preview, not a second
+opinion. Plus the obvious safety property: never print a recorded value.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from noui_core.capture.inspect import summarize
+from noui_core.compile.har_to_tools import har_to_tool_defs
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+for _p in (_NOUI_ROOT / "skills" / "noui", _NOUI_ROOT / "skills" / "noui" / "scripts"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import bundle_inspect as bi  # noqa: E402
+
+T = {k: f"2026-01-01T00:00:{k:02d}.000Z" for k in range(12)}
+
+
+def _entry(ts, url, method="GET", status=200, text="{}", mime="application/json", body=None):
+    entry = {
+        "startedDateTime": ts,
+        "request": {"method": method, "url": url},
+        "response": {"status": status, "content": {"mimeType": mime, "text": text}},
+    }
+    if body is not None:
+        entry["request"]["postData"] = {"mimeType": "application/json", "text": body}
+    return entry
+
+
+def _bundle(*, stamped="login", clicks=None, urls=None, entries=None) -> dict:
+    return {
+        "session_id": "sess-abc",
+        "recording_mode": stamped,
+        "started_at": T[0],
+        "stopped_at": T[9],
+        "click_events": clicks or [],
+        "url_events": urls or [],
+        "cookies": [{"name": "sid", "value": "secret-cookie-value"}],
+        "har": {"log": {"entries": entries or []}},
+    }
+
+
+def _workflow_bundle() -> dict:
+    """A workflow capture stamped 'login' — the production mismatch."""
+    return _bundle(
+        stamped="login",
+        clicks=[{"timestamp": T[3], "tag_name": "button", "text_content": "Listings"}],
+        urls=[
+            {
+                "timestamp": T[2],
+                "from_url": "https://airbnb.test/",
+                "to_url": "https://airbnb.test/hosting/listings",
+            }
+        ],
+        entries=[
+            _entry(T[4], "https://airbnb.test/api/v3/UnifiedListOfListingsQuery", text="x" * 500),
+            _entry(T[5], "https://airbnb.test/api/v3/IsHostQuery"),
+            _entry(T[6], "https://airbnb.test/analytics/collect?e=1"),  # noise
+            _entry(T[7], "https://airbnb.test/static/app.js", mime="application/javascript"),
+        ],
+    )
+
+
+class TestModeBlock:
+    def test_surfaces_the_stamp_mismatch(self):
+        summary = summarize(_workflow_bundle())
+        mode = summary["mode"]
+        assert mode["tabby_reported"] == "login"
+        assert mode["noui_classification"] == "workflow"
+        assert mode["tabby_disagrees"] is True
+
+    def test_rendered_output_warns_about_the_unreliable_field(self):
+        text = bi.render(summarize(_workflow_bundle()))
+        assert "recording_mode (Tabby, IGNORED) : login" in text
+        assert "NoUI classification            : workflow" in text
+        assert "warm-pool" in text
+
+    def test_ledger_mismatch_names_the_override_flag(self):
+        summary = summarize(_workflow_bundle(), ledger_entry={"declared_mode": "combined"})
+        assert summary["mode"]["ledger_disagrees"] is True
+        text = bi.render(summary)
+        assert "provisioned as 'combined'" in text
+        assert "--mode workflow" in text
+
+    def test_no_ledger_is_stated_not_hidden(self):
+        text = bi.render(summarize(_workflow_bundle()))
+        assert "no ledger entry" in text
+
+    def test_agreement_produces_no_warnings(self):
+        summary = summarize(
+            _workflow_bundle() | {"recording_mode": "workflow"},
+            ledger_entry={"declared_mode": "workflow"},
+        )
+        assert summary["mode"]["tabby_disagrees"] is False
+        assert "⚠" not in bi.render(summary)
+
+
+class TestEndpointTable:
+    def test_matches_what_the_compiler_would_emit(self):
+        bundle = _workflow_bundle()
+        summary = summarize(bundle)
+        compiled = har_to_tool_defs(
+            bundle["har"], workflow_name="listings", tabby_profile_id="airbnb"
+        )
+        assert [e["tool_name"] for e in summary["endpoints"]] == [t["name"] for t in compiled]
+
+    def test_noise_and_static_assets_are_excluded(self):
+        summary = summarize(_workflow_bundle())
+        paths = [e["path_template"] for e in summary["endpoints"]]
+        assert "/analytics/collect" not in paths
+        assert "/static/app.js" not in paths
+        assert summary["counts"]["har_entries"] == 4
+        assert summary["counts"]["api_calls"] == 2
+
+    def test_repeats_are_deduped_and_counted(self):
+        bundle = _bundle(
+            entries=[
+                _entry(T[1], "https://app.test/api/search?q=a"),
+                _entry(T[2], "https://app.test/api/search?q=b"),
+                _entry(T[3], "https://app.test/api/search?q=c"),
+            ]
+        )
+        endpoints = summarize(bundle)["endpoints"]
+        assert len(endpoints) == 1
+        assert endpoints[0]["occurrences"] == 3
+
+    def test_measures_the_captured_body_when_har_omits_size(self):
+        """Tabby's HAR has content.text but no content.size — 0 would read as empty."""
+        endpoints = summarize(_workflow_bundle())["endpoints"]
+        by_name = {e["path_template"]: e for e in endpoints}
+        assert by_name["/api/v3/UnifiedListOfListingsQuery"]["size"] == 500
+
+    def test_flags_operations_that_send_a_body(self):
+        bundle = _bundle(
+            entries=[_entry(T[1], "https://app.test/api/graphql", method="POST", body='{"q":1}')]
+        )
+        assert summarize(bundle)["endpoints"][0]["has_request_body"] is True
+
+    def test_empty_har_does_not_explode(self):
+        summary = summarize(_bundle(entries=[]))
+        assert summary["endpoints"] == []
+        assert "nothing here looks like an API call" in bi.render(summary)
+
+
+class TestTimeline:
+    def test_reads_from_url_and_to_url_not_url(self):
+        """url_events carry from_url/to_url; click_events carry a flat url."""
+        summary = summarize(_workflow_bundle())
+        assert summary["url_timeline"] == [
+            {
+                "timestamp": T[2],
+                "from_url": "https://airbnb.test/",
+                "to_url": "https://airbnb.test/hosting/listings",
+                "is_login_boundary": False,
+                "post_login": False,
+            }
+        ]
+
+    def test_marks_the_login_boundary(self):
+        bundle = _bundle(
+            clicks=[
+                {"timestamp": T[1], "tag_name": "input", "field_role": "username"},
+                {"timestamp": T[2], "tag_name": "input", "field_role": "password"},
+            ],
+            urls=[
+                {
+                    "timestamp": T[3],
+                    "from_url": "https://app.test/login",
+                    "to_url": "https://app.test/home",
+                },
+                {
+                    "timestamp": T[5],
+                    "from_url": "https://app.test/home",
+                    "to_url": "https://app.test/reports",
+                },
+            ],
+            entries=[_entry(T[6], "https://app.test/api/reports")],
+        )
+        timeline = summarize(bundle)["url_timeline"]
+        assert [(e["is_login_boundary"], e["post_login"]) for e in timeline] == [
+            (True, False),
+            (False, True),
+        ]
+        assert "login boundary" in bi.render(summarize(bundle))
+
+
+class TestSafety:
+    def test_never_emits_recorded_values(self):
+        bundle = _bundle(
+            clicks=[
+                {
+                    "timestamp": T[1],
+                    "tag_name": "input",
+                    "field_role": "password",
+                    "value": "hunter2-should-never-print",
+                    "is_redacted": False,
+                },
+            ],
+            entries=[_entry(T[2], "https://app.test/api/me", text='{"token":"leaky-token"}')],
+        )
+        text = bi.render(summarize(bundle))
+        assert "hunter2-should-never-print" not in text
+        assert "leaky-token" not in text
+        assert "secret-cookie-value" not in text
+
+    def test_credential_roles_are_counted_with_redaction_status(self):
+        bundle = _bundle(
+            clicks=[
+                {"timestamp": T[1], "tag_name": "input", "field_role": "username"},
+                {"timestamp": T[2], "tag_name": "input", "field_role": "otp", "is_redacted": True},
+                {"timestamp": T[3], "tag_name": "input", "field_role": "otp", "is_redacted": True},
+            ]
+        )
+        assert summarize(bundle)["credential_events"] == [
+            {"field_role": "otp", "count": 2, "redacted": 2},
+            {"field_role": "username", "count": 1, "redacted": 0},
+        ]
+
+    def test_unredacted_secrets_are_flagged_loudly(self):
+        bundle = _bundle(
+            clicks=[
+                {
+                    "timestamp": T[1],
+                    "tag_name": "input",
+                    "field_role": "password",
+                    "value": "plaintext",
+                    "is_redacted": False,
+                }
+            ]
+        )
+        summary = summarize(bundle)
+        assert summary["unredacted_secrets"] == 1
+        assert "capture_import will refuse this bundle" in bi.render(summary)
+
+
+class TestCli:
+    def test_reads_a_bundle_from_disk(self, tmp_path, capsys, monkeypatch):
+        import json
+
+        from noui_core.config import settings
+
+        monkeypatch.setattr(settings, "workbench_dir", str(tmp_path))
+        path = tmp_path / "b.json"
+        path.write_text(json.dumps(_workflow_bundle()))
+        monkeypatch.setattr(sys, "argv", ["bundle_inspect.py", str(path)])
+        assert bi.main() == 0
+        assert "NoUI classification            : workflow" in capsys.readouterr().out
+
+    def test_json_mode_is_machine_readable(self, tmp_path, capsys, monkeypatch):
+        import json
+
+        from noui_core.config import settings
+
+        monkeypatch.setattr(settings, "workbench_dir", str(tmp_path))
+        path = tmp_path / "b.json"
+        path.write_text(json.dumps(_workflow_bundle()))
+        monkeypatch.setattr(sys, "argv", ["bundle_inspect.py", str(path), "--json"])
+        assert bi.main() == 0
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["mode"]["noui_classification"] == "workflow"
+
+    def test_missing_file_is_an_error_not_a_traceback(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["bundle_inspect.py", str(tmp_path / "nope.json")])
+        assert bi.main() == 1
+        assert "Could not read bundle" in capsys.readouterr().err
+
+    def test_requires_an_argument(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["bundle_inspect.py"])
+        with pytest.raises(SystemExit):
+            bi.main()

--- a/tests/test_capture_import_mode_precedence.py
+++ b/tests/test_capture_import_mode_precedence.py
@@ -1,0 +1,120 @@
+"""capture_import decides the capture's mode by declaration, not by Tabby's stamp.
+
+Precedence: --mode flag > provision ledger > content inference. Tabby's
+``bundle.recording_mode`` is not a source at all.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from noui_core.capture import ledger
+from noui_core.config import settings
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+for _p in (_NOUI_ROOT / "skills" / "noui", _NOUI_ROOT / "skills" / "noui" / "scripts"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import capture_import as ci  # noqa: E402
+
+
+@pytest.fixture
+def workbench(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "workbench_dir", str(tmp_path))
+    return tmp_path
+
+
+def _args(session_id: str = "sess-1", *, mode: str = "auto", combined: bool = False):
+    return SimpleNamespace(session_id=session_id, mode=mode, combined=combined)
+
+
+class TestPrecedence:
+    def test_explicit_mode_wins_over_everything(self, workbench):
+        ledger.record("sess-1", declared_mode="login")
+        assert ci._resolve_mode(_args(mode="workflow"), "combined") == ("workflow", "--mode flag")
+
+    def test_combined_flag_is_an_alias(self, workbench):
+        ledger.record("sess-1", declared_mode="workflow")
+        assert ci._resolve_mode(_args(combined=True), "login") == ("combined", "--combined flag")
+
+    def test_ledger_beats_inference(self, workbench):
+        """The production case: content-ambiguous capture, ledger says workflow."""
+        ledger.record("sess-1", declared_mode="workflow", url="https://x.test/listings")
+        assert ci._resolve_mode(_args(), "login") == ("workflow", "provision ledger")
+
+    def test_inference_is_the_fallback(self, workbench):
+        assert ci._resolve_mode(_args("unknown-session"), "workflow") == (
+            "workflow",
+            "bundle content",
+        )
+
+    def test_corrupt_ledger_entry_falls_back_to_inference(self, workbench):
+        ledger.path_for("sess-1").parent.mkdir(parents=True, exist_ok=True)
+        ledger.path_for("sess-1").write_text("{not json")
+        assert ci._resolve_mode(_args(), "login") == ("login", "bundle content")
+
+    def test_unknown_declared_mode_falls_back_to_inference(self, workbench):
+        ledger.path_for("sess-1").parent.mkdir(parents=True, exist_ok=True)
+        ledger.path_for("sess-1").write_text('{"declared_mode": "sideways"}')
+        assert ci._resolve_mode(_args(), "workflow") == ("workflow", "bundle content")
+
+
+class TestTabbyStampIsNeverASource:
+    @pytest.mark.parametrize("stamped", ["login", "workflow", None])
+    def test_stamp_does_not_influence_resolution(self, workbench, stamped):
+        ledger.record("sess-1", declared_mode="workflow")
+        mode, source = ci._resolve_mode(_args(), "workflow")
+        assert (mode, source) == ("workflow", "provision ledger")
+
+
+class TestLedger:
+    def test_roundtrip(self, workbench):
+        path = ledger.record(
+            "sess-9",
+            declared_mode="combined",
+            url="https://x.test/login",
+            from_session="sess-8",
+            residential=True,
+        )
+        assert path.exists()
+        entry = ledger.lookup("sess-9")
+        assert entry["declared_mode"] == "combined"
+        assert entry["from_session"] == "sess-8"
+        assert entry["residential"] is True
+        assert entry["created_at"].startswith("20")
+        assert ledger.declared_mode("sess-9") == "combined"
+
+    def test_missing_entry_is_empty_not_an_error(self, workbench):
+        assert ledger.lookup("nope") is None
+        assert ledger.declared_mode("nope") == ""
+        assert ledger.declared_mode("") == ""
+
+    def test_rejects_a_mode_it_cannot_honour(self, workbench):
+        with pytest.raises(ValueError, match="declared_mode"):
+            ledger.record("sess-x", declared_mode="sideways")
+
+
+class TestReporting:
+    def test_disagreement_with_the_stamp_is_surfaced(self, workbench, capsys):
+        ci._report_mode("workflow", "provision ledger", "workflow", {"recording_mode": "login"})
+        err = capsys.readouterr().err
+        assert "Treating this capture as 'workflow' (source: provision ledger)" in err
+        assert "recording_mode='login' — ignored" in err
+        assert "warm-pool" in err
+
+    def test_disagreement_with_inference_is_surfaced_with_a_hint(self, workbench, capsys):
+        ci._report_mode("workflow", "provision ledger", "combined", {"recording_mode": "login"})
+        err = capsys.readouterr().err
+        assert "Content looks like 'combined'" in err
+        assert "--mode combined" in err
+
+    def test_quiet_when_everything_agrees(self, workbench, capsys):
+        ci._report_mode("workflow", "--mode flag", "workflow", {"recording_mode": "workflow"})
+        err = capsys.readouterr().err
+        assert "Treating this capture as 'workflow'" in err
+        assert "ignored" not in err
+        assert "Content looks like" not in err

--- a/tests/test_combined_import.py
+++ b/tests/test_combined_import.py
@@ -75,6 +75,7 @@ def _args(**over) -> SimpleNamespace:
         "tenant_id": "",
         "post_login_url_pattern": "",
         "profile_slug": "",
+        "activate_session": False,
     }
     base.update(over)
     return SimpleNamespace(**base)

--- a/tests/test_recording_bundle_adapter.py
+++ b/tests/test_recording_bundle_adapter.py
@@ -66,12 +66,13 @@ def _bundle(**overrides):
 
 
 class TestValidate:
-    def test_returns_mode(self):
-        assert validate_bundle(_bundle()) == "login"
+    def test_validates_shape_only(self):
+        """No longer a classifier — see noui_core.capture.classify for why."""
+        assert validate_bundle(_bundle()) is None
 
-    def test_rejects_bad_mode(self):
-        with pytest.raises(ValueError):
-            validate_bundle(_bundle(recording_mode="nope"))
+    def test_ignores_the_recording_mode_stamp(self):
+        """Tabby's stamp is unreliable, so it can't be a validation failure either."""
+        validate_bundle(_bundle(recording_mode="nope"))
 
     def test_rejects_missing_har(self):
         with pytest.raises(ValueError):

--- a/tests/test_tabby_sessions.py
+++ b/tests/test_tabby_sessions.py
@@ -8,7 +8,7 @@ from noui_core import tabby_client
 def test_scale_sessions(monkeypatch):
     captured = {}
 
-    def fake_http(method, path, body=None, token=None, timeout=15):
+    def fake_http(method, path, body=None, token=None, timeout=15, retries=0):
         captured.update(method=method, path=path, body=body, token=token)
         return {"desired_sessions": 1, "app_id": "app-1"}
 
@@ -21,7 +21,7 @@ def test_scale_sessions(monkeypatch):
 
 
 def test_get_session_status_login_needed(monkeypatch):
-    def fake_http(method, path, body=None, token=None, timeout=15):
+    def fake_http(method, path, body=None, token=None, timeout=15, retries=0):
         assert method == "GET"
         assert path == "/agent/session-status/expedia-e2e2"
         return {
@@ -57,7 +57,7 @@ def test_get_session_status_healthy(monkeypatch):
 def test_create_recording_session_residential_proxy(monkeypatch):
     captured = {}
 
-    def fake_http(method, path, body=None, token=None, timeout=15):
+    def fake_http(method, path, body=None, token=None, timeout=15, retries=0):
         captured.update(method=method, path=path, body=body)
         return {"session_id": "s1", "vnc_url": "https://t/vnc/s1#token=x"}
 
@@ -72,7 +72,7 @@ def test_create_recording_session_residential_proxy(monkeypatch):
 def test_create_recording_session_omits_residential_proxy_by_default(monkeypatch):
     captured = {}
 
-    def fake_http(method, path, body=None, token=None, timeout=15):
+    def fake_http(method, path, body=None, token=None, timeout=15, retries=0):
         captured.update(body=body)
         return {"session_id": "s1", "vnc_url": "https://t/vnc/s1#token=x"}
 

--- a/tests/test_tabby_transport_resilience.py
+++ b/tests/test_tabby_transport_resilience.py
@@ -135,6 +135,17 @@ class TestRetry:
             tabby_client.get_session_status("acme", "cap-tok")
         assert opened.call_count == 1
 
+    def test_token_minting_is_retried(self, broker, _no_sleep):
+        """In agent_token mode this is the FIRST call of every command.
+
+        Found by live-testing against dev Tabby: with the control plane down, the
+        failure surfaced as `POST /auth/agent-token` before the work even started.
+        """
+        outcomes = [OSError("refused"), _Resp({"access_token": "tok"})]
+        with patch.object(tabby_client.urllib.request, "urlopen", side_effect=outcomes) as opened:
+            assert tabby_client.get_agent_token("cid", "csec") == "tok"
+        assert opened.call_count == 2
+
     def test_recording_session_creation_is_not_retried(self, broker):
         """Retrying a provision would leak shell apps / warm-pool claims."""
         with (

--- a/tests/test_tabby_transport_resilience.py
+++ b/tests/test_tabby_transport_resilience.py
@@ -1,0 +1,166 @@
+"""Transport resilience + diagnosability at the NoUI→Tabby/broker seam.
+
+Regression cover for the harness failure where ``capture_import.py`` died with a
+raw ``ConnectionRefusedError`` traceback mid-flow (right after a human had driven
+a recording). Two defects: transport errors are ``OSError`` subclasses, so they
+escaped every ``except RuntimeError`` handler in the scripts, and the message
+named neither the URL nor the auth mode — which got it misdiagnosed as a bearer
+problem. Nothing retried, either, so a ~10s upstream blip was fatal.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+from noui_core import tabby_client
+from noui_core.config import settings
+
+
+class _Resp:
+    """Minimal urlopen context-manager stand-in."""
+
+    def __init__(self, payload: dict):
+        self._raw = json.dumps(payload).encode()
+
+    def read(self) -> bytes:
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        "http://tabby.test/x", code, "boom", {}, BytesIO(b'{"detail":"upstream"}')
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    """Collapse the backoff so tests don't actually wait 1-2-4-8-16s."""
+    with patch.object(tabby_client.time, "sleep") as slept:
+        yield slept
+
+
+@pytest.fixture
+def broker(monkeypatch):
+    monkeypatch.setattr(settings, "tabby_auth_mode", "broker")
+    monkeypatch.setattr(settings, "broker_token", "cap-tok")
+    monkeypatch.setattr(
+        settings, "tabby_api_host", "http://broker.internal:8000/internal/noui-broker"
+    )
+
+
+class TestTransportErrorsBecomeRuntimeError:
+    def test_connection_refused_is_runtime_error(self, broker):
+        """The exact harness failure: ECONNREFUSED must not escape as an OSError."""
+        err = urllib.error.URLError(ConnectionRefusedError(111, "Connection refused"))
+        with (
+            patch.object(tabby_client.urllib.request, "urlopen", side_effect=err),
+            pytest.raises(RuntimeError) as exc,
+        ):
+            tabby_client.get_recording_bundle("sess-1", "cap-tok")
+        msg = str(exc.value)
+        # Diagnosable: names the host, the path, the auth mode, and rules out auth.
+        assert "broker.internal:8000" in msg
+        assert "/recording/sessions/sess-1/bundle" in msg
+        assert "broker mode" in msg
+        assert "not an auth problem" in msg
+        assert "401/403" in msg
+
+    def test_runtime_error_is_catchable_by_the_scripts(self, broker):
+        """capture_import catches (RuntimeError, ValueError) — this must land there."""
+        with (
+            patch.object(
+                tabby_client.urllib.request, "urlopen", side_effect=ConnectionResetError("reset")
+            ),
+            pytest.raises((RuntimeError, ValueError)),
+        ):
+            tabby_client.get_recording_bundle("sess-1", "cap-tok")
+
+    def test_socket_timeout_is_runtime_error(self, broker):
+        with (
+            patch.object(tabby_client.urllib.request, "urlopen", side_effect=TimeoutError("slow")),
+            pytest.raises(RuntimeError, match="Cannot reach"),
+        ):
+            tabby_client.get_session_status("acme", "cap-tok")
+
+    def test_message_reports_the_retry_budget(self, broker, _no_sleep):
+        with (
+            patch.object(tabby_client.urllib.request, "urlopen", side_effect=OSError("nope")),
+            pytest.raises(RuntimeError, match=r"Retried 6 time\(s\)"),
+        ):
+            tabby_client.get_recording_bundle("sess-1", "cap-tok")
+
+
+class TestRetry:
+    def test_transport_error_then_success(self, broker, _no_sleep):
+        """A blip mid-flow must not throw away a drained bundle."""
+        outcomes = [OSError("refused"), OSError("refused"), _Resp({"har": {"log": {}}})]
+        with patch.object(tabby_client.urllib.request, "urlopen", side_effect=outcomes) as opened:
+            bundle = tabby_client.get_recording_bundle("sess-1", "cap-tok")
+        assert bundle == {"har": {"log": {}}}
+        assert opened.call_count == 3
+        assert _no_sleep.call_count == 2
+
+    def test_backoff_is_exponential(self, broker, _no_sleep):
+        outcomes = [OSError("x"), OSError("x"), OSError("x"), _Resp({"har": {}})]
+        with patch.object(tabby_client.urllib.request, "urlopen", side_effect=outcomes):
+            tabby_client.get_recording_bundle("sess-1", "cap-tok")
+        assert [c.args[0] for c in _no_sleep.call_args_list] == [1.0, 2.0, 4.0]
+
+    def test_502_from_broker_is_retried(self, broker, _no_sleep):
+        """The broker answers 502 for a transient bearer-resolution failure."""
+        outcomes = [_http_error(502), _Resp({"state": "HEALTHY"})]
+        with patch.object(tabby_client.urllib.request, "urlopen", side_effect=outcomes) as opened:
+            assert tabby_client.get_session_status("acme", "cap-tok")["state"] == "HEALTHY"
+        assert opened.call_count == 2
+
+    @pytest.mark.parametrize("code", [400, 401, 403, 404, 409])
+    def test_client_errors_are_not_retried(self, broker, code):
+        """401/403 are answers, not outages — retrying them just wastes time."""
+        with (
+            patch.object(
+                tabby_client.urllib.request, "urlopen", side_effect=_http_error(code)
+            ) as opened,
+            pytest.raises(RuntimeError, match=f"HTTP {code}"),
+        ):
+            tabby_client.get_session_status("acme", "cap-tok")
+        assert opened.call_count == 1
+
+    def test_recording_session_creation_is_not_retried(self, broker):
+        """Retrying a provision would leak shell apps / warm-pool claims."""
+        with (
+            patch.object(
+                tabby_client.urllib.request, "urlopen", side_effect=OSError("refused")
+            ) as opened,
+            pytest.raises(RuntimeError, match="Not retried"),
+        ):
+            tabby_client.create_recording_session("workflow", "https://x.test", "cap-tok")
+        assert opened.call_count == 1
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda: tabby_client.register_app_template({"name": "x"}, "tok"),
+            lambda: tabby_client.update_app_template("tid", {"name": "x"}, "tok"),
+            lambda: tabby_client.scale_sessions("app-1", 1, "tok"),
+            lambda: tabby_client.execute_browser("slug", "navigate", token="tok"),
+        ],
+    )
+    def test_writes_are_not_retried(self, broker, call):
+        with (
+            patch.object(
+                tabby_client.urllib.request, "urlopen", side_effect=OSError("refused")
+            ) as opened,
+            pytest.raises(RuntimeError),
+        ):
+            call()
+        assert opened.call_count == 1


### PR DESCRIPTION
Four defects surfaced by a live harness authoring session (building an Airbnb "list places" skill end to end). One commit each, all NoUI-side — no Tabby or `adoptai-workflows` change needed.

Investigation notes: `plans/noui/noui-harness-authoring-friction-fixes-plan.md`.

## 1. Workflow recordings mis-routed as logins — `65adc7d`

Two sessions provisioned with `--mode workflow` came back stamped `recording_mode: "login"` and were registered as login App Templates instead of compiled into a skill. The HAR was perfect; only the label lied.

**Root cause is the warm recording pool, not `--from` cookie seeding.** The pool's shared shell app hardcodes `browser_policy.recording_mode: 'login'` (`recording-pool.service.ts`), and the worker reads that policy once at pod boot (`worker/src/main.ts`). A warm claim rebinds the running pod to the request's own shell app but never re-reads it, so the declared mode is lost by drain time — while the HTTP provision response still reports it correctly, which is why the divergence only surfaces at import. **Every warm-claimed session is affected**, whatever it declared.

NoUI now decides for itself: `--mode {login,workflow,combined}` → the provision ledger (`capture_record.py` writes `<workbench>/sessions/<id>.json` recording what it actually asked for) → content classification. `bundle.recording_mode` is not a source at all, and `validate_bundle` no longer returns it. `capture_import` prints which source won and warns when the content disagrees, naming the flag to override.

The classifier is deliberately conservative about `combined` (a false positive splits a pure login capture and registers a truncated template): it needs post-login *driving* — a click, or a second stable navigation — **and** real post-login API traffic. Both halves earn their keep against real captures: Airbnb's login lands on a page firing 21 XHRs with zero interaction, Expedia's settles through one last `/onboarding` → `/` bounce. All three bundles in `workbench/bundles/` classify as `login`; a naive "any post-login traffic" rule called two of them `combined`.

## 2. `ConnectionRefusedError` traceback mid-flow — `91dcf98`

Not a bearer problem, despite how it read. The token is attached identically on every route, the route is broker-allowlisted, and the same call had succeeded minutes earlier — the broker host simply stopped accepting connections for ~10-30s and recovered unaided.

The NoUI defects: `_tabby_http` caught only `HTTPError`, so transport failures (`OSError` subclasses) escaped every `except RuntimeError` handler in the scripts and surfaced as a raw traceback naming neither URL nor auth mode — which is what produced the wrong diagnosis. And nothing retried, so a brief blip was fatal *after* a human had already driven the recording.

Now transport errors become a `RuntimeError` naming host, path, auth mode, who was unreachable, and the retry budget spent, stating plainly that a rejected bearer answers 401/403. Bounded 1-2-4-8-16s retry is opt-in per call site, on transport errors and 502/503/504 (the broker answers 502 for a transient bearer-resolution failure), applied to repeatable reads only. `POST /recording/sessions` and all writes stay unretried — retrying a provision would leak shell apps and warm-pool claims.

## 3. `bundle_inspect.py` — `f75d58a`

Diagnosing #1 meant hand-writing throwaway Python, which walked into a field-name trap (`click_events` carry a flat `url`; `url_events` carry `from_url`/`to_url`) and reported an empty timeline.

`python scripts/bundle_inspect.py <bundle.json>` (also `--session <id>`, `--json`) prints a MODE block putting Tabby's stamp, NoUI's classification and the provisioned mode side by side; the URL timeline with the login boundary marked; credential interactions by role (counts and redaction only, never values); and the API endpoint table built with the compiler's own filter, dedup, templating and naming — a test asserts the tool names match `har_to_tool_defs` for the same HAR, so it stays a preview rather than a second opinion.

Response size is measured from the captured body: Tabby's HAR carries `content.text` but no `content.size`, so reading `size` showed 0 for every row.

## 4. The third sign-in — `0237de2`

Three different sessions are involved — login recording, workflow recording, and the profile's **own** per-user session that `call_web_api` resolves. The third starts `LOGIN_NEEDED` because the template stores nothing.

**The sign-in stays.** Avoiding it would mean seeding recording cookies into a tenant-wide template — handing the recorder's live session to every member of the org. The fix is announcing it at the right moment: `ensure_session(slug)` provokes provisioning, polls session status, and mints a redaction-safe resolve-panel link when a sign-in is pending (`needs_login` is True/False/**None** — a still-provisioning session says so rather than reporting a false green). Wired to `capture_import --activate-session` (so the link can be surfaced in the same turn as the workflow recording link) and a standalone `activate_session.py`. Docs in `generalize.md` and the harness `SKILL.md` explain *why* the cookies aren't reused, so the next agent doesn't try to "fix" it.

All routes it uses were already broker-allowlisted.

## Validation

- **New tests: 82** across classification, mode precedence + ledger, transport resilience, bundle inspect, and activation. `ruff check` / `ruff format` clean.
- Suite: **556 passed, 7 failed** — the 7 are pre-existing on `dev` (verified via `git stash`): `test_auth_adapter` / `test_execute_adapter` pick up ambient `ADOPT_*` config and resolve `platform_jwt` where they assert `agent_token`. Untouched by this branch, worth a separate fix.
- Real-bundle checks: all three saved bundles classify correctly, and `bundle_inspect` renders each.
- CLI smoke: `--help` parses for all four scripts; `build_bundle.py` confirmed to include all six new modules.

## Follow-ups (not in this PR)

- **Tabby:** `recording-pool.service.ts` should stamp the claimed session's declared mode (or the worker should re-read `browser_policy` on `bindWorker`). NoUI no longer depends on it, but the field still lies to every other consumer.
- **Deploy:** these reach the sandbox only once `noui-bundle.zip` is rebuilt and the harness skill republished.
- **Open question:** make `--activate-session` the default for login/combined imports on the harness path? It would remove the surprise entirely; kept opt-in here so a local compile doesn't provision a session as a side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
