### PR TITLE
fix(noui): never compile a post-login wait_for_url that a login can't satisfy

### DIFF
--- a/skills/noui/noui_core/compile/login_assets.py
+++ b/skills/noui/noui_core/compile/login_assets.py
@@ -149,6 +149,111 @@ def _url_domain(url: str) -> str:
         return url
 
 
+# First path segments that belong to a login/auth flow rather than to the app
+# behind it. Used to reject a "post-login" pattern that is really another login
+# page. Over-rejecting is cheap (the human confirms with "Mark as Resolved");
+# under-rejecting hangs the session forever, so the list leans inclusive.
+# Deliberately absent: post-login landing routes that only *look* auth-adjacent,
+# e.g. Airbnb's `/` and Expedia's `/onboarding`.
+_LOGIN_FLOW_SEGMENTS = frozenset(
+    {
+        "login",
+        "log-in",
+        "log_in",
+        "logon",
+        "signin",
+        "sign-in",
+        "sign_in",
+        "signup",
+        "sign-up",
+        "register",
+        "auth",
+        "authn",
+        "authenticate",
+        "authentication",
+        "authorize",
+        "oauth",
+        "oauth2",
+        "openid",
+        "sso",
+        "saml",
+        "idp",
+        "password",
+        "enterpassword",
+        "resetpassword",
+        "forgot",
+        "verify",
+        "verifyotp",
+        "verification",
+        "otp",
+        "mfa",
+        "2fa",
+        "twofactor",
+        "two-factor",
+        "challenge",
+    }
+)
+
+
+def _first_path_segment(url: str) -> str:
+    raw = url if url.startswith(("http://", "https://")) else f"http://{url}"
+    path = urlparse(raw).path.strip("/")
+    return path.split("/")[0].lower() if path else ""
+
+
+def _derive_post_login_pattern(login_url: str, landing_url: str) -> str:
+    """A glob the LOGGED-IN url matches but the login page does not, or ``""``.
+
+    Returning ``""`` means "no trustworthy pattern": the caller then emits no
+    ``wait_for_url``, and login completes when the human clicks *Mark as
+    Resolved*. That degradation is cheap. A **wrong** pattern is not — a
+    ``wait_for_url`` that can never match leaves the session waiting until it
+    times out, and a session that never reports LOGIN_NEEDED never gets a
+    sign-in prompt either.
+
+    Seen live on dev: an Airbnb profile compiled
+    ``https://www.airbnb.com/login/**`` as its *logged-in* check. It matches
+    ``/login/otp`` but not ``/``, ``/hosting/listings`` or ``/s/homes``, so no
+    real sign-in could ever satisfy it. The cause is upstream — the capture's
+    login slice ended before the post-login navigation, so the "landing" URL was
+    still inside the login flow — but the compiler must not turn that into an
+    unsatisfiable step.
+
+    Three rejections, in order of how directly they'd break:
+      1. the candidate also matches the login page → it would auto-resolve
+         instantly, before the human has logged in;
+      2. the landing path is itself a login-flow route (see
+         ``_LOGIN_FLOW_SEGMENTS``) → it can never match once logged in;
+      3. the landing path shares its top-level route with the login page → not a
+         distinguishing signal, and covers custom auth routes the list misses.
+
+    Shape note: the glob is ``/<segment>**``, NOT ``/<segment>/**``. Both
+    matchers that consume it — Playwright's anchored ``page.waitForURL`` glob and
+    Tabby's own unanchored ``urlGlobToRegex`` (worker ``login-dsl-runner.ts``,
+    which turns ``**`` into ``.*``) — require the literal ``/`` when the pattern
+    carries one, so ``/dashboard/**`` matches ``/dashboard/x`` but NOT the bare
+    ``/dashboard`` or ``/dashboard?tab=1``. Landing exactly on the route is the
+    common case, so the slash-less form is the one that actually fires.
+    """
+    raw = (
+        landing_url if landing_url.startswith(("http://", "https://")) else f"http://{landing_url}"
+    )
+    parsed = urlparse(raw)
+    seg = _first_path_segment(landing_url)
+    candidate = (
+        f"{parsed.scheme}://{parsed.netloc}/{seg}**"
+        if seg
+        else f"{parsed.scheme}://{parsed.netloc}/**"
+    )
+    if fnmatch(login_url, candidate):
+        return ""
+    if seg and seg in _LOGIN_FLOW_SEGMENTS:
+        return ""
+    if seg and seg == _first_path_segment(login_url):
+        return ""
+    return candidate
+
+
 def _is_redirect_hop(prev_url: str, next_url: str) -> bool:
     """True if next_url looks like a transient redirect (same domain, /callback, /sso, /auth)."""
     try:
