### PR TITLE
feat(noui): api-key harness skills declare api_hosts for server-side routing (+ CORS authoring guidance)

### DIFF
--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -145,7 +145,12 @@ deterministic):
    `python operations/<tool>.py …` or `activate_verify.py`), **2–3 times each**, and
    confirm it returns the expected data.
 3. **Fix or drop** failures (empty creds → healthy session; 429 → browser-side
-   execute; wrong/empty body → recompile from the saved bundle), then **rename**
+   execute; wrong/empty body → recompile from the saved bundle;
+   **`cors_blocked` / `TypeError: Failed to fetch` → the app's page blocks the
+   cross-origin call — this is NOT a login/session fault, so do NOT re-sign or
+   re-record; recompile as an api-key skill** (`--auth-type api-key
+   --api-key-header <header>`, `${SECRET:...}`), or capture the in-page bearer
+   via `request_header_allowlist` if the app mints its own), then **rename**
    cryptic tools/params to natural language and **parameterize** hardcoded values.
 4. **Loop** until every remaining operation passes 2–3 clean runs — only then install.
 

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -150,7 +150,7 @@ deterministic):
    cross-origin call — this is NOT a login/session fault, so do NOT re-sign or
    re-record; recompile as an api-key skill** (`--auth-type api-key
    --api-key-header <header>`, `${SECRET:...}`), or capture the in-page bearer
-   via `request_header_allowlist` if the app mints its own), then **rename**
+   via `request_header_allowlist` if the app mints its own, then **rename**
    cryptic tools/params to natural language and **parameterize** hardcoded values.
 4. **Loop** until every remaining operation passes 2–3 clean runs — only then install.
 

