### PR TITLE
fix(noui): record login + workflow in ONE session by default; one link per turn

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,8 @@ All commands run from `skills/noui/`.
 ### Unauthenticated apps
 
 ```bash
-# 1. Record a workflow in a Tabby VNC session
+# 1. Record a workflow in a Tabby VNC session. --mode workflow is EXPLICIT here: with no
+#    login to capture, the combined default would ask you to sign in to nothing.
 python scripts/capture_record.py --mode workflow --url "https://example.com"
 #    open the printed VNC URL, perform the workflow, click "Finish & export"
 
@@ -262,31 +263,38 @@ python scripts/capture_record.py --mode workflow --url "https://example.com"
 python scripts/capture_import.py <session_id> --as mcp
 ```
 
-### Authenticated apps (with Tabby)
+### Authenticated apps (with Tabby) — the default flow
+
+One recording session captures the login **and** the workflow, so the human gets a
+single link and signs in once. NoUI splits the capture at the login boundary.
 
 ```bash
-# 1. Record a login and register it with Tabby (no stored credentials — VNC takeover)
-python scripts/capture_record.py --mode login --url "https://app.example.com/"
-python scripts/capture_import.py <session_id> --name example \
-  --credential-mode takeover \
+# 1. Record: sign in AND drive the workflow in ONE VNC session, one "Finish & export".
+#    No --mode needed (it defaults to combined); --name also skips the capture entirely
+#    if an App Template already covers this app.
+python scripts/capture_record.py --url "https://app.example.com/login" --name example
+
+# 2. Drain + compile: registers a tenant-wide login App Template (per-user profiles
+#    auto-provision → ACTIVE, no stored credentials) AND compiles the workflow bound
+#    to it. No --combined flag: the provision ledger already recorded the mode.
+python scripts/capture_import.py <session_id> --as skill --name example \
   --post-login-url-pattern "<glob the logged-in URL matches but login does not>"
-# → registers a tenant-wide App Template (per-user profiles auto-provision → ACTIVE)
 
-# 2. Record the workflow, authenticated — Autopilot (agent drives) …
-python scripts/capture_autopilot.py <profile_slug> --steps steps.json --as both
-#    … or VNC, seeded from the login: capture_record.py --mode workflow --from <login-session-id>
+# 3. Activate the profile's own runtime session (one sign-in, its own step)
+python scripts/activate_session.py <profile-slug>
 
-# 3. Install the generated Skill into your agent
+# 4. Install the generated Skill into your agent
 python scripts/activate_install.py workbench/skills/<app> claude-code
 ```
 
-### Combined capture — login + workflow in one session
+### Workflow only — the app already has a profile
 
 ```bash
-# Sign in AND drive the workflow in a single VNC session; NoUI splits the one
-# capture into a registered login App Template + a workflow asset.
-python scripts/capture_record.py --mode combined --url "https://app.example.com/login"
-python scripts/capture_import.py <session_id> --combined --as skill --name <app>
+# --profile/--from means the auth exists, so the mode defaults to workflow-only.
+python scripts/capture_record.py --url "https://app.example.com/app" --profile example
+python scripts/capture_import.py <session_id> --as both --profile-slug example
+# … or let the agent drive it headlessly instead of a human:
+python scripts/capture_autopilot.py <profile_slug> --steps steps.json --as both
 ```
 
 ### Static API-key apps (no login to record)
