### PR TITLE
fix(noui): explain silenced captures, and actually capture the bearer

### DIFF
--- a/skills/noui/noui_core/capture/classify.py
+++ b/skills/noui/noui_core/capture/classify.py
@@ -97,6 +97,126 @@ def bundle_signals(bundle: dict[str, Any]) -> dict[str, Any]:
     return signals
 
 
+# URL fragments that mean "a sign-in flow ran here". Matched against the
+# capture's url_events, which come from CDP frame navigations and so survive
+# anything the page itself does.
+_LOGIN_URL_MARKERS = (
+    "/login",
+    "/signin",
+    "/sign-in",
+    "/sign_in",
+    "/prelogin",
+    "/oauth",
+    "/authorize",
+    "/sso",
+    "/session/new",
+    "/account/login",
+    "/auth/",
+)
+
+
+def diagnose_missing_login(bundle: dict[str, Any]) -> dict[str, Any] | None:
+    """Explain a capture that yielded no login boundary but looks like it should.
+
+    Returns None when the absence is unremarkable (a genuine workflow-only
+    capture). Otherwise returns ``{"reason", "detail", "recorder_silent",
+    "login_urls"}`` describing why the boundary is missing.
+
+    There are two very different failure shapes, and telling them apart is the
+    whole point — a silent fallback to workflow-only used to hide both:
+
+    * **The recorder was silenced.** Zero interaction events alongside real
+      network traffic does not mean the human sat still; it means nothing the
+      recorder emitted got through. The usual cause is the page's
+      Content-Security-Policy: the beacon the DOM recorder posts each event to
+      is refused before it becomes a request, so the whole capture arrives with
+      empty ``click_events`` (fixed in Tabby by posting the beacon same-origin —
+      older workers and older bundles still show this).
+    * **The login left no credential field.** Interaction events exist but none
+      is a credential field: SSO hand-off, a magic link clicked in another tab,
+      or a session already authenticated by a warm-pool browser.
+
+    Both are recoverable without re-recording (``--mode login``), which is why
+    the caller must say so instead of quietly compiling half the asset.
+    """
+    signals = bundle_signals(bundle)
+    if signals["login_boundary"] is not None:
+        return None
+
+    clicks = [c for c in (bundle.get("click_events") or []) if isinstance(c, dict)]
+    url_events = [u for u in (bundle.get("url_events") or []) if isinstance(u, dict)]
+    login_urls = [
+        u["to_url"]
+        for u in url_events
+        if u.get("to_url") and any(m in u["to_url"].lower() for m in _LOGIN_URL_MARKERS)
+    ]
+    recorder_silent = not clicks and (signals["api_calls_total"] > 0 or len(url_events) > 1)
+
+    if recorder_silent:
+        return {
+            "reason": "recorder_silent",
+            "recorder_silent": True,
+            "login_urls": login_urls,
+            "detail": (
+                f"the capture holds {signals['api_calls_total']} API call(s) and "
+                f"{len(url_events)} navigation(s) but NOT ONE interaction event. The human "
+                "drove this session, so the recorder was silenced rather than idle — most "
+                "often the page's Content-Security-Policy refusing the recorder's beacon. "
+                "No credential field can be detected in this capture, whatever was typed."
+            ),
+        }
+    if login_urls:
+        return {
+            "reason": "login_without_credential_field",
+            "recorder_silent": False,
+            "login_urls": login_urls,
+            "detail": (
+                f"{len(clicks)} interaction event(s) were captured but none is a credential "
+                f"field, even though the session passed through a sign-in URL "
+                f"({login_urls[0]}). Typical of SSO hand-off, magic-link/passwordless login, "
+                "or a warm-pool browser that was already signed in."
+            ),
+        }
+    return None
+
+
+def missing_login_advice(bundle: dict[str, Any], session_id: str, name: str = "") -> list[str]:
+    """Operator-facing lines for a capture whose login could not be detected.
+
+    Empty when nothing looks wrong. Otherwise: what happened, why, and the exact
+    commands that recover it — the recovery path (``--mode login``) is not
+    guessable from the failure alone and used to require reading NoUI's source.
+    """
+    diagnosis = diagnose_missing_login(bundle)
+    if diagnosis is None:
+        return []
+
+    name_flag = f" --name {name}" if name else ""
+    lines = [
+        "",
+        "  ⚠ No login segment detected, but this capture does not look login-free:",
+        f"    {diagnosis['detail']}",
+        "",
+        "    Compiling workflow-only means NO App Template is registered, so at runtime",
+        "    call_web_api will report that no Tabby profile exists for this app.",
+        "",
+        "    Recover WITHOUT re-recording — the bundle is already saved:",
+        f"      python scripts/capture_import.py {session_id} --mode login{name_flag}",
+        "        └ registers the App Template from this same capture, then",
+        f"      python scripts/capture_import.py {session_id} --mode workflow{name_flag} \\",
+        "          --profile-slug <slug-printed-above> --as skill",
+        "        └ compiles the workflow bound to it.",
+    ]
+    if diagnosis["reason"] == "recorder_silent":
+        lines += [
+            "",
+            "    If you do re-record, note that a silenced recorder will silence the next",
+            "    capture too: check the worker log for '[Recording] NO DOM interaction",
+            "    events captured' and make sure the worker carries the same-origin beacon fix.",
+        ]
+    return lines
+
+
 def classify_bundle(bundle: dict[str, Any]) -> str:
     """Return ``"login"``, ``"workflow"`` or ``"combined"`` from the capture's content."""
     signals = bundle_signals(bundle)