--- a/skills/noui/noui_core/compile/harness_md_generator.py
+++ b/skills/noui/noui_core/compile/harness_md_generator.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import re
+from urllib.parse import urlsplit
 
 from noui_core.compile.skill_md_generator import (
     _escape_yaml_scalar,
@@ -108,6 +109,32 @@ def secret_names(auth_plan: dict | None) -> list[str]:
     return names
 
 
+def is_api_key_auth(auth_plan: dict | None) -> bool:
+    """True when the skill authenticates with a static secret header (an API
+    key), rather than (or in addition to) a recorded browser session. Such a
+    skill self-authenticates, so the harness can call it server-side."""
+    return bool(auth_plan and auth_plan.get("strategy") == "static_secret_header")
+
+
+def api_hosts_for(tool_defs: list[dict]) -> list[str]:
+    """Distinct API hosts this skill's operations target, in first-seen order.
+
+    Emitted into an api-key skill's frontmatter as ``api_hosts`` — the harness
+    reads it as BOTH the opt-in to its direct (non-browser) call path AND the
+    egress allowlist for it. A static-key REST API whose API host differs from
+    the app's SPA origin CORS-fails in the browser (the Rocketlane case), so it
+    must be called server-side; declaring the host here is what lets the harness
+    do that safely, with no per-deployment config. Cross-domain ops are kept
+    (a workflow can legitimately span an auth host + an api host)."""
+    hosts: list[str] = []
+    for td in tool_defs:
+        base = td.get("base_url") or ""
+        host = urlsplit(base).hostname or urlsplit(f"{base}{td.get('path', '')}").hostname
+        if host and host not in hosts:
+            hosts.append(host)
+    return hosts
+
+
 def build_operation_recipe(td: dict, *, profile_slug: str, auth_plan: dict | None = None) -> dict:
     """Build the machine-readable request recipe for one recorded operation."""
     method = td["method"].upper()
@@ -189,12 +216,24 @@ def render_harness_skill_md(
         workflow_name=workflow_name,
         tool_defs=tool_defs,
         profile_slug=profile_slug,
-        requires_auth=bool(auth_plan),
+        auth_plan=auth_plan,
     )
+
+    # An api-key skill declares its auth mode + API host(s) in frontmatter so
+    # the harness routes call_web_api server-side (direct httpx) instead of
+    # through the browser session, which cross-origin-CORS-fails for a static-
+    # key REST API (the Rocketlane case). api_hosts is both the opt-in and the
+    # egress allowlist; it ships with the skill via install_skill, so no
+    # per-app deployment config is needed. Non-api-key skills are unchanged.
+    auth_lines = ""
+    if is_api_key_auth(auth_plan):
+        hosts = api_hosts_for(tool_defs)
+        host_block = "".join(f"\n  - {_escape_yaml_scalar(h)}" for h in hosts)
+        auth_lines = f"\nauth: api-key\napi_hosts:{host_block}" if hosts else "\nauth: api-key"
 
     frontmatter = f"""---
 name: {skill_id}
-description: {_escape_yaml_scalar(description)}
+description: {_escape_yaml_scalar(description)}{auth_lines}
 ---
 """
     body = _render_body(

--- a/skills/noui/noui_core/compile/harness_md_generator.py
+++ b/skills/noui/noui_core/compile/harness_md_generator.py
@@ -265,13 +265,28 @@ def _render_body(
     auth_plan: dict,
     profile_slug: str,
 ) -> str:
+    # An api-key skill is called server-side (direct httpx to its api_hosts), not
+    # through the Tabby browser — so its prose must NOT claim a live session/profile
+    # or advise re-recording login for CORS, which would loop authors back into the
+    # re-sign trap this whole change removes.
+    is_api_key = is_api_key_auth(auth_plan)
     authed = bool(profile_slug)
     secrets = secret_names(auth_plan)
     sections: list[str] = []
 
     sections.append(f"# {app_name}")
     sections.append("")
-    if authed:
+    if is_api_key:
+        sections.append(
+            f"Skill for {app_name}, targeting the **Adopt Agent Harness**. Operations are "
+            f"executed by calling the harness `call_web_api` tool — there are no scripts to "
+            f"run and nothing to install. This API authenticates with a **static API key**, so "
+            f"the harness calls it **directly, server-side**: it substitutes the "
+            f"`${{SECRET:...}}` header worker-side and fetches the API host (declared in this "
+            f"skill's `api_hosts` frontmatter) directly. No Tabby profile, member sign-in, or "
+            f"browser session is involved."
+        )
+    elif authed:
         sections.append(
             f"Skill for {app_name}, targeting the **Adopt Agent Harness**. Operations are "
             f"executed by calling the harness `call_web_api` tool — there are no scripts to "
@@ -290,7 +305,24 @@ def _render_body(
     # Prerequisites
     sections.append("## Prerequisites")
     sections.append("")
-    if authed:
+    if is_api_key:
+        items: list[str] = []
+        if secrets:
+            names = ", ".join(f"`{n}`" for n in secrets)
+            items.append(
+                f"The API key secret(s) {names} are configured in the harness secret store "
+                f"(`AGENT_HARNESS_WEB_API_SECRETS`, or the org secret vault). The operation "
+                f"cards carry the key as a `${{SECRET:name}}` placeholder — **pass it verbatim, "
+                f"never a real key**; an unconfigured secret returns an actionable error naming it."
+            )
+        items.append(
+            "The skill's `api_hosts` frontmatter lists the API host(s) the harness may reach "
+            "directly. No Tabby profile, session, or member sign-in is required — the key "
+            "authenticates every call."
+        )
+        for i, item in enumerate(items, 1):
+            sections.append(f"{i}. {item}")
+    elif authed:
         sections.append(
             f"1. The Tabby profile **`{profile_slug}`** is **ACTIVE** and listed in the "
             f"harness agent client's `allowed_profiles` (a `forbidden` result means it is "
@@ -379,7 +411,28 @@ def _render_body(
     # Troubleshooting
     sections.append("## Troubleshooting")
     sections.append("")
-    if authed:
+    if is_api_key:
+        sections.append(
+            "- **`cors_blocked` / `Failed to fetch`** — the call was attempted through the "
+            "browser and blocked cross-origin. This is **not** a login problem: do **not** "
+            "re-record a login or retry with `wait_for_login`. It means this URL's host is not "
+            "in the skill's `api_hosts` frontmatter — add the host and re-install so the call "
+            "routes server-side."
+        )
+        sections.append(
+            "- **HTTP 401 / 403 from the API** — the API key is missing, wrong, or lacks the "
+            "needed scope; this is a key/permission problem, not a session one. Check the "
+            "configured secret, not sign-in."
+        )
+        sections.append(
+            "- **Unconfigured secret** — a `${SECRET:name}` with no stored value returns an "
+            "error naming it; an admin adds it to the harness secret store."
+        )
+        sections.append(
+            "- **Truncated response** — the result hit the harness text cap. Narrow the query "
+            "(filters, pagination params) instead of re-fetching the same URL."
+        )
+    elif authed:
         sections.append(
             "- **`forbidden`** — the profile is not in the harness agent client's "
             "`allowed_profiles`, or is not ACTIVE. An admin must fix the profile; this is "

--- a/skills/noui/noui_core/compile/skill_md_generator.py
+++ b/skills/noui/noui_core/compile/skill_md_generator.py
@@ -113,9 +113,12 @@ def _synthesize_description(
     # browser session — so the old "Requires an authenticated Tabby session"
     # line was misleading for it (the Rocketlane case).
     if auth_plan and auth_plan.get("strategy") == "static_secret_header":
+        # Location-neutral: the harness resolves the key server-side, the http
+        # execution mode reads it from a local env var — either way it's a
+        # static key, not a browser sign-in.
         auth_caveat = (
-            f" Authenticates with a static API key (configured server-side), not a "
-            f"browser sign-in, and calls {hostname} directly."
+            f" Authenticates with a static API key rather than a browser sign-in, "
+            f"and calls {hostname} directly."
         )
     elif auth_plan:
         auth_caveat = (

--- a/skills/noui/noui_core/compile/skill_md_generator.py
+++ b/skills/noui/noui_core/compile/skill_md_generator.py
@@ -49,7 +49,7 @@ def render_skill_md(
         workflow_name=workflow_name,
         tool_defs=tool_defs,
         profile_slug=profile_slug,
-        requires_auth=bool(auth_plan),
+        auth_plan=auth_plan,
     )
 
     body = _render_body(
@@ -90,7 +90,7 @@ def _synthesize_description(
     workflow_name: str,
     tool_defs: list[dict],
     profile_slug: str,
-    requires_auth: bool,
+    auth_plan: dict | None,
 ) -> str:
     """Draft a description + trigger phrases from the recording metadata."""
     actions = [_tool_to_action(td) for td in tool_defs if _tool_to_action(td)]
@@ -108,12 +108,22 @@ def _synthesize_description(
     )[:4]
     trigger_str = ", ".join(f'"{t}"' for t in triggers)
 
-    auth_caveat = (
-        f" Requires an authenticated Tabby session for the `{profile_slug or app_name.lower()}` "
-        f"profile; not usable as a generic {hostname} tool."
-        if requires_auth
-        else ""
-    )
+    # The caveat must match how the skill actually authenticates: an api-key
+    # (static_secret_header) skill calls the API directly with a key — no
+    # browser session — so the old "Requires an authenticated Tabby session"
+    # line was misleading for it (the Rocketlane case).
+    if auth_plan and auth_plan.get("strategy") == "static_secret_header":
+        auth_caveat = (
+            f" Authenticates with a static API key (configured server-side), not a "
+            f"browser sign-in, and calls {hostname} directly."
+        )
+    elif auth_plan:
+        auth_caveat = (
+            f" Requires an authenticated Tabby session for the `{profile_slug or app_name.lower()}` "
+            f"profile; not usable as a generic {hostname} tool."
+        )
+    else:
+        auth_caveat = ""
 
     return (
         f"Use this skill when the user wants to {action_phrase} on {app_name}. "

--- a/tests/test_harness_md_secret_prose.py
+++ b/tests/test_harness_md_secret_prose.py
@@ -84,6 +84,25 @@ def test_session_description_keeps_tabby_session_caveat():
     assert "authenticated Tabby session" in desc
 
 
+def test_api_key_body_describes_server_side_not_resign():
+    # The generated body for an api-key skill must agree with the api_hosts
+    # frontmatter: server-side routing, no Tabby session, and NO advice to
+    # re-record login on a CORS/Failed-to-fetch (which would loop authors).
+    md = _render(_STATIC_PLAN)
+    body = md.split("---\n", 2)[2]  # after frontmatter
+    assert "directly, server-side" in body
+    tshoot = body.split("## Troubleshooting", 1)[1].split("<!-- custom", 1)[0]
+    assert "cors_blocked" in tshoot.lower() or "failed to fetch" in tshoot.lower()
+    assert "do **not** re-record" in tshoot  # steers away from the re-sign loop
+    assert "re-record the login if needed" not in tshoot  # the old session advice is gone
+    assert "api_hosts" in tshoot
+
+
+def test_session_body_still_mentions_tabby_profile():
+    body = _render(_SESSION_PLAN).split("---\n", 2)[2]
+    assert "Tabby profile" in body
+
+
 def test_api_hosts_dedupes_across_operations_in_order():
     from noui_core.compile.harness_md_generator import api_hosts_for
 

--- a/tests/test_harness_md_secret_prose.py
+++ b/tests/test_harness_md_secret_prose.py
@@ -48,3 +48,48 @@ def test_session_auth_skill_md_has_no_secret_placeholder():
 def test_static_secret_skill_md_keeps_secret_guidance():
     md = _render(_STATIC_PLAN)
     assert "${SECRET:" in md  # a real static-secret skill still documents it
+
+
+def _frontmatter_block(md):
+    """The raw YAML frontmatter (between the first two --- fences)."""
+    assert md.startswith("---\n")
+    return md.split("---\n", 2)[1]
+
+
+def test_static_secret_skill_declares_auth_and_api_hosts():
+    # The harness reads api_hosts frontmatter to route this call server-side
+    # (direct, non-browser) — the fix for the cross-origin CORS failure.
+    fm = _frontmatter_block(_render(_STATIC_PLAN))
+    assert "\nauth: api-key\n" in fm
+    assert "\napi_hosts:\n  - www.airbnb.com\n" in fm
+
+
+def test_session_auth_skill_declares_no_direct_routing():
+    # A browser/session skill must NOT be marked for server-side routing.
+    fm = _frontmatter_block(_render(_SESSION_PLAN))
+    assert "auth: api-key" not in fm
+    assert "api_hosts:" not in fm
+
+
+def test_static_secret_description_has_no_tabby_session_caveat():
+    # The synthesized description must not claim an api-key skill needs a Tabby
+    # sign-in — it authenticates server-side with a static key.
+    desc = _frontmatter_block(_render(_STATIC_PLAN)).split("description:", 1)[1]
+    assert "authenticated Tabby session" not in desc
+    assert "static API key" in desc
+
+
+def test_session_description_keeps_tabby_session_caveat():
+    desc = _frontmatter_block(_render(_SESSION_PLAN)).split("description:", 1)[1]
+    assert "authenticated Tabby session" in desc
+
+
+def test_api_hosts_dedupes_across_operations_in_order():
+    from noui_core.compile.harness_md_generator import api_hosts_for
+
+    tds = [
+        {"name": "a", "method": "GET", "path": "/p", "base_url": "https://auth.example.com"},
+        {"name": "b", "method": "GET", "path": "/q", "base_url": "https://api.example.com"},
+        {"name": "c", "method": "GET", "path": "/r", "base_url": "https://api.example.com"},
+    ]
+    assert api_hosts_for(tds) == ["auth.example.com", "api.example.com"]


### PR DESCRIPTION
## Overview

Makes NoUI-compiled **api-key harness skills** work server-side, and aligns the authoring guidance. An api-key REST API whose API host differs from the app's SPA origin cross-origin-CORS-fails when `call_web_api` runs it in the Tabby browser (`TypeError: Failed to fetch`) — the Rocketlane case. The harness can call such a skill directly (server-side), but only if the skill tells it which host to allow.

## Changes

### 1. Emit `api_hosts` frontmatter for api-key skills — `e629182` (compiler)
`harness_md_generator.py` now emits `auth: api-key` + `api_hosts:` (distinct hosts from the operations' `base_url`s, first-seen order) into the harness `SKILL.md` frontmatter whenever the auth plan is `static_secret_header`. The harness reads `api_hosts` as **both** the opt-in to its direct (non-browser) path **and** the egress allowlist, so every api-key skill enables server-side routing on `install_skill` with no per-deployment config. Non-api-key skills are unchanged. New helpers `is_api_key_auth()` / `api_hosts_for()`.

Also fixes the synthesized description: an api-key skill no longer claims it "Requires an authenticated Tabby session" — it authenticates with a static key, server-side. `_synthesize_description` now takes the `auth_plan` to pick the right caveat.

### 2. CORS authoring guidance — `a2710449` (docs)
Adds the cross-origin case to the capture failure-triage list in the NoUI `SKILL.md`: `cors_blocked` / `Failed to fetch` → **not** a login fault → recompile as an api-key skill (`--auth-type api-key --api-key-header <header>`, `${SECRET:...}`), or capture the in-page bearer via `request_header_allowlist` if the app mints its own. Never re-sign or re-record.

## Paired with
**adoptai-workflows#1531** (`fix/tabby-auth-session-id`) — the runtime side: `execute_fetch` classifies the CORS signature as a distinct `cors_blocked` outcome, and `_dispatch_call_web_api` routes api-key skills server-side by reading exactly the `api_hosts` frontmatter §1 emits. §1's contract (`auth: api-key` + `api_hosts` list) matches that reader one-to-one.

## Tests
`test_harness_md_secret_prose.py` covers frontmatter emission, host de-dup/order, and the corrected description prose. **153 compile tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