@@ -330,8 +338,12 @@ The bundle replaces the old CLI with thin, purpose-built scripts (run from
 `skills/noui/`):
 
 ```
-scripts/capture_record.py    --mode login|workflow|combined --url <url> [--from <login-session>]
+scripts/capture_record.py    --url <url> [--mode login|workflow|combined] [--from <login-session>]
                              [--profile <slug>] [--auth-type {session|api-key}] [--api-key-header <h>]
+                             # --mode defaults to `combined` (one link, one sign-in), or
+                             # `workflow` when --profile/--from supplies the auth
+scripts/bundle_inspect.py    <bundle.json> | --session <session_id> [--json]
+scripts/activate_session.py  <profile-slug> [--wait-seconds N]
 scripts/capture_autopilot.py <profile> --steps steps.json --as {mcp|skill|both}
 scripts/capture_import.py    <session_id> [--name <app>] [--as {mcp|skill|both}] [--execution-mode {tabby|http|harness}]
                              [--combined] [--auth-type {session|api-key|auto}] [--api-key-header <h>]

--- a/skills/noui-harness/SKILL.md
+++ b/skills/noui-harness/SKILL.md
@@ -95,10 +95,12 @@ Then **end your turn**. Do not poll. Do not mention any other link yet.
 > `--profile <profile_id>` and the mode defaults to workflow-only — the recorder starts
 > already authenticated, so there is no login to record.
 >
-> **Static API-key apps** have no session to record either: record only the workflow (no
-> `--profile`/`--from`) and compile with `--auth-type api-key --api-key-header <header>`
-> (default `Authorization`). The compile prints a `${SECRET:...}` name for an admin to
-> register. **Otherwise leave `--auth-type` at its default** (`session`).
+> **Apps with no login at all** — unauthenticated, or authenticated by a static API key —
+> need `--mode workflow` **explicitly**, because the default would tell the user to sign in
+> to nothing. For a static key, record only the workflow (no `--profile`/`--from`) and
+> compile with `--auth-type api-key --api-key-header <header>` (default `Authorization`);
+> the compile prints a `${SECRET:...}` name for an admin to register. **Otherwise leave
+> `--auth-type` at its default** (`session`).
 >
 > **Record the halves separately** (`--mode login`, then `--mode workflow --from
 > <login_session_id>`) only when you have a specific reason — e.g. you must confirm the
@@ -211,8 +213,9 @@ is an LLM-driven step you do — no script):
    each **2–3 times** and confirm it returns the expected data — not just a non-error.
    You can do this now: `call_web_api` is a catalog tool, not part of the skill.
 3. **Fix or drop.** `login_required` / empty creds / 401 → the profile's own session needs
-   its activation sign-in: run `python scripts/activate_session.py <profile-slug>` and
-   surface the link it prints; 429 → retry; wrong/empty body → recompile from the saved bundle
+   its activation sign-in: run `python scripts/activate_session.py <profile-slug>`, surface
+   the link it prints **on its own** and end your turn; 429 → retry; wrong/empty body →
+   recompile from the saved bundle
    (`compile_workflow.py <bundle.json> --as skill --execution-mode harness`). If an op
    can't be made to work and isn't essential, drop it.
 4. **Make it reusable.** Rename cryptic tool/param names to natural language and
@@ -270,9 +273,10 @@ ever picks wrong, pass `--mode {login,workflow,combined}` explicitly.
 ## Troubleshooting
 
 - **`login_required` on the first live `call_web_api`** — expected, not a failure: the
-  profile's own session needs its one activation sign-in (see *Three sessions* above). Run
-  `python scripts/activate_session.py <profile-slug>` and surface the link. Only if that
-  reports the session already HEALTHY is something actually wrong.
+  profile's own session needs its one activation sign-in (see *Two sessions, two sign-ins*
+  above). Run `python scripts/activate_session.py <profile-slug>` and surface the link — on
+  its own, not next to another link. Only if that reports the session already HEALTHY is
+  something actually wrong.
 - **`login_required` / session not healthy on import** — the login wasn't completed; have
   the user redo the VNC sign-in and click *Finish & export*.
 - **The compiled asset is the wrong kind** (a workflow recording registered as an App

--- a/skills/noui-harness/SKILL.md
+++ b/skills/noui-harness/SKILL.md
@@ -8,10 +8,10 @@ description: "Author a new Tabby App Template + Skill from a website by recordin
 You are inside the Agent Harness sandbox. This skill lets you onboard a website into
 Tabby and produce a runnable Skill, end to end, on the **signed-in user's** identity:
 
-1. **Record the LOGIN** → compile into a Tabby **App Template + ServiceProfile** (the
-   reusable, per-user login).
-2. **Record the WORKFLOW** (seeded with that login) → compile into a **harness Skill**
-   (`call_web_api` operation cards).
+1. **One recording** — the human signs in *and* drives the workflow in the same browser
+   session (a single VNC link).
+2. **One import** → NoUI splits that capture into a Tabby **App Template + ServiceProfile**
+   (the reusable, per-user login) *and* a **harness Skill** (`call_web_api` operation cards).
 
 You drive the scripts with `bash`; **the human drives the browser** through a VNC link
 you surface to them. Never ask the user for a Tabby token, never write a `.env`.
@@ -26,10 +26,11 @@ instructions.** In the harness:
 2. **No credentials.** Do not create a `.env` or set `TABBY_CLIENT_ID/SECRET/ADMIN_TOKEN`.
    The broker injects the user's federated bearer (`owner_user_id` = the real user) on
    every call. Profiles/templates you create are **owned by that user** automatically.
-3. **Recording is human-in-the-loop.** `capture_record.py` returns a **VNC URL**. You
-   cannot open it — you must **show it to the user as a markdown link, tell them what to
-   do, and STOP** (end your turn). When they reply that they've finished, continue with
-   `capture_import.py`. Recording spans multiple turns; that is expected.
+3. **Recording is human-in-the-loop, and ONE LINK AT A TIME.** `capture_record.py` returns
+   a **VNC URL**. You cannot open it — you must **show it to the user as a markdown link,
+   tell them what to do, and STOP** (end your turn). When they reply that they've finished,
+   continue with `capture_import.py`. Recording spans multiple turns; that is expected.
+   **Never surface two links in one message** — see the section below.
 4. **Harness execution mode for the skill.** Compile workflows with
    `--execution-mode harness` (never `tabby`/`http`).
 
@@ -55,129 +56,144 @@ instructions.** In the harness:
 Ask the user up front for: the **site** (login URL + the workflow to capture) and a short
 **skill/app name**.
 
-## Part A — create the App Template (record the LOGIN)
+## 🔗 ONE LINK AT A TIME — the rule that matters most
 
-> **Skip Part A entirely** if the site already has a Tabby profile / App Template
-> (the user will say so, e.g. *"the profile `adopt-bank` is ready"*). Go straight
-> to **Part B** and provision the workflow recording with `--profile <profile_id>`
-> — the recorder starts already authenticated via that profile, no login needed.
+Every link you surface is a task for a human. **Never put two links in one message.**
+A user shown a recording link and a sign-in link together cannot tell which to open
+first, and will do the wrong one. Surface a link, say what to do with it, **end your
+turn**, and wait. Only after they confirm do you move on — and only then may the next
+link appear.
 
-> **Static API-key apps also skip Part A** (there is no login session to record).
-> If the user says the app authenticates with a static API key, do **only** Part B
-> (record the workflow, no `--profile`/`--from`) and compile it with
-> `--auth-type api-key --api-key-header <header>` (default `Authorization`). The
-> compile prints a `${SECRET:...}` name; an admin registers the key value in the
-> harness secret store. **Otherwise leave `--auth-type` at its default** (`session`).
+This is why the default captures the login and the workflow in **one** recording
+session: one link, one sign-in, one confirmation.
 
-> **Combined capture collapses Part A + Part B into one session.** When the user
-> prefers to sign in and drive the workflow in a single sitting, provision with
-> `capture_record.py --mode combined --url "<LOGIN_URL>"`, have them sign in **and
-> then** drive the workflow before *Finish & export*, and import once with
-> `capture_import.py <session_id> --combined --as skill --execution-mode harness
-> --name "<app>"`. NoUI splits the one capture at the login boundary, registers the
-> login App Template, and compiles the workflow (session-auth) bound to it — no
-> separate `--from`/`--profile-slug` step. Prefer the split A/B flow when you want to
-> confirm the login registered before recording the workflow.
+## Part A — capture login + workflow in ONE session (the default)
 
-### A1. Provision the login recording, surface the VNC link, STOP
 ```bash
 cd /workspace/noui
-python scripts/capture_record.py --mode login --url "<LOGIN_URL>"
+python scripts/capture_record.py --url "<LOGIN_URL>" --name "<app-name>"
 ```
-This prints `session_id` and a short, redaction-safe **`login_url`** (`.../s/<id>`) that
-opens the **recording** viewer (with the **Finish & export** toolbar). **Show the user
-the `login_url` as a clickable markdown link.** Say: *"Open this, sign in to the site,
-then click **Finish & export** in the viewer, and tell me when you're done."* Record the
-`session_id`. **End your turn here** — do not poll, do not continue until the user
-confirms.
 
-### A2. Import the login → App Template (after the user confirms)
+No `--mode` needed — with no `--profile`/`--from` it defaults to **combined**: the human
+signs in *and* drives the workflow in the same browser, then clicks *Finish & export*
+once. NoUI splits the capture at the login boundary afterwards.
+
+It prints `session_id` and a short, redaction-safe **`login_url`** (`.../s/<id>`) that
+opens the recording viewer (with the *Finish & export* toolbar). **Show the user that one
+link as a clickable markdown link** and tell them, in this order:
+
+1. Sign in to the site.
+2. **Then keep going in the same window** and drive the exact workflow you want as a
+   tool (run the search, open the report, browse the listings).
+3. Click **Finish & export**.
+4. Come back and say "done".
+
+Then **end your turn**. Do not poll. Do not mention any other link yet.
+
+> **Skip the login half** when the site already has a Tabby profile / App Template (the
+> user will say so, e.g. *"the profile `adopt-bank` is ready"*): pass
+> `--profile <profile_id>` and the mode defaults to workflow-only — the recorder starts
+> already authenticated, so there is no login to record.
+>
+> **Static API-key apps** have no session to record either: record only the workflow (no
+> `--profile`/`--from`) and compile with `--auth-type api-key --api-key-header <header>`
+> (default `Authorization`). The compile prints a `${SECRET:...}` name for an admin to
+> register. **Otherwise leave `--auth-type` at its default** (`session`).
+>
+> **Record the halves separately** (`--mode login`, then `--mode workflow --from
+> <login_session_id>`) only when you have a specific reason — e.g. you must confirm the
+> App Template registered before spending the user's time on the workflow. It costs an
+> extra link and an extra sign-in, so it is not the default.
+
+## Part B — import: App Template + Skill from that one capture
+
 ```bash
 cd /workspace/noui