--- a/skills/noui/noui_core/capture/inspect.py
+++ b/skills/noui/noui_core/capture/inspect.py
@@ -21,7 +21,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from noui_core.capture.bundle import count_sensitive_unredacted
-from noui_core.capture.classify import bundle_signals, classify_bundle
+from noui_core.capture.classify import bundle_signals, classify_bundle, diagnose_missing_login
 from noui_core.capture.split import CREDENTIAL_FIELD_ROLES
 
 # Deliberately the compiler's own internals: the table must mirror compile, not
@@ -164,6 +164,9 @@ def summarize(
             "cookies": len(bundle.get("cookies") or []),
         },
         "signals": signals,
+        # Why no login boundary was found, when the capture suggests there should
+        # have been one (silenced recorder, SSO/passwordless, warm-pool session).
+        "missing_login": diagnose_missing_login(bundle),
         "url_timeline": _url_timeline(bundle, signals["login_boundary"]),
         "credential_events": _credential_events(bundle),
         "endpoints": endpoints,

--- a/skills/noui/noui_core/compile/login_assets.py
+++ b/skills/noui/noui_core/compile/login_assets.py
@@ -1061,6 +1061,23 @@ def generate(
         # for JWT-minting SPAs (tabby/CLAUDE.md gotcha #17) — the 3600s
         # worker-side default is far too slow for this class of header.
         export_policy["refresh_interval_seconds"] = 180
+        # THE allowlist that turns request-header capture on. Tabby's
+        # registerRequestHeaderCapture() opens with
+        #     if (allowlist.length === 0) return;
+        # so without this the listener is never even registered and the header
+        # is never captured — no matter how correct target_urls is, and even
+        # though credential_types.headers declares it. Those two are different
+        # halves of the same contract: credential_types is what
+        # /credentials/request SERVES, request_header_allowlist is what the
+        # worker CAPTURES. Declaring only the first yields a profile that looks
+        # correct, reports HEALTHY, and hands out an empty authorization value,
+        # so every compiled operation 401s.
+        #
+        # Cookie is excluded by Tabby's validator (cookies have their own
+        # extraction path); _analyze_har never collects it here anyway.
+        export_policy["request_header_allowlist"] = [
+            h for h in har_analysis["auth_header_names"] if h.lower() != "cookie"
+        ]
 
     # ---- Infer credential_types ----
     credential_types: dict[str, list] = {"cookies": [], "headers": []}

--- a/skills/noui/noui_core/compile/login_assets.py
+++ b/skills/noui/noui_core/compile/login_assets.py
@@ -283,6 +283,7 @@ def _analyze_har(har: dict | None) -> dict[str, Any]:
         "auth_domains": [],
         "set_cookie_headers": [],
         "auth_header_names": [],
+        "auth_header_origins": [],
     }
     if not har:
         return result
@@ -291,6 +292,10 @@ def _analyze_har(har: dict | None) -> dict[str, Any]:
     domains_seen: set[str] = set()
     cookie_names: list[str] = []
     auth_header_names: list[str] = []