@@ -812,14 +917,7 @@ def generate(
         # falsely auto-resolve). Same-origin root-path apps need an explicit pattern.
         pattern = post_login_url_pattern
         if not pattern and stable_urls:
-            _raw = stable_urls[-1]
-            if not _raw.startswith(("http://", "https://")):
-                _raw = "http://" + _raw
-            p = urlparse(_raw)
-            seg = p.path.strip("/").split("/")[0] if p.path.strip("/") else ""
-            cand = f"{p.scheme}://{p.netloc}/{seg}/**" if seg else f"{p.scheme}://{p.netloc}/**"
-            if not fnmatch(first_url, cand):  # skip if it also matches the login page
-                pattern = cand
+            pattern = _derive_post_login_pattern(first_url, stable_urls[-1])
         if pattern:
             takeover_steps.append(
                 {
@@ -844,10 +942,12 @@ def generate(
                     "type": "no_autoresolve_pattern",
                     "severity": "info",
                     "message": (
-                        "Post-login URL shares the login origin/path, so no auto-resolve "
-                        "wait_for_url was added — the user clicks 'Mark as Resolved' to "
-                        "continue. Pass post_login_url_pattern (a glob the logged-in URL "
-                        "matches but the login page does not) to enable auto-resolve."
+                        "No trustworthy post-login URL pattern (the recorded landing URL "
+                        "is still a login-flow page, or shares the login page's route), so "
+                        "no auto-resolve wait_for_url was added — the user clicks 'Mark as "
+                        "Resolved' to continue, which always works. Pass "
+                        "post_login_url_pattern (a glob the logged-in URL matches but the "
+                        "login page does not) to enable auto-resolve."
                     ),
                 }
             )

--- a/tests/test_post_login_pattern.py
+++ b/tests/test_post_login_pattern.py
@@ -1,0 +1,138 @@
+"""The auto-resolve `wait_for_url` must never be a pattern a login can't satisfy.
+
+Live failure this pins: an `airbnb-best-places` profile on dev compiled
+`https://www.airbnb.com/login/**` as its *logged-in* check. That matches
+`/login/otp` but not `/`, `/hosting/listings` or `/s/homes`, so no real sign-in
+could ever satisfy it. (That profile's session was separately stuck in STARTING
+for other reasons; this pattern is what would have kept it from auto-resolving
+once it got going — every login would burn the 30s wait and fall through to
+"Mark as Resolved".)
+
+Emitting no `wait_for_url` is the safe outcome: login then completes on the
+human's click, which always works.
+
+The `_matches` helper below mirrors the two matchers that actually consume these
+globs, so a pattern shape that looks fine but can never fire cannot regress in.
+"""
+
+from __future__ import annotations
+
+import re
+from fnmatch import fnmatch
+
+import pytest
+from noui_core.compile.login_assets import _derive_post_login_pattern
+
+
+def _matches(url: str, pattern: str) -> bool:
+    """True only if BOTH consumers of the glob match `url`.
+
+    Mirrors Tabby's `urlGlobToRegex` (worker login-dsl-runner.ts: `**` → `.*`,
+    unanchored `new RegExp`) and Playwright's anchored `waitForURL` glob.
+    """
+    body = re.sub(r"[.+^${}()|\[\]\\]", lambda m: "\\" + m.group(0), pattern)
+    body = body.replace("**", "\0").replace("*", "[^/]*").replace("\0", ".*").replace("?", "[^/]")
+    return bool(re.search(body, url)) and bool(re.fullmatch(body, url))
+
+
+class TestTheLiveAirbnbFailure:
+    def test_login_flow_landing_yields_no_pattern(self):
+        assert (
+            _derive_post_login_pattern(
+                "https://www.airbnb.com/", "https://www.airbnb.com/login/otp"
+            )
+            == ""
+        )
+
+    def test_the_bad_pattern_could_not_have_matched_a_real_sign_in(self):
+        """Why it hung, asserted rather than asserted-about."""
+        bad = "https://www.airbnb.com/login/**"
+        for logged_in in (
+            "https://www.airbnb.com/",
+            "https://www.airbnb.com/hosting/listings",
+            "https://www.airbnb.com/s/homes",
+        ):
+            assert not fnmatch(logged_in, bad)
+
+
+class TestRejections:
+    @pytest.mark.parametrize(
+        "landing",
+        [
+            "https://app.test/login",
+            "https://app.test/signin/step2",
+            "https://app.test/sign-in",
+            "https://app.test/auth/callback",
+            "https://app.test/oauth2/authorize",
+            "https://app.test/sso/saml",
+            "https://app.test/verifyotp?x=1",
+            "https://app.test/mfa",
+            "https://app.test/challenge/abc",
+            "https://app.test/enterpassword?redirectTo=%2F",
+            "https://app.test/register",
+        ],
+    )
+    def test_login_flow_routes_are_rejected(self, landing):
+        assert _derive_post_login_pattern("https://app.test/", landing) == ""
+
+    def test_landing_sharing_the_login_route_is_rejected(self):
+        """Covers custom auth routes the keyword list doesn't know."""
+        assert (
+            _derive_post_login_pattern(
+                "https://app.test/gateway/entry", "https://app.test/gateway/landed"
+            )
+            == ""
+        )
+
+    def test_pattern_that_also_matches_the_login_page_is_rejected(self):
+        """It would auto-resolve instantly, before the human has logged in."""
+        assert (
+            _derive_post_login_pattern("https://app.test/app/login", "https://app.test/app/home")
+            == ""
+        )
+
+    def test_case_insensitive(self):
+        assert _derive_post_login_pattern("https://app.test/", "https://app.test/LogIn/OTP") == ""
+
+
+class TestAccepted:
+    @pytest.mark.parametrize(
+        ("login", "landing", "expected"),
+        [
+            (
+                "https://app.test/login",
+                "https://app.test/dashboard",
+                "https://app.test/dashboard**",
+            ),
+            (
+                "https://www.airbnb.com/login",
+                "https://www.airbnb.com/hosting/listings",
+                "https://www.airbnb.com/hosting**",
+            ),
+            # Expedia's real post-login landing — auth-adjacent looking, but genuine.
+            (
+                "https://www.expedia.com/login",
+                "https://www.expedia.com/onboarding?originUrl=%2F",
+                "https://www.expedia.com/onboarding**",
+            ),
+            # Salesforce Lightning: different host after login.
+            (
+                "https://login.salesforce.com/",
+                "https://acme.lightning.force.com/lightning/page/home",
+                "https://acme.lightning.force.com/lightning**",
+            ),
+        ],
+    )
+    def test_genuine_landings_produce_a_usable_pattern(self, login, landing, expected):
+        pattern = _derive_post_login_pattern(login, landing)
+        assert pattern == expected
+        # The pattern must actually fire on the URL the human lands on …
+        assert _matches(landing, pattern)
+        # … and must not fire on the login page (that would auto-resolve early).
+        assert not _matches(login, pattern)
+
+    def test_bare_host_landing_is_parsed_not_mangled(self):
+        """A scheme-less URL must not put the host in `scheme`."""
+        assert _derive_post_login_pattern("https://app.test/login", "app.test/home") == (
+            "http://app.test/home**"
+        )


### PR DESCRIPTION
Found while diagnosing a `airbnb-best-places` session stuck on dev.

## The bug

That profile's compiled login DSL ended with:

```json
{"action": "wait_for_url", "pattern": "https://www.airbnb.com/login/**"}
```

The **login** page glob, used as the **logged-in** check. Tested: it matches `/login/otp` but **not** `/`, `/hosting/listings`, or `/s/homes`. No real sign-in could ever satisfy it, so every login would burn the 30s wait and fall through to `on_failure` → "Mark as Resolved".

Upstream cause: the capture's login slice ended *before* the post-login navigation, so `stable_urls[-1]` was still inside the login flow. The existing guard only rejected a candidate that **also matched the login entry URL** — and `https://www.airbnb.com/login/**` doesn't match `https://www.airbnb.com/`, so it sailed through.

## Fix 1 — refuse to emit an unsatisfiable pattern

`_derive_post_login_pattern()` returns `""` (→ no `wait_for_url`; login completes on the human's click, which always works) unless the candidate is trustworthy. Three rejections:

1. the candidate also matches the login page → would auto-resolve *before* the human logs in;
2. the landing path is itself a login-flow route (`_LOGIN_FLOW_SEGMENTS`: `login`, `signin`, `auth`, `oauth2`, `sso`, `verifyotp`, `mfa`, `challenge`, …) → can never match once logged in;
3. the landing shares its top-level route with the login page → not a distinguishing signal, and catches custom auth routes the keyword list misses.

Over-rejecting costs one click. Under-rejecting wedges the session — so the list leans inclusive, and deliberately *excludes* auth-adjacent-looking routes that are genuinely post-login (Airbnb's `/`, Expedia's `/onboarding`).

## Fix 2 — the glob shape was also wrong (found by the test, not by reading)

The emitted pattern was `/<segment>/**`. I checked both consumers — Playwright's anchored `page.waitForURL` glob, and Tabby's own unanchored `urlGlobToRegex` in `apps/worker/src/login-dsl-runner.ts` (`**` → `.*`, `new RegExp` with no anchors) — by reimplementing them:

| candidate | `/dashboard` | `/dashboard?tab=1` | `/dashboard/x` | `/login` |
|---|---|---|---|---|
| `…/dashboard/**` | ❌ | ❌ | ✅ | ❌ |
| `…/dashboard**` | ✅ | ✅ | ✅ | ❌ |

Landing *exactly* on the route is the common case, so the old shape meant auto-resolve silently never fired for it — which is very likely why same-origin apps kept needing an explicit `--post-login-url-pattern`. Now `/<segment>**`.

## Tests

`tests/test_post_login_pattern.py` (21 cases). The helper mirrors **both** matchers instead of using `fnmatch` alone, so a pattern that looks plausible but can never fire cannot regress in. Real landings covered: Airbnb `/hosting/listings`, Expedia `/onboarding?originUrl=…`, Salesforce cross-host `/lightning/page/home`.

## Scope note — what this does *not* fix

This makes the compiler refuse to emit a broken step; it does not change *why* the landing URL was a login page. That is the splitter: `find_login_boundary` stops at the first stable navigation after the last credential entry, which for Airbnb is still inside `/login/...`. Teaching the boundary to skip login-flow navigations would fix the derivation at its source **and** clean up the workflow slice — but it moves the login/workflow split, which changes `classify_bundle`'s inputs, so it deserves its own PR with its own validation rather than riding along here.

Also from the same investigation, no code change needed: the stuck session (`ec293d6f`, STARTING for 41 min, zero interventions, no pending input) never reached the human-input step at all, so this pattern was not what wedged it. I deactivated that stale app on dev (`DELETE /apps/339213e9…` → desired 0, session now TERMINATED); the next `call_web_api` will auto-provision a fresh app from the newer template, whose DSL has no `wait_for_url` at all.

## Validation

`ruff check`, `ruff format --check`, **mypy** (82 files), pytest **577 passed** (7 known local-only failures from `~/.config/noui/.env`, green in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