-python scripts/capture_import.py <login_session_id> --name "<app-name>" --activate-session
+python scripts/capture_import.py <session_id> --as skill --execution-mode harness \
+    --name "<app-name>"
 # same-origin apps: add --post-login-url-pattern '<glob the logged-in URL matches>'
 ```
 
-`--activate-session` brings the profile's **own** per-user session up and prints a sign-in
-link if it needs one. **Expect it to need one** — see *Three sessions, up to three sign-ins*
-below. Surface that link to the user in the same turn as the Part B recording link so they
-do both sign-ins in one sitting, instead of hitting `login_required` during B3 testing.
-Registration is **template-first**: this creates a tenant-wide **App Template**
-only — it does NOT create an App/ServiceProfile directly. Tabby auto-provisions a
-private, per-user App+Profile (straight to ACTIVE) on each member's first
-`call_web_api`, so there is no `--promote` step and the credential model defaults
-to `manual:` (the member logs in via VNC; nothing is stored). Note the **profile
-slug** it reports — you need it for Part B. The drained bundle is saved under
-`workbench/bundles/`.
+No `--combined` flag and no `--profile-slug`: `capture_record.py` recorded the mode in the
+provision ledger, so the import splits the capture, registers the login App Template, and
+compiles the workflow (session-auth) bound to that new profile in one step. It prints the
+**profile slug** — note it.
 
-## Part B — author the Skill (record the WORKFLOW)
+Registration is **template-first**: a tenant-wide **App Template** only, never a direct
+App/ServiceProfile. Tabby auto-provisions a private, per-user App+Profile (straight to
+ACTIVE) on each member's first `call_web_api`, so there is no `--promote` step and the
+credential model defaults to `manual:` (the member signs in via VNC; nothing is stored).
+The drained bundle is saved under `workbench/bundles/`.
 
-### B1. Provision the workflow recording, surface the link, STOP
-
-Pick the variant by how the profile got set up:
-
-```bash
-cd /workspace/noui
-# (a) Existing profile / App Template already set up (Part A skipped) — RECOMMENDED
-#     when the user says the profile is ready. Auth comes from the profile.
-python scripts/capture_record.py --mode workflow --profile <profile_id> --url "<START_URL>"
-
-# (b) You just recorded the login in this same flow (Part A above): seed from it.
-python scripts/capture_record.py --mode workflow --from <login_session_id> --url "<START_URL>"
-```
-`--profile <profile_id>` starts the recorder authenticated via that Tabby profile (skip
-login); `--from <login_session_id>` instead reuses cookies from a login you just captured.
-There is **no `--from-profile`** flag. Again surface the printed **`login_url`** (the short,
-recording-viewer link): *"Open this and drive the exact workflow you want as a tool (e.g.
-run the search / open the report), then click **Finish & export** and tell me when
-done."* **End your turn.**
-
-### B2. Import the workflow → harness Skill (after the user confirms)
-```bash
-cd /workspace/noui
-python scripts/capture_import.py <workflow_session_id> \
-    --as skill --execution-mode harness \
-    --profile-slug <profile-slug> --name "<skill-name>"
-```
-`<profile-slug>` is the slug from A2, or — if you skipped Part A — the existing profile
-id the user gave you (e.g. `adopt-bank`). The compiled skill lands under
-`workbench/skills/<app>/` as `call_web_api` cards + `operations.json` (no transport code).
-
-For a **static API-key app** (Part A skipped, no profile), drop `--profile-slug` and add
-`--auth-type api-key --api-key-header <header>` instead — the skill authenticates from a
-`${SECRET:...}` the admin registers, not a session. Leave `--auth-type` unset otherwise.
-
-> If the profile already has a HEALTHY session, you may instead drive the workflow
-> **agent-side** with `capture_autopilot.py <slug> --steps steps.json --as skill
-> --execution-mode harness` (no human VNC) — see the toolkit reference. For a brand-new
-> profile, the VNC workflow recording above is the reliable path.
-
-## Three sessions, up to three sign-ins (tell the user this up front)
-
-Authoring involves three **different** browser sessions, and only the first two are the
-ones the human drove:
-
-1. the **login recording** session (Part A),
-2. the **workflow recording** session (Part B — usually cookie-seeded from #1),
-3. the **profile's own session** — the one `call_web_api` resolves at runtime. Tabby
-   auto-provisions it per user from the App Template, on first use.
-
-Session #3 starts `LOGIN_NEEDED` because the template stores nothing
-(`credential_ref: manual:`). The recording's cookies are deliberately not reused for it:
-the template is tenant-wide, so seeding them would share the recorder's live session with
-every member of the org. That is why a user who *just signed in twice* still gets one more
-prompt — it is correct, not a bug.
-
-Handle it explicitly rather than letting it ambush the B3 test loop:
+### Then, as its own turn: the activation sign-in
 
 ```bash
 cd /workspace/noui
 python scripts/activate_session.py <profile-slug>
 ```
 
-It prints a sign-in link (show it to the user as a markdown link, same as a recording link)
-or confirms the session is already HEALTHY. Say plainly: *"this is your app's own session —
-sign in once here and every future call uses it; nothing is stored."*
+The profile's own runtime session is a **different** browser from the recording (see
+*Two sessions, two sign-ins* below), so it needs one sign-in before any live call. Run
+this, and **if it prints a link, that is the only link in this message** — surface it,
+explain it is the app's own session (*"sign in once here and every future call uses it;
+nothing is stored"*), and end your turn. If it reports the session already HEALTHY, say
+nothing about sign-ins and go straight to B3.
+
+Do **not** run this in the same message as the Part A recording link.
+
+## Workflow-only capture (existing profile, or the split flow)
+
+When the login half is already covered — the user has a profile, or you deliberately
+recorded the login separately — record just the workflow:
+
+```bash
+cd /workspace/noui
+# (a) Existing profile / App Template. Auth comes from the profile.
+python scripts/capture_record.py --url "<START_URL>" --profile <profile_id>
+
+# (b) You recorded the login separately in this same flow: seed cookies from it.
+python scripts/capture_record.py --mode workflow --url "<START_URL>" --from <login_session_id>
+```
+
+Either way the mode resolves to workflow-only. There is **no `--from-profile`** flag.
+Surface the printed `login_url` — *"open this and drive the exact workflow you want as a
+tool, then click Finish & export and tell me when done"* — and **end your turn**. Import
+with an explicit profile binding:
+
+```bash
+python scripts/capture_import.py <session_id> --as skill --execution-mode harness \
+    --profile-slug <profile-slug> --name "<skill-name>"
+```
+
+The compiled skill lands under `workbench/skills/<app>/` as `call_web_api` cards +
+`operations.json` (no transport code).
+
+For a **static API-key app** (no profile at all), drop `--profile-slug` and add
+`--auth-type api-key --api-key-header <header>` instead — the skill authenticates from a
+`${SECRET:...}` an admin registers, not a session.
+
+> If the profile already has a HEALTHY session, you may instead drive the workflow
+> **agent-side** with `capture_autopilot.py <slug> --steps steps.json --as skill
+> --execution-mode harness` (no human VNC) — see the toolkit reference. For a brand-new
+> profile, the VNC recording above is the reliable path.
+
+## Two sessions, two sign-ins (tell the user this up front)
+
+With the combined default there are exactly **two** browser sessions, so the user signs in
+twice — no more:
+
+1. the **recording** session (Part A) — login *and* workflow, one sitting, one link;
+2. the **profile's own session** — the one `call_web_api` resolves at runtime. Tabby
+   auto-provisions it per user from the App Template, on first use.
+
+Session #2 starts `LOGIN_NEEDED` because the template stores nothing
+(`credential_ref: manual:`). The recording's cookies are deliberately not reused for it:
+the template is tenant-wide, so seeding them would share the recorder's live session with
+every member of the org. So the second sign-in is correct, not a bug — and worth saying
+out loud when you hand over that link, because the user *just* signed in.
+
+Recording the halves separately adds a third session and a third sign-in. That is the
+reason it is not the default.
 
 ## Step B3 — generalize: prune the noise, then test until it works
 

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -201,10 +201,10 @@ Every capture (`capture_autopilot.py` and `capture_import.py`) **persists the ra
 
 ## Reference docs
 
-- `references/pillar-1-capture.md` — VNC vs Autopilot, bundle shape, session reuse (`--from`)
+- `references/pillar-1-capture.md` — VNC vs Autopilot, the combined default, how the login/workflow mode is decided, bundle shape, session reuse (`--from`)
 - `references/pillar-2-compile.md` — HAR→tools, execution modes (`tabby`/`http`/`harness`), login drafts
 - `references/generalize.md` — post-compile agent pass: prune noise ops + test until they work
-- `references/pillar-3-activate.md` — register (template-first), verify, install, `/execute` runtime
+- `references/pillar-3-activate.md` — register (template-first), the per-user activation sign-in, verify, install, `/execute` runtime
 - `references/tabby-setup.md` — pointing NoUI at a local or cloud Tabby
 - `references/auth-modes.md` — `agent_token` vs `platform_jwt`
 

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -109,7 +109,9 @@ python scripts/capture_import.py <session_id> --as both --profile-slug example
 
 ```bash
 # The app authenticates with a static key sent on every request — there is no