+    # Origins that actually carry an auth header. These are what Tabby's
+    # request-header sniffer must be pointed at — see the target_urls note in
+    # generate(); they are frequently NOT the origin the human logged in on.
+    auth_header_origins: list[str] = []
 
     for entry in entries:
         response = entry.get("response", {})
@@ -317,6 +322,7 @@ def _analyze_har(har: dict | None) -> dict[str, Any]:
             if hname in ("authorization", "x-auth-token", "x-api-key"):
                 result["has_auth_headers"] = True
                 auth_header_names.append(header.get("name", ""))
+                auth_header_origins.append(_url_origin(url))
 
         # Check for CSRF tokens
         for header in req.get("headers", []):
@@ -324,10 +330,12 @@ def _analyze_har(har: dict | None) -> dict[str, Any]:
             if "csrf" in hname or "xsrf" in hname:
                 result["has_csrf"] = True
                 auth_header_names.append(header.get("name", ""))
+                auth_header_origins.append(_url_origin(url))
 
     result["auth_domains"] = list(domains_seen)
     result["set_cookie_headers"] = list(set(cookie_names))[:20]
     result["auth_header_names"] = list(set(auth_header_names))[:10]
+    result["auth_header_origins"] = [o for o in dict.fromkeys(auth_header_origins) if o][:10]
     return result
 
 
@@ -986,8 +994,24 @@ def generate(
     # string, never "https://x.com/api/...". A "/**" suffix is required for any
     # real request path to match. Verified live: capture stayed empty until
     # this suffix was added, even with a correct request_header_allowlist.
-    target_urls = [f"{u}/**" for u in dict.fromkeys([origin, post_login_origin]) if u]
-    target_domains_list = [d for d in dict.fromkeys([domain, post_login_domain]) if d]
+    #
+    # The post-login origin is still not enough on its own. A SPA typically
+    # serves its UI from one origin and its API from another (app.adopt.ai ->
+    # api.adopt.ai; the bearer only ever rides on the API calls), so scoping
+    # capture to the origins the human *navigated* misses the origins the token
+    # is actually sent to. Nothing then populates the declared header, Tabby's
+    # attach_captured_credentials falls back to caller headers only, and every
+    # compiled operation 401s while the session reports HEALTHY. So include
+    # every origin observed carrying an auth header.
+    auth_origins = list(har_analysis["auth_header_origins"])
+    target_urls = [
+        f"{u}/**" for u in dict.fromkeys([origin, post_login_origin, *auth_origins]) if u
+    ]
+    target_domains_list = [
+        d
+        for d in dict.fromkeys([domain, post_login_domain, *(_url_domain(o) for o in auth_origins)])
+        if d
+    ]
 
     # ---- Infer keepalive ----
     keepalive_actions: list[dict] = []

--- a/skills/noui/noui_core/compile/workflow.py
+++ b/skills/noui/noui_core/compile/workflow.py
@@ -155,7 +155,16 @@ def compile_workflow_bundle(
     # `activate/register.py::extend_login_scope_for_workflow` for why this is
     # necessary (target_urls otherwise never covers hosts only visited during
     # a LATER workflow capture, so the declared header never gets captured).
-    if login_credential_headers and profile_slug:
+    #
+    # Gated on the *workflow's own* auth headers, NOT on having successfully read
+    # the login profile's declared ones. `_fetch_login_credential_headers` needs
+    # an Editor+ token and returns None on any failure — inside the harness, or
+    # with only an agent token, it always does. Gating on its result meant the
+    # one step that widens capture scope silently never ran in exactly the
+    # environments that need it, and the skill 401'd at runtime with a HEALTHY
+    # session. When the login's declared headers are unknown, fall back to the
+    # headers this workflow was actually observed sending.
+    if profile_slug and declared_strategy != "static_secret_header":
         try:
             from noui_core.activate.register import extend_login_scope_for_workflow
             from noui_core.compile.auth_plan import (
@@ -163,14 +172,25 @@ def compile_workflow_bundle(
                 _extract_target_domains,
             )
 
-            observed_headers = [
-                h for h in login_credential_headers if h in _extract_observed_auth_headers(har)
-            ]
-            result["scope_extension"] = extend_login_scope_for_workflow(
-                profile_slug,
-                target_domains=_extract_target_domains(har),
-                required_headers=observed_headers,
+            observed = _extract_observed_auth_headers(har)
+            observed_headers = (
+                [h for h in login_credential_headers if h in observed]
+                if login_credential_headers
+                else list(observed)
             )
+            if not observed_headers:
+                # Cookie-only app: the browser session carries the auth itself,
+                # so there is no declared header whose capture scope to widen.
+                result["scope_extension"] = {
+                    "status": "skipped",
+                    "reason": "workflow sends no non-cookie auth header",
+                }
+            else:
+                result["scope_extension"] = extend_login_scope_for_workflow(
+                    profile_slug,
+                    target_domains=_extract_target_domains(har),
+                    required_headers=observed_headers,
+                )
         except Exception as exc:  # noqa: BLE001 — never break compilation over this
             result["scope_extension"] = {
                 "status": "skipped",

--- a/skills/noui/scripts/bundle_inspect.py
+++ b/skills/noui/scripts/bundle_inspect.py
@@ -80,7 +80,19 @@ def _render_timeline(summary: dict) -> list[str]:
 def _render_credentials(summary: dict) -> list[str]:
     creds = summary["credential_events"]
     if not creds:
-        return ["", "CREDENTIAL INTERACTIONS", "  none — no login segment in this capture"]
+        lines = ["", "CREDENTIAL INTERACTIONS", "  none — no login segment in this capture"]
+        # "none" is ambiguous on its own: it reads as "no login happened" when it
+        # can equally mean "the login happened and we could not see it".
+        diagnosis = summary.get("missing_login")
+        if diagnosis:
+            lines += [f"  ⚠ {diagnosis['detail']}"]
+            if diagnosis["login_urls"]:
+                lines += [f"    sign-in URL(s) in the timeline: {diagnosis['login_urls'][0]}"]
+            lines += [
+                "    → this capture can still register an App Template: re-import it with",
+                "      --mode login (no re-recording needed).",
+            ]
+        return lines
     lines = ["", "CREDENTIAL INTERACTIONS (roles + redaction only, never values)"]
     for c in creds:
         lines.append(f"  {c['field_role']:<20} {c['count']} event(s), {c['redacted']} redacted")

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -26,7 +26,7 @@ import _bootstrap  # noqa: F401
 from noui_core.activate import register
 from noui_core.capture import ledger, recording
 from noui_core.capture.bundle import save_bundle
-from noui_core.capture.classify import COMBINED, LOGIN, WORKFLOW
+from noui_core.capture.classify import COMBINED, LOGIN, WORKFLOW, missing_login_advice
 from noui_core.capture.split import split_bundle
 from noui_core.compile.login import compile_login_bundle
 from noui_core.compile.workflow import compile_workflow_bundle
@@ -134,6 +134,12 @@ def _run_combined(args: argparse.Namespace, bundle: dict) -> int:
             "if the capture used an existing profile's auth.",
             file=sys.stderr,
         )
+        # Never let this fall back quietly when the capture shows a login DID
+        # happen (or the recorder was silenced): workflow-only skips App Template
+        # registration, and the failure only surfaces much later as an opaque
+        # "no Tabby profile exists" at runtime.
+        for line in missing_login_advice(bundle, args.session_id, args.name):
+            print(line, file=sys.stderr)
         try:
             result = compile_workflow_bundle(
                 session_id=args.session_id,
@@ -332,6 +338,10 @@ def main() -> int:
             return 1
         if args.auth_type != "api-key" and not args.profile_slug:
             print("No --profile-slug: tools run unauthenticated.", file=sys.stderr)
+            # Same trap as the combined path: an undetected login compiles to an
+            # unauthenticated asset that only fails at runtime.
+            for line in missing_login_advice(bundle, args.session_id, args.name):
+                print(line, file=sys.stderr)
         return _report_workflow(result, args)
 
     # login

--- a/tests/test_csp_blind_capture.py
+++ b/tests/test_csp_blind_capture.py
@@ -230,6 +230,25 @@ class TestAuthHeaderOriginsInScope:
             har=bundle["har"],
         )
 
+    def test_request_header_allowlist_turns_capture_on(self) -> None:
+        """Tabby's registerRequestHeaderCapture() returns immediately on an empty
+        allowlist, so without this nothing is captured however right the scope is."""
+        export_policy = self._draft()["application_draft"]["export_policy"]
+        assert export_policy["request_header_allowlist"] == ["authorization"]
+
+    def test_allowlist_never_contains_cookie(self) -> None:
+        """Tabby's validator rejects Cookie — cookies have their own path."""
+        allowlist = self._draft()["application_draft"]["export_policy"]["request_header_allowlist"]
+        assert all(h.lower() != "cookie" for h in allowlist)
+
+    def test_allowlist_agrees_with_declared_credential_types(self) -> None:
+        """The two halves of the contract: what the worker CAPTURES must cover
+        what /credentials/request SERVES, or the value is always empty."""
+        draft = self._draft()
+        served = draft["service_profile_draft"]["credential_types"]["headers"]
+        captured = draft["application_draft"]["export_policy"]["request_header_allowlist"]
+        assert {h.lower() for h in served} <= {h.lower() for h in captured}
+
     def test_api_origin_lands_in_target_urls(self) -> None:
         """Without this the request-header sniffer never fires and auth stays empty."""
         target_urls = self._draft()["application_draft"]["target_urls"]

--- a/tests/test_csp_blind_capture.py
+++ b/tests/test_csp_blind_capture.py
@@ -1,0 +1,255 @@
+"""Regression tests for the adopt-ai-skills friction session (2026-07-30).
+
+Building one skill against app.adopt.ai took 3 recordings and 5 human sign-ins
+instead of 1 and 2. Two distinct defects, both silent:
+
+1. app.adopt.ai enforces a CSP whose `connect-src` excludes the DOM recorder's
+   beacon host, so the browser refused every interaction beacon and the capture
+   arrived with zero `click_events`. `find_login_boundary` then found no
+   credential field, `--mode combined` degraded to workflow-only, and no App
+   Template was registered — reported to the operator as one calm line.
+   (Fixed in the worker by posting the beacon same-origin; NoUI must still
+   recognise and explain the shape, including for bundles already captured.)
+
+2. The login profile's capture scope only ever covered the origins the human
+   *navigated* (app.adopt.ai), never the origin the bearer is actually sent to
+   (api.adopt.ai). Tabby's request-header sniffer is filtered by that scope, so
+   the declared `authorization` header never got a captured value and every
+   compiled operation 401'd against a HEALTHY session.
+
+The bundle below is shaped exactly as Tabby drains one from that site.
+"""
+
+from __future__ import annotations
+
+from noui_core.capture.classify import (
+    classify_bundle,
+    diagnose_missing_login,
+    missing_login_advice,
+)
+from noui_core.capture.split import split_bundle
+from noui_core.compile.login_assets import _analyze_har, generate
+
+BEARER = "Bearer eyJhbGciOiJSUzI1NiJ9.PAYLOAD.SIG"
+
+
+def _hdrs(*pairs: tuple[str, str]) -> list[dict]:
+    return [{"name": n, "value": v} for n, v in pairs]
+
+
+def _entry(ts: str, method: str, url: str, headers: list[dict]) -> dict:
+    return {
+        "startedDateTime": ts,
+        "request": {"method": method, "url": url, "headers": headers, "queryString": []},
+        "response": {"status": 200, "content": {"mimeType": "application/json"}, "headers": []},
+        "_resourceType": "fetch",
+    }
+
+
+AUTHED = _hdrs(("accept", "*/*"), ("authorization", BEARER))
+
+
+def _adopt_bundle(*, click_events: list[dict] | None = None) -> dict:
+    """A combined (login + workflow) capture of app.adopt.ai.
+
+    click_events defaults to [] — what the CSP-silenced recorder produced.
+    """
+    return {
+        "session_id": "adopt-skills",
+        "recording_mode": "login",  # warm-pool stamp; NoUI ignores it
+        "click_events": click_events if click_events is not None else [],
+        "url_events": [
+            {
+                "from_url": "about:blank",
+                "to_url": "https://app.adopt.ai/",
+                "timestamp": "2026-07-30T10:00:05.000Z",
+            },
+            {
+                "from_url": "https://app.adopt.ai/",
+                "to_url": "https://app.adopt.ai/prelogin",
+                "timestamp": "2026-07-30T10:00:07.000Z",
+            },
+            {
+                "from_url": "https://app.adopt.ai/prelogin",
+                "to_url": "https://app.adopt.ai/account/login",
+                "timestamp": "2026-07-30T10:00:09.000Z",
+            },
+            {
+                "from_url": "https://app.adopt.ai/account/login",
+                "to_url": "https://app.adopt.ai/oauth/callback?code=abc",
+                "timestamp": "2026-07-30T10:01:22.000Z",
+            },
+            {
+                "from_url": "https://app.adopt.ai/oauth/callback?code=abc",
+                "to_url": "https://app.adopt.ai/",
+                "timestamp": "2026-07-30T10:01:24.000Z",
+            },
+        ],
+        "har": {
+            "log": {
+                "entries": [
+                    _entry(
+                        "2026-07-30T10:00:10.000Z",
+                        "POST",
+                        "https://app.adopt.ai/frontegg/identity/resources/auth/v2/user/token/refresh",
+                        _hdrs(("accept", "*/*")),
+                    ),
+                    # The bearer only ever rides on the API origin, never the UI origin.
+                    _entry(
+                        "2026-07-30T10:02:31.000Z",
+                        "GET",
+                        "https://api.adopt.ai/v1/end-user/agent-harness/skills",
+                        AUTHED,
+                    ),
+                ]
+            }
+        },
+        "cookies": [],
+    }
+
+
+# ── 1. A silenced recorder must not read as "no login happened" ──────────────
+
+
+class TestSilencedRecorderDiagnosis:
+    def test_capture_has_no_login_boundary(self) -> None:
+        """The precondition: this is what the operator actually hit."""
+        bundle = _adopt_bundle()
+        assert split_bundle(bundle) is None
+        assert classify_bundle(bundle) == "workflow"
+
+    def test_zero_interactions_with_real_traffic_is_flagged(self) -> None:
+        diagnosis = diagnose_missing_login(_adopt_bundle())
+        assert diagnosis is not None
+        assert diagnosis["reason"] == "recorder_silent"
+        assert diagnosis["recorder_silent"] is True
+        assert "Content-Security-Policy" in diagnosis["detail"]
+
+    def test_flags_the_signin_urls_it_saw(self) -> None:
+        diagnosis = diagnose_missing_login(_adopt_bundle())
+        assert diagnosis is not None
+        assert any("/account/login" in u for u in diagnosis["login_urls"])
+
+    def test_advice_names_the_mode_login_recovery(self) -> None:
+        """The workaround took source-reading to find; it must be printed."""
+        advice = "\n".join(missing_login_advice(_adopt_bundle(), "sess-123", "adopt-ai-skills"))
+        assert "--mode login" in advice
+        assert "sess-123" in advice
+        assert "no App Template" in advice.lower() or "NO App Template" in advice
+        assert "re-record" in advice.lower()
+
+    def test_login_without_credential_field_is_a_distinct_reason(self) -> None:
+        """SSO / passwordless / warm-pool: interactions exist, no credential field."""
+        clicks = [
+            {
+                "event_type": "click",
+                "tag_name": "BUTTON",
+                "field_role": None,
+                "selector": "#sso",
+                "timestamp": "2026-07-30T10:00:08.000Z",
+            }
+        ]
+        diagnosis = diagnose_missing_login(_adopt_bundle(click_events=clicks))
+        assert diagnosis is not None
+        assert diagnosis["reason"] == "login_without_credential_field"
+        assert diagnosis["recorder_silent"] is False
+
+    def test_genuine_workflow_capture_is_not_flagged(self) -> None:
+        """No false alarm on a workflow recorded against an existing profile."""
+        bundle = {
+            "session_id": "wf",
+            "click_events": [
+                {
+                    "event_type": "click",
+                    "tag_name": "BUTTON",
+                    "field_role": None,
+                    "selector": "#export",
+                    "timestamp": "2026-07-30T10:00:08.000Z",
+                }
+            ],
+            "url_events": [
+                {
+                    "from_url": "",
+                    "to_url": "https://app.example.com/reports",
+                    "timestamp": "2026-07-30T10:00:05.000Z",
+                }
+            ],
+            "har": {
+                "log": {
+                    "entries": [
+                        _entry(
+                            "2026-07-30T10:00:06.000Z",
+                            "GET",
+                            "https://app.example.com/api/reports",
+                            _hdrs(("accept", "*/*")),
+                        ),
+                    ]
+                }
+            },
+        }
+        assert diagnose_missing_login(bundle) is None
+        assert missing_login_advice(bundle, "sess-1") == []
+
+    def test_no_diagnosis_when_a_login_was_detected(self) -> None:
+        clicks = [
+            {
+                "event_type": "input",
+                "tag_name": "INPUT",
+                "field_role": "username",
+                "field_name": "email",
+                "selector": "#email",
+                "value": "a@b.c",
+                "timestamp": "2026-07-30T10:00:08.000Z",
+            }
+        ]
+        assert diagnose_missing_login(_adopt_bundle(click_events=clicks)) is None
+
+
+# ── 2. Capture scope must follow the token, not the human ────────────────────
+
+
+class TestAuthHeaderOriginsInScope:
+    def test_analyze_har_records_the_origin_carrying_the_bearer(self) -> None:
+        analysis = _analyze_har(_adopt_bundle()["har"])
+        assert analysis["auth_header_origins"] == ["https://api.adopt.ai"]
+
+    def test_analyze_har_ignores_origins_with_no_auth_header(self) -> None:
+        analysis = _analyze_har(_adopt_bundle()["har"])
+        assert "https://app.adopt.ai" not in analysis["auth_header_origins"]
+
+    def _draft(self) -> dict:
+        bundle = _adopt_bundle()
+        return generate(
+            {
+                "id": "adopt-skills",
+                "app_name": "Adopt AI Skills",
+                "login_url": "https://app.adopt.ai/account/login",
+            },
+            [],
+            bundle["url_events"],
+            har=bundle["har"],
+        )
+
+    def test_api_origin_lands_in_target_urls(self) -> None:
+        """Without this the request-header sniffer never fires and auth stays empty."""
+        target_urls = self._draft()["application_draft"]["target_urls"]
+        assert "https://api.adopt.ai/**" in target_urls
+
+    def test_ui_origin_is_still_covered(self) -> None:
+        target_urls = self._draft()["application_draft"]["target_urls"]
+        assert "https://app.adopt.ai/**" in target_urls
+
+    def test_export_policy_scope_matches(self) -> None:
+        """export_policy.target_urls is the list Tabby actually filters capture on."""
+        export_policy = self._draft()["application_draft"]["export_policy"]
+        assert "https://api.adopt.ai/**" in export_policy["target_urls"]
+
+    def test_target_urls_keep_the_glob_suffix(self) -> None:
+        """Tabby anchors each glob: a bare origin matches nothing with a path."""
+        for url in self._draft()["application_draft"]["target_urls"]:
+            assert url.endswith("/**"), url
+
+    def test_api_domain_reaches_target_domains(self) -> None:
+        """target_domains gates execute/fetch's attach_captured_credentials."""
+        domains = self._draft()["service_profile_draft"].get("target_domains", [])
+        assert "api.adopt.ai" in domains


### PR DESCRIPTION
## What

Two silent failures in the capture → compile path, found rebuilding the `adopt-ai-skills` skill against the real `app.adopt.ai` (the run documented in `noui-friction-report-adopt-skills.md`: 3 recordings and 5 human sign-ins instead of 1 and 2).

The report's symptoms were all accurate. Three of its **diagnoses** were not, so its prioritised fix list would have treated symptoms and left the real defects in place.

### 1. A capture whose login we couldn't see was reported as a capture with no login

`--mode combined` printed one line — `No login segment detected — compiling workflow-only.` — and carried on. That reads as "no login happened" when it actually means "the login was invisible to us". On `app.adopt.ai` the page CSP refused the DOM recorder's beacon, so `click_events` came back empty (fixed worker-side in adoptai/tabby#152; older workers and already-captured bundles still show this).

The operator got no signal until `call_web_api` failed at runtime with an unrelated-sounding "no Tabby profile exists", and the recovery — `--mode login` on the **same** bundle, no re-recording — was only discoverable by reading NoUI's source.

`diagnose_missing_login()` now separates two very different shapes:

- **the recorder was silenced** — zero interaction events alongside real network traffic; the human drove the session, so something ate the events (usually CSP)
- **the login left no credential field** — interactions exist but none is a credential field: SSO hand-off, magic-link, or a warm-pool browser already signed in

`capture_import` and `bundle_inspect` print the reason and the exact recovery commands.

### 2. Credential capture was scoped to where the human clicked, not where the token goes

Two independent bugs, both of which had to be fixed before a compiled skill could authenticate:

**Scope.** Login profiles only ever put the *navigated* origins in `target_urls`. A SPA serves its UI and its API from different origins and the bearer only rides on the API calls — on the real capture, `authorization` appeared on `api.adopt.ai` (16 requests) and `auth.adopt.ai` (7), and **never** on `app.adopt.ai`, the only origin the human visited. Tabby's request-header sniffer is filtered by that scope, so it never observed a matching request. Now every origin observed carrying an auth header is included.

**The allowlist.** The bigger one. Profiles declared `credential_types.headers: ['authorization']` but never `export_policy.request_header_allowlist`. Those are two halves of one contract — `credential_types` is what `/credentials/request` **serves**, `request_header_allowlist` is what the worker **captures** — and Tabby's `registerRequestHeaderCapture()` opens with `if (allowlist.length === 0) return;`. The listener was never registered. The profile looked correct, reported HEALTHY, and served an `authorization` value of length **zero**.

That is the actual cause of the report's Pain Point 5. Its suggested fix — inject `${SESSION:<slug>:accessToken:Bearer}` into `operations.json` — would have been wrong: a recipe with no `Authorization` header is *correct*, because Tabby injects it server-side via `attach_captured_credentials`. Nothing was ever capturing one.

**Also**: `extend_login_scope_for_workflow` — the step that exists precisely to widen scope for a later workflow capture — was gated on having read the login profile's declared headers, which needs an Editor+ token and returns `None` on any failure. Inside the harness it *always* returned `None`, so the step silently never ran. Now gated on the workflow's own observed auth headers.

## Validation

Live, against real `app.adopt.ai` on local Kind:

| | |
|---|---|
| Interaction events | 4 (was 0), incl. cross-origin `auth.adopt.ai` |
| Skills call captured | `GET https://api.adopt.ai/v1/end-user/agent-harness/skills` → 200 |
| Template `target_urls` | `app.adopt.ai/**`, `auth.adopt.ai/**`, **`api.adopt.ai/**`** |
| `request_header_allowlist` | `["authorization"]` |
| Compiled skill | 46 ops, `get_end_user_agent_harness_skills` bound `tabby_per_user` |
| End-to-end call | **200**, 3782 bytes of real skills JSON |

The end-to-end call succeeded by passing the captured `accessToken` as the bearer explicitly, because the auto-provision glob bug (see below) was still stripping capture scope at the time. That is fixed in adoptai/tabby#152; the fully automatic `attach_captured_credentials` path has not yet been re-run against a session provisioned by the fixed code.

Before the allowlist fix, on that same profile: `/credentials/request` returned `headers: [('authorization', 0)]` and `execute/fetch` with `attach_captured_credentials` returned `401 Not authenticated`.

Tests: **600 passed, +17 new** in `tests/test_csp_blind_capture.py`. The one failure (`test_execute_adapter.py::test_missing_agent_creds_raise_actionable_error`) is the pre-existing local-only `~/.config/noui/.env` shadowing, unrelated and present on `dev`. New tests confirmed non-vacuous against the pre-fix tree.

## Risk

- Wider `target_urls` means the worker captures headers from more origins. All of them already appeared in the capture and in the app's egress allowlist; capped at 10.
- `extend_login_scope_for_workflow` now attempts on more paths. It is best-effort by design and reports failures in `scope_extension` rather than raising.

## Companion fix in Tabby

This PR makes NoUI emit a correct App Template. Two things on the Tabby side had to change for that template to actually work, both in **adoptai/tabby#152**:

- **The recorder** — a page CSP silenced the interaction beacon, and shadow-DOM retargeting hid credential fields. Without those, a combined capture of `app.adopt.ai` yields no `click_events` at all, so nothing here can detect a login.
- **`autoProvisionFromTemplate`** — it rebuilt a cloned app's `target_urls` from `target_domains` as bare origins, discarding the globs. `buildUrlMatcher` anchors each pattern, so no URL with a path matched and capture yielded nothing *even with everything in this PR correct*. Originally flagged here as a known gap with a manual `PUT /apps/{id}` workaround; it is now fixed properly in that PR (verified live — a freshly cloned app comes out with `https://api.adopt.ai/**`).

**This PR should land with, or after, adoptai/tabby#152.** On its own it produces a better-formed template, but a capture on any CSP-enforcing site still arrives empty.

Investigation write-up: `plans/noui/noui-csp-blind-capture-investigation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