-# session to record. Record ONLY the workflow, then declare the auth model:
+# session to record. Record ONLY the workflow (--mode workflow must be explicit:
+# with no login to capture, the combined default would ask for a sign-in that
+# doesn't exist), then declare the auth model:
 python scripts/capture_record.py --mode workflow --url https://example.com
 python scripts/capture_import.py <session_id> --as skill --execution-mode harness \
     --auth-type api-key --api-key-header Authorization
@@ -155,7 +157,7 @@ Full playbook: `references/generalize.md`.
 
 | Script | Pillar | Purpose |
 |---|---|---|
-| `capture_record.py` | 1 | Provision a VNC recording session; prints the viewer URL |
+| `capture_record.py` | 1 | Provision a VNC recording session; prints one viewer URL (default: login + workflow in one session) |
 | `capture_autopilot.py` | 1→2 | Drive a profile's session via `/execute/browser` (scripted steps); synthesize a bundle + compile |
 | `capture_import.py` | 1→2→3 | Drain the bundle; compile (workflow) or compile+register (login) |
 | `bundle_inspect.py` | 1 | Summarise a saved bundle: mode block, URL timeline, endpoint/tool table |

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -70,37 +70,39 @@ Run scripts from this directory: `python scripts/<name>.py …`.
 > the recorded browser through a US residential IP). See
 > `references/pillar-1-capture.md` → *Residential proxy egress*.
 
-**Record a workflow → MCP + Skill (authenticated):**
+**The default — login + workflow in ONE session (one link, one sign-in):**
 
 ```bash
-python scripts/capture_record.py --mode workflow --url https://example.com --from <login-session-id>
-# open the printed VNC URL, drive the flow, click "Finish & export", then:
-python scripts/capture_import.py <session_id> --as both --profile-slug <login-profile>
+# No --mode: with no --profile/--from this defaults to `combined`.
+# --name also checks for an existing App Template first (same name + URL) and tells
+# you to reuse that profile instead of recording the login again (--force to bypass).
+python scripts/capture_record.py --url https://example.com/login --name example
+# Sign in AND then drive the workflow in the same session; one "Finish & export".
+# NoUI splits the capture at the login boundary → registers the login App Template
+# AND compiles the workflow (auth_type=session) bound to that new profile:
+python scripts/capture_import.py <session_id> --as skill --name example
 # GENERALIZE (agent step): prune noise ops, then test each 2-3x until it fetches
 # what's expected — see references/generalize.md. THEN:
-python scripts/activate_verify.py workbench/mcp_servers/<app>/<server_id>
 python scripts/activate_install.py workbench/skills/<app> claude-code
 ```
 
-**Record a login → registered Tabby profile:**
+**Workflow only — the app already has a profile / App Template:**
+
+```bash
+# --profile makes the recorder start authenticated, so the mode defaults to workflow.
+python scripts/capture_record.py --url https://example.com/app --profile example
+python scripts/capture_import.py <session_id> --as both --profile-slug example
+python scripts/activate_verify.py workbench/mcp_servers/<app>/<server_id>
+```
+
+**The halves, recorded separately** (costs an extra link and an extra sign-in — use only
+when you need the login registered before recording the workflow):
 
 ```bash
 python scripts/capture_record.py --mode login --url https://example.com/login --name example
-# ^ --name triggers a check for an existing App Template with a similar name + same URL;
-#   if one matches, the capture is skipped and a reuse command is printed instead (--force to bypass)
-# drive the login in VNC, finish, then:
-python scripts/capture_import.py <session_id> --name example      # registers a tenant-wide App Template
-```
-
-**Combined — login + workflow in ONE session:**
-
-```bash
-# Provisions a normal login session (Tabby records it as 'login'); sign in AND
-# then drive the workflow in the same session, one "Finish & export".
-python scripts/capture_record.py --mode combined --url https://example.com/login
-# NoUI splits the one capture at the login boundary → registers the login App
-# Template AND compiles the workflow (auth_type=session) bound to that profile:
-python scripts/capture_import.py <session_id> --combined --as skill --name example
+python scripts/capture_import.py <session_id> --name example    # registers the App Template
+python scripts/capture_record.py --mode workflow --url https://example.com/app --from <login-session-id>
+python scripts/capture_import.py <session_id> --as both --profile-slug example
 ```
 
 **Static API-key app (no login to record):**

--- a/skills/noui/noui_core/capture/split.py
+++ b/skills/noui/noui_core/capture/split.py
@@ -2,10 +2,15 @@
 
 A single Tabby recording session can capture BOTH the login and the subsequent
 authenticated workflow (see
-`plans/noui/noui-single-session-login-workflow-capture-investigation.md`). Tabby
-stamps such a session `recording_mode='login'` — the mode is behaviorally inert,
-so NoUI always provisions combined sessions as 'login' and does the login/workflow
-differentiation here, on the NoUI side, with zero Tabby changes.
+`plans/noui/noui-single-session-login-workflow-capture-investigation.md`), and
+that is now the default (`capture_record.py` with no `--mode`): one viewer link,
+one sign-in. Tabby stamps such a session `recording_mode='login'`, which is
+inert server-side, so NoUI provisions combined sessions as 'login' and does the
+login/workflow differentiation here, with zero Tabby changes.
+
+NoUI never *reads* that stamp to decide what a bundle is — it cannot be trusted
+at all (a warm-pool session reports 'login' whatever was provisioned). See
+`noui_core.capture.classify` for how the decision is actually made.
 
 The boundary is the moment the login completes: the first *stable* navigation
 after the last credential-field interaction. Everything up to and including that

--- a/skills/noui/references/generalize.md
+++ b/skills/noui/references/generalize.md
@@ -37,24 +37,24 @@ Delete pruned operations from the asset:
 When in doubt, keep it for now and let the test in step 3 decide — a call that
 returns nothing useful is noise.
 
-## Before you test: three sessions, up to three sign-ins
+## Before you test: the profile's session needs its own sign-in
 
-Testing hits a **different browser session** from the ones you just recorded. Three are
-involved:
+Testing hits a **different browser session** from the one you just recorded. With the
+default combined capture there are two:
 
-1. the **login recording** session (the human drove it),
-2. the **workflow recording** session (a second one, usually cookie-seeded from #1),
-3. the **profile's own session** — what `call_web_api` / `/execute/fetch` actually resolve.
+1. the **recording** session — login *and* workflow, driven by the human in one sitting;
+2. the **profile's own session** — what `call_web_api` / `/execute/fetch` actually resolve.
    Tabby auto-provisions it per user from the App Template, on first use.
 
-Session #3 starts `LOGIN_NEEDED`: the template registers `credential_ref: manual:`, so
+Session #2 starts `LOGIN_NEEDED`: the template registers `credential_ref: manual:`, so
 nothing is stored. Recording cookies are deliberately **not** reused for it — the template
 is tenant-wide, so seeding them would hand the recorder's live session to every member of
 the org. Per-user auth with nothing stored costs one sign-in.
 
 So expect **one activation sign-in** before the first live call, even though the human just
 signed in during capture. Get it out of the way before step 3 rather than discovering it as
-a `login_required` mid-test:
+a `login_required` mid-test — and surface that link on its own, never alongside a recording
+link:
 
 ```bash
 python scripts/activate_session.py <profile-slug>

--- a/skills/noui/references/pillar-1-capture.md
+++ b/skills/noui/references/pillar-1-capture.md
@@ -8,11 +8,19 @@ Record a login or workflow as a **bundle** = `{har, click_events, url_events}` (
 A human drives a real browser in a Tabby VNC session.
 
 ```bash
-python scripts/capture_record.py --mode workflow --url https://example.com
-# → prints session_id + vnc_url
-# open vnc_url, drive the flow, click "Finish & export"
-python scripts/capture_import.py <session_id> --as both --profile-slug <slug>
+# Default (no --mode): ONE session for the login AND the workflow — one link, one sign-in.
+python scripts/capture_record.py --url https://example.com/login --name example
+# → prints session_id + a short recording-viewer link
+# open it, SIGN IN, then drive the flow in the same window, click "Finish & export"
+python scripts/capture_import.py <session_id> --as skill --name example
+
+# Auth already exists (profile/App Template set up) → the mode defaults to workflow-only:
+python scripts/capture_record.py --url https://example.com/app --profile example
+python scripts/capture_import.py <session_id> --as both --profile-slug example
 ```
+
+**Give the human one link at a time.** Recording the halves separately means two links and
+two sign-ins; the combined default exists so there is only ever one recording link in play.
 
 `capture_record.py` → `noui_core.capture.recording.start()` → Tabby `POST /recording/sessions`.
 `capture_import.py` → `recording.fetch_bundle()` → Tabby `GET /recording/sessions/{id}/bundle`, then compile.
@@ -57,7 +65,8 @@ if st["hitl_active"]:
 Record a workflow already authenticated, with **no stored credentials**: seed the recording browser with cookies captured by a prior **login** recording.
 
 ```bash
-python scripts/capture_record.py --mode workflow --url https://example.com --from <login-session-id>
+python scripts/capture_record.py --url https://example.com --from <login-session-id>
+# --from implies the login already exists, so the mode defaults to workflow-only
 ```
 
 Tabby pulls the source recording's cookies server-side; they never pass through NoUI.
@@ -79,24 +88,36 @@ python scripts/capture_record.py --mode login --url https://www.pnc.com --reside
 
 Works with any mode (`login`/`workflow`/`combined`) and combines with `--from`/`--profile`. The flag flows to Tabby's `POST /recording/sessions` as `residential_proxy: true`; omitted by default so the recording-shell app default applies. Requires the residential proxy to be configured on Tabby (`EGRESS_UPSTREAM_PROXY_URL` on the egress-proxy) — otherwise egress stays datacenter.
 
-## Combined login + workflow in one session (`--mode combined`)
-Capture the login **and** the authenticated workflow in a **single** VNC session — no separate login recording, no `--from` seeding.
+## Combined login + workflow in one session — **the default**
+Capture the login **and** the authenticated workflow in a **single** VNC session: one viewer link, one sign-in, no separate login recording and no `--from` seeding.
 
 ```bash
-python scripts/capture_record.py --mode combined --url https://example.com/login
+# `--mode` omitted → combined (it becomes workflow-only if --profile/--from is given)
+python scripts/capture_record.py --url https://example.com/login --name example
 # sign in, THEN keep driving the workflow, one "Finish & export"
-python scripts/capture_import.py <session_id> --combined --as skill --name example
+python scripts/capture_import.py <session_id> --as skill --name example
 ```
 
-Tabby's `recording_mode` is behaviorally inert, so a combined session is provisioned as an ordinary **`login`** session (zero Tabby change). NoUI does the differentiation at import: `--combined` splits the one bundle at the login boundary (`noui_core.capture.split.split_bundle` — the first stable navigation after the last credential-field interaction), then **registers the login App Template** from the login slice and **compiles the workflow** (`--auth-type session`) bound to that new profile. Splitting *before* tool generation is what keeps the login form-submit request — and its credential body — out of the workflow's tool set. If no login segment is present (no credential fields), `--combined` falls back to compiling the bundle workflow-only.
+A combined session is provisioned as an ordinary **`login`** session server-side (zero Tabby change), and NoUI does the differentiation at import. **The import needs no flag:** `capture_record.py` writes the declared mode to the provision ledger (`<workbench>/sessions/<session_id>.json`), and `capture_import.py` reads it — see [the mode decision](#how-the-loginworkflow-mode-is-decided) below. `--mode combined` / the legacy `--combined` alias force it explicitly.
 
-Prefer the split flow (`--mode login` then `--mode workflow`) when you want to confirm the login registered before recording the workflow.
+The split itself happens at the login boundary (`noui_core.capture.split.split_bundle` — the first stable navigation after the last credential-field interaction): NoUI **registers the login App Template** from the login slice and **compiles the workflow** (`--auth-type session`) bound to that new profile. Splitting *before* tool generation is what keeps the login form-submit request — and its credential body — out of the workflow's tool set. If no login segment is present (no credential fields), it falls back to compiling the bundle workflow-only.
 
-## Duplicate-template pre-check (`--mode login`)
-Before provisioning a **login** recording session, pass `--name`:
+Record the halves separately (`--mode login`, then `--mode workflow --from <session>`) only when you need the login registered before spending the user's time on the workflow. It costs an extra link and an extra sign-in, which is why it is not the default.
+
+## How the login/workflow mode is decided
+Tabby's `recording_mode` on the drained bundle is **never** used — a warm-pool recording session always reports `login` regardless of what was provisioned (see `noui_core.capture.classify`). `capture_import.py` decides in this order:
+
+1. explicit `--mode {login,workflow,combined}` (or the legacy `--combined` alias);
+2. the **provision ledger** — what `capture_record.py` asked Tabby for;
+3. **content classification** — credential-field interactions, and whether the human kept driving afterwards.
+
+It prints which source won, and warns when the content suggests something else. `python scripts/bundle_inspect.py <bundle.json>` shows all three side by side.
+
+## Duplicate-template pre-check (`--name`)
+Before provisioning a session that would capture a **login** (the combined default, or `--mode login`), pass `--name`:
 
 ```bash
-python scripts/capture_record.py --mode login --url https://example.com/login --name example
+python scripts/capture_record.py --url https://example.com/login --name example
 ```
 
 This checks Tabby's existing App Templates (`GET /admin/app-templates`, via `tabby_client.list_app_templates`) for one with the **same origin** (from `login_config.login_url` or `export_policy.target_urls`) **and** a similar `name` (`noui_core.capture.template_match.find_similar_templates`, fuzzy match + substring check, threshold 0.6). Both signals are required — same host alone is common across unrelated logins, and name similarity alone proves nothing about the site.
@@ -104,7 +125,7 @@ This checks Tabby's existing App Templates (`GET /admin/app-templates`, via `tab
 If a match is found, the login capture is **skipped** (no session is provisioned): the matching template's name/slug/id are printed along with the command to go straight to workflow recording against that profile —
 
 ```bash
-python scripts/capture_record.py --mode workflow --url <workflow-url> --profile <slug>
+python scripts/capture_record.py --url <workflow-url> --profile <slug>
 ```
 
 — since the login is already covered. Pass `--force` to record the login anyway (e.g. deliberately re-capturing a login to widen or refresh it). Without `--name`, the pre-check is skipped entirely (nothing to compare against).
@@ -133,6 +154,8 @@ Both capture scripts persist the raw bundle to `workbench/bundles/<name>.json` v
 `--save-bundle <path>` overrides the location; otherwise it lands in `workbench/bundles/`.
 
 ## Bundle validation
-`noui_core.capture.bundle.validate_bundle` enforces shape (`recording_mode` ∈ {login, workflow}, HAR present); `count_sensitive_unredacted` blocks import if passwords/OTP weren't redacted. `validate.validate_har_dict` reports API-call count, domains, and credential-leak / no-mutation warnings.
+`noui_core.capture.bundle.validate_bundle` checks **shape only** — a HAR must be present. It deliberately does *not* validate or return `recording_mode`: that field is unreliable (see [the mode decision](#how-the-loginworkflow-mode-is-decided)), so it can neither classify a bundle nor fail one. `count_sensitive_unredacted` blocks import if passwords/OTP weren't redacted. `validate.validate_har_dict` reports API-call count, domains, and credential-leak / no-mutation warnings.
 
-See also: [pillar-2-compile](pillar-2-compile.md), [auth-modes](auth-modes.md).
+`python scripts/bundle_inspect.py <bundle.json>` renders all of this — plus the mode block, URL timeline, and the operation set compile would emit — for a saved bundle.
+
+See also: [pillar-2-compile](pillar-2-compile.md), [auth-modes](auth-modes.md), [generalize](generalize.md).

--- a/skills/noui/references/pillar-2-compile.md
+++ b/skills/noui/references/pillar-2-compile.md
@@ -28,8 +28,8 @@ How the app authenticates is **declared** at compile, not inferred from the HAR:
 
 `generate_auth_plan(declared_strategy=…)` implements the override; `auto`/`None` keeps the heuristic. (Distinct from `--auth-mode`/`NOUI_TABBY_AUTH_MODE`, which is the runtime **token** mode — see [auth-modes](auth-modes.md).)
 
-### Combined capture (`--combined`)
-`capture_import.py --combined` splits one login+workflow bundle (`noui_core.capture.split`) and runs both compilers: register the login App Template, then `compile_workflow_bundle(..., auth_type="session")` bound to the new profile — see [pillar-1-capture](pillar-1-capture.md).
+### Combined capture (the default)
+A capture holding both halves splits at the login boundary (`noui_core.capture.split`) and runs both compilers: register the login App Template, then `compile_workflow_bundle(..., auth_type="session")` bound to the new profile. `capture_import.py` routes there on its own — from the provision ledger, or from content classification (`noui_core.capture.classify`), never from Tabby's `recording_mode`; `--mode combined` (legacy alias `--combined`) forces it. See [pillar-1-capture](pillar-1-capture.md).
 
 ## Login → App Template + ServiceProfile drafts
 `noui_core.compile.login.compile_login_bundle` → `login_assets.generate`: builds `application_draft` (target URLs, login DSL from click/url events, egress allowlist, keepalive) and `service_profile_draft` (`profile_id`, `credential_types`, `target_domains`). `build_app_template_payload` emits a tenant-wide App Template for federated auto-provisioning.

--- a/skills/noui/references/pillar-3-activate.md
+++ b/skills/noui/references/pillar-3-activate.md
@@ -14,6 +14,17 @@ When a federated member (platform JWT, `owner_user_id` set) first requests that 
 
 CLI: `scripts/activate_register.py compiled-login.json` (or, for a login capture, `capture_import.py <id> --name <app>` registers the template in one step).
 
+## Activate the per-user session (one sign-in)
+The auto-provisioned App+Profile lands in ACTIVE, but its **session** starts `LOGIN_NEEDED`: the template's `credential_ref` is `manual:`, so nothing is stored. The recording's cookies are deliberately **not** seeded into it — the template is tenant-wide, so that would share the recorder's live session with every member of the org. Each member therefore signs in **once**, in their own session, before their first live call.
+
+```bash
+python scripts/activate_session.py <profile-slug>
+```
+
+`noui_core.activate.session.ensure_session` provokes the provisioning (`POST /credentials/request`), polls `GET /agent/session-status/{slug}`, and prints a redaction-safe short link when a sign-in is pending — or reports the session already HEALTHY. `capture_import.py --activate-session` does the same right after registering. **Surface that link on its own**, never alongside a recording link: two links in one message is the fastest way to confuse the person who has to open them.
+
+`needs_login` is `True` / `False` / `None` — `None` means still provisioning or terminal, never a false green.
+
 ## Verify auth before use
 `scripts/activate_verify.py <server_dir>` → `noui_core.activate.verify.verify_before_install`. Deterministic-first repairs; statuses: `PASS`, `REPAIR_APPLIED`, `NEEDS_SECRET`, `UNSUPPORTED`. No `auth_plan.json` ⇒ `PASS` (unauthenticated server).
 

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -46,7 +46,9 @@ def main() -> int:
         "already exists, so the default becomes workflow.) combined: sign in, then drive "
         "the workflow, and import with `capture_import.py` (NoUI splits it into a login "
         "App Template + a workflow asset). login: record a login only. workflow: record "
-        "a workflow only, seeding auth via --profile/--from.",
+        "a workflow only — pass this EXPLICITLY for an app with no login at all "
+        "(unauthenticated, or a static API key), since the default would otherwise ask "
+        "the human to sign in to nothing.",
     )
     p.add_argument("--url", default="", help="login/start URL to open")
     p.add_argument(
@@ -108,6 +110,12 @@ def main() -> int:
     # which is the confusing outcome this default exists to prevent. When
     # --profile/--from is given the auth already exists, so there is no login to
     # record and 'workflow' is the only sensible default.
+    #
+    # This assumes the app HAS a login. An app with none (unauthenticated, or a
+    # static API key) needs an explicit --mode workflow: the default would tell the
+    # human to sign in to nothing. Import still self-corrects — a bundle with no
+    # credential events compiles workflow-only — but the recording instructions
+    # would have been wrong, so say so rather than rely on that.
     if not args.mode:
         args.mode = "workflow" if (args.profile or args.from_session) else "combined"
         why = (
@@ -174,9 +182,9 @@ def main() -> int:
     # stale one (restart, else re-provision) before returning — so login_url is
     # always a live, redaction-safe short link (.../s/<id> → ?mode=recording, the
     # "Finish & export" viewer), never a dead raw vnc_url.
-    # A combined capture is provisioned as a normal 'login' session — Tabby's
-    # recording_mode is behaviorally inert, so one session records login + workflow
-    # in one HAR; NoUI does the login/workflow split at import (--combined).
+    # A combined capture is provisioned as a normal 'login' session — the server-side
+    # mode is behaviorally inert, so one session records login + workflow in one HAR.
+    # NoUI splits it at import, routed by the provision ledger written below.
     tabby_mode = "login" if args.mode == "combined" else args.mode
     try:
         result = recording.provision_live_link(

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -1,17 +1,27 @@
 #!/usr/bin/env python3
 """Provision a Tabby VNC recording session and print the viewer URL.
 
-    python scripts/capture_record.py --mode workflow --url https://example.com
+    # DEFAULT: one session for the login AND the workflow — ONE link, one sign-in
+    python scripts/capture_record.py --url https://example.com/login --name example
+
+    # Auth already exists (App Template / profile set up) → workflow only
+    python scripts/capture_record.py --url https://example.com/app --profile example
+
+    # Explicit halves, when you really want them separate (two links, two sign-ins)
     python scripts/capture_record.py --mode login --url https://example.com/login --name example
     python scripts/capture_record.py --mode workflow --from <login-session-id>
 
 Open the printed VNC URL, drive the browser, click "Finish & export", then:
     python scripts/capture_import.py <session_id>
 
---mode login with --name set checks Tabby for an existing App Template with a
-similar name and the same URL first; if one is found, the capture is skipped
-and a command to reuse it for the workflow is printed instead (--force to
-bypass).
+Give the human ONE link at a time. Recording the login and the workflow
+separately means two links and two sign-ins, and surfacing both at once is
+confusing — hence the combined default.
+
+With --name and --url set, the login-capturing modes check Tabby for an existing
+App Template with a similar name and the same URL first; if one is found, the
+capture is skipped and a command to reuse that profile is printed instead
+(--force to bypass).
 """
 
 from __future__ import annotations
@@ -30,11 +40,13 @@ def main() -> int:
     p.add_argument(
         "--mode",
         choices=["login", "workflow", "combined"],
-        default="workflow",
-        help="login: record a login only. workflow: record a workflow only (seed auth "
-        "via --profile/--from). combined: ONE session capturing both — sign in, then "
-        "drive the workflow, and import with `capture_import.py --combined` (NoUI splits "
-        "it into a login App Template + a workflow asset; Tabby records it as 'login').",
+        default="",
+        help="DEFAULT: combined — ONE session capturing the login AND the workflow, so "
+        "the human gets a single link and signs in once. (With --profile/--from the auth "
+        "already exists, so the default becomes workflow.) combined: sign in, then drive "
+        "the workflow, and import with `capture_import.py` (NoUI splits it into a login "
+        "App Template + a workflow asset). login: record a login only. workflow: record "
+        "a workflow only, seeding auth via --profile/--from.",
     )
     p.add_argument("--url", default="", help="login/start URL to open")
     p.add_argument(
@@ -90,6 +102,21 @@ def main() -> int:
     )
     args = p.parse_args()
 
+    # Default to ONE session for the login AND the workflow. Recording them
+    # separately means two viewer links and two sign-ins for the human, and an
+    # agent juggling two links in one conversation tends to surface both at once —
+    # which is the confusing outcome this default exists to prevent. When
+    # --profile/--from is given the auth already exists, so there is no login to
+    # record and 'workflow' is the only sensible default.
+    if not args.mode:
+        args.mode = "workflow" if (args.profile or args.from_session) else "combined"
+        why = (
+            "auth comes from --profile/--from"
+            if args.mode == "workflow"
+            else "one session, one link"
+        )
+        print(f"(--mode not given → '{args.mode}': {why})", file=sys.stderr)
+
     # Static API-key app: there is no session to record. Skip the login capture
     # entirely and tell the operator to record just the workflow, then declare
     # the auth model at compile time. The key value goes into the harness secret
@@ -112,7 +139,10 @@ def main() -> int:
         )
         return 0
 
-    if args.mode == "login" and args.name and args.url and not args.force:
+    # Both login-capturing modes benefit from this: if a template already covers
+    # this app, the login half is wasted work (and a duplicate template) — the
+    # workflow can be recorded against the existing profile instead.
+    if args.mode in ("login", "combined") and args.name and args.url and not args.force:
         try:
             token = recording.resolve_agent_token()
             matches = find_similar_templates(args.name, args.url, token)
@@ -134,8 +164,7 @@ def main() -> int:
                 file=sys.stderr,
             )
             print(
-                f"  python scripts/capture_record.py --mode workflow --url <workflow-url> "
-                f"--profile {slug}",
+                f"  python scripts/capture_record.py --url <workflow-url> --profile {slug}",
                 file=sys.stderr,
             )
             print("(pass --force to record the login anyway)", file=sys.stderr)
@@ -209,12 +238,17 @@ def main() -> int:
     print(f"  session_id : {session_id}")
     print(f"  login_url  : {login_url}    <-- open THIS (recording viewer, redaction-safe)")
     print()
+    print("This is the ONLY link to give the human right now. Do not surface another")
+    print("link until they confirm this recording is finished.")
+    print()
     if args.mode == "combined":
         print(
             "Open the login_url, SIGN IN, then keep going and DRIVE THE WORKFLOW you want "
             "as a tool (run the search / open the report), click 'Finish & export', then:"
         )
-        print(f"  python scripts/capture_import.py {session_id} --combined --as skill --name <app>")
+        # No --combined flag needed: the provision ledger already recorded this
+        # session as combined, so capture_import routes it without being told.
+        print(f"  python scripts/capture_import.py {session_id} --as skill --name <app>")
     else:
         print("Open the login_url, sign in, drive the flow, click 'Finish & export', then run:")
         print(f"  python scripts/capture_import.py {session_id}")

--- a/tests/test_capture_record_default_mode.py
+++ b/tests/test_capture_record_default_mode.py
@@ -1,0 +1,128 @@
+"""capture_record defaults to ONE session for the login and the workflow.
+
+Recording the halves separately means two viewer links and two sign-ins, and an
+agent holding two links in one conversation tends to surface both at once — which
+is what a live harness run did, and it read as more confusing than the problem it
+was meant to solve. So `combined` is the default, and `workflow` only when the
+auth already exists (--profile/--from).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from noui_core.capture import ledger
+from noui_core.config import settings
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+for _p in (_NOUI_ROOT / "skills" / "noui", _NOUI_ROOT / "skills" / "noui" / "scripts"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import capture_record as cr  # noqa: E402
+
+_PROVISIONED = {
+    "session_id": "sess-new",
+    "login_url": "https://tabby.test/s/abc123",
+    "warm": True,
+}
+
+
+@pytest.fixture
+def run(tmp_path, monkeypatch, capsys):
+    """Run capture_record.main() with argv, Tabby provisioning stubbed."""
+    monkeypatch.setattr(settings, "workbench_dir", str(tmp_path))
+
+    def _run(*argv: str):
+        monkeypatch.setattr(sys, "argv", ["capture_record.py", *argv])
+        with patch.object(
+            cr.recording, "provision_live_link", return_value=dict(_PROVISIONED)
+        ) as prov:
+            rc = cr.main()
+        out = capsys.readouterr()
+        return rc, out.out + out.err, prov
+
+    return _run
+
+
+class TestDefaultMode:
+    def test_no_flags_defaults_to_combined(self, run):
+        rc, text, prov = run("--url", "https://app.test/login")
+        assert rc == 0
+        assert prov.call_args.args[0] == "login"  # combined provisions as a login session
+        assert "→ 'combined': one session, one link" in text
+        assert ledger.declared_mode("sess-new") == "combined"
+
+    @pytest.mark.parametrize("auth_flag", [("--profile", "acme"), ("--from", "sess-old")])
+    def test_existing_auth_defaults_to_workflow(self, run, auth_flag):
+        rc, text, prov = run("--url", "https://app.test/app", *auth_flag)
+        assert rc == 0
+        assert prov.call_args.args[0] == "workflow"
+        assert "→ 'workflow': auth comes from --profile/--from" in text
+        assert ledger.declared_mode("sess-new") == "workflow"
+
+    @pytest.mark.parametrize("mode", ["login", "workflow", "combined"])
+    def test_explicit_mode_is_honoured_and_not_announced(self, run, mode):
+        rc, text, _prov = run("--mode", mode, "--url", "https://app.test/x", "--force")
+        assert rc == 0
+        assert "--mode not given" not in text
+        assert ledger.declared_mode("sess-new") == mode
+
+
+class TestOneLinkAtATime:
+    def test_combined_instructions_cover_sign_in_then_workflow(self, run):
+        _rc, text, _prov = run("--url", "https://app.test/login")
+        assert "SIGN IN" in text
+        assert "DRIVE THE WORKFLOW" in text
+        assert "ONLY link to give the human right now" in text
+        # The import command needs no --combined: the ledger already knows.
+        assert "capture_import.py sess-new --as skill" in text
+        assert "--combined" not in text
+
+    def test_workflow_run_also_warns_against_a_second_link(self, run):
+        _rc, text, _prov = run("--url", "https://app.test/app", "--profile", "acme")
+        assert "ONLY link to give the human right now" in text
+
+
+class TestTemplateReuseCheck:
+    """A template that already covers this app makes the login half wasted work."""
+
+    def _match(self):
+        return [{"name": "Acme", "profile_name_pattern": "acme", "id": "tpl-1"}]
+
+    @pytest.mark.parametrize("argv", [(), ("--mode", "combined")])
+    def test_combined_checks_for_an_existing_template(self, run, argv):
+        with patch.object(cr, "find_similar_templates", return_value=self._match()):
+            rc, text, prov = run("--url", "https://app.test/login", "--name", "acme", *argv)
+        assert rc == 0
+        prov.assert_not_called()  # nothing recorded
+        assert "Skipping the login capture" in text
+        assert "--profile acme" in text
+
+    def test_login_mode_still_checks(self, run):
+        with patch.object(cr, "find_similar_templates", return_value=self._match()):
+            rc, text, prov = run(
+                "--mode", "login", "--url", "https://app.test/login", "--name", "acme"
+            )
+        assert rc == 0
+        prov.assert_not_called()
+        assert "Skipping the login capture" in text
+
+    def test_force_records_anyway(self, run):
+        with patch.object(cr, "find_similar_templates", return_value=self._match()):
+            rc, _text, prov = run("--url", "https://app.test/login", "--name", "acme", "--force")
+        assert rc == 0
+        prov.assert_called_once()
+
+    def test_workflow_mode_does_not_check(self, run):
+        """There is no login to skip when auth comes from a profile."""
+        with patch.object(cr, "find_similar_templates") as find:
+            rc, _text, prov = run(
+                "--url", "https://app.test/app", "--profile", "acme", "--name", "acme"
+            )
+        assert rc == 0
+        find.assert_not_called()
+        prov.assert_called_once()

--- a/tests/test_capture_record_default_mode.py
+++ b/tests/test_capture_record_default_mode.py
@@ -33,8 +33,18 @@ _PROVISIONED = {
 
 @pytest.fixture
 def run(tmp_path, monkeypatch, capsys):
-    """Run capture_record.main() with argv, Tabby provisioning stubbed."""
+    """Run capture_record.main() with argv; every Tabby call stubbed.
+
+    ``resolve_agent_token`` is stubbed too, not just provisioning: the
+    duplicate-template pre-check resolves a bearer *before* calling
+    ``find_similar_templates``, and in agent_token mode that mints a real token
+    over the network. Left unstubbed, these tests would hit Tabby whenever the
+    developer happens to have credentials in their environment — and silently
+    take the "no match" branch (RuntimeError → ``matches = []``) wherever they
+    don't, e.g. CI.
+    """
     monkeypatch.setattr(settings, "workbench_dir", str(tmp_path))
+    monkeypatch.setattr(cr.recording, "resolve_agent_token", lambda: "test-token")
 
     def _run(*argv: str):
         monkeypatch.setattr(sys, "argv", ["capture_record.py", *argv])


### PR DESCRIPTION
A live harness run on dev surfaced **two links in the same message** — *"Activate your Airbnb Tabby session"* (2a) and *"Open Workflow Recording"* (2b). That is worse than the `login_required` surprise #123 set out to fix: the user cannot tell which to open first.

The cause was an instruction I added in #123 — the harness playbook told the agent to surface the activation link *"in the same turn as the Part B recording link so they do both sign-ins in one sitting"*. It did exactly that. Removed.

## Changes

**1. `capture_record.py` defaults to `combined`.** One recording session captures the login *and* the workflow, so the human gets **one link** and signs in **once** — there is no second recording link to juggle. With `--profile`/`--from` the auth already exists, so the default resolves to `workflow`. The chosen mode and the reason are printed; explicit `--mode` still wins.

```
$ python scripts/capture_record.py --url "https://example.org/x"
(--mode not given → 'combined': one session, one link)
Recording session ready (combined):
  session_id : e1153f49-…
  login_url  : https://tabby-api.adoptai.dev/s/1k6lmuk9

This is the ONLY link to give the human right now. Do not surface another
link until they confirm this recording is finished.
```

The import needs no `--combined` flag — the provision ledger from #123 already recorded the mode.

**2. ONE LINK AT A TIME is now the harness playbook's first rule**, and the flow is restructured around it:

| Turn | What happens | Links surfaced |
|---|---|---|
| 1 | Part A — one recording: sign in, then drive the workflow | **1** (recording) |
| 2 | Part B — one import → App Template + Skill; then `activate_session.py` | **1** (activation, only if needed) |
| 3 | B3 generalize + test, Step C install | 0 |

`capture_record.py` prints the same reminder next to every link it hands over, so the rule survives even if an agent skims the playbook. Split A/B recording is kept as a documented fallback for when you must confirm the template registered first — it costs an extra link and an extra sign-in, which is why it is no longer the default.

**3. The existing-App-Template check now runs for `combined`**, not just `--mode login`. Verified live: recording `airbnb` short-circuited to `--profile airbnb` instead of capturing a duplicate login.

Net effect: **two sign-ins instead of three, and never two links at once.**

## Validation

Live against dev Tabby (`tabby-api.adoptai.dev`):

- default (no `--mode`) → `combined`, warm claim, single link, one-link reminder printed;
- `--profile airbnb` → `workflow` with the reason printed;
- `--name airbnb` on the airbnb login URL → short-circuited to the existing template, nothing recorded;
- both test recording sessions torn down afterwards (`recording-stop`).

13 new tests (default resolution, ledger value, one-link messaging, template-reuse short-circuit for both login-capturing modes). Full local gate: `ruff check`, `ruff format --check`, **mypy** (84 files), pytest — all clean.

## Docs updated

- `skills/noui-harness/SKILL.md` — the one-link rule, restructured Parts A/B, activation as its own turn, "two sessions, two sign-ins" (was three).
- `skills/noui/SKILL.md` — quick flows lead with the combined default.
- `skills/noui/references/generalize.md` — sign-in count corrected; surface the activation link on its own.

Follows #123 / #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
