### PR TITLE
fix(noui): order recorded events by seq, not by the recorder's flush timestamp

### DIFF
--- a/skills/noui/noui_core/capture/autopilot.py
+++ b/skills/noui/noui_core/capture/autopilot.py
@@ -68,6 +68,13 @@ class AutopilotSession:
         self._urls: list[dict[str, Any]] = []
         self._current_url = ""
         self.capturing = False
+        # One counter across clicks AND url transitions — the compilers read
+        # `seq` as a total order over both (noui_core.event_order). NoUI issues
+        # the commands here, so recording order IS interaction order and the
+        # counter is simply the order the driver drove them in. These bundles
+        # carry no wall clock at all, so without `seq` the compilers have nothing
+        # to correlate a route change with the click that caused it.
+        self._seq = 0
 
     # ── low-level ────────────────────────────────────────────────────────────
     def _exec(
@@ -126,13 +133,20 @@ class AutopilotSession:
         return self._exec("screenshot")
 
     # ── bundle synthesis ──────────────────────────────────────────────────────
+    def _next_seq(self) -> int:
+        self._seq += 1
+        return self._seq
+
     def _record_url(self, to_url: str) -> None:
         if to_url and to_url != self._current_url:
-            self._urls.append({"from_url": self._current_url, "to_url": to_url})
+            self._urls.append(
+                {"from_url": self._current_url, "to_url": to_url, "seq": self._next_seq()}
+            )
             self._current_url = to_url
 
     def _record_click(self, **info: Any) -> None:
-        self._clicks.append({"event_type": "click", **info})
+        # seq last so a caller kwarg can never shadow the ordinal.
+        self._clicks.append({"event_type": "click", **info, "seq": self._next_seq()})
 
     def build_bundle(self, har: dict) -> dict:
         """Assemble a workflow recording bundle from a captured HAR + driven events."""

--- a/skills/noui/noui_core/capture/bundle.py
+++ b/skills/noui/noui_core/capture/bundle.py
@@ -26,6 +26,12 @@ from pathlib import Path
 from typing import Any
 
 # Fields accepted by backend ClickEventCreate (backend/shared/schemas.py).
+# NOTE: `seq` — the interaction-order ordinal the compilers sort on (see
+# noui_core.event_order) — is deliberately NOT projected here: the backend schema
+# has no such column, so it would be rejected or dropped. A bundle that makes the
+# round trip through /clicks therefore comes back orderable only by list order,
+# which is what the compilers fall back to. Add it here once the backend carries
+# it; the direct bundle→compiler path (compile_login_bundle) keeps seq already.
 _CLICK_FIELDS = (
     "event_type",
     "url",

--- a/skills/noui/noui_core/capture/split.py
+++ b/skills/noui/noui_core/capture/split.py
@@ -27,6 +27,7 @@ click_events, url_events, cookies?}`).
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 from noui_core.compile.login_assets import _is_redirect_hop
@@ -34,6 +35,34 @@ from noui_core.event_order import event_seq, merged_order
 
 # Field roles that mark a credential-entry interaction (login-only signal).
 CREDENTIAL_FIELD_ROLES = frozenset({"username", "password", "otp", "unknown_sensitive"})
+
+# An event's position on whichever axis the bundle supports: its `seq` ordinal
+# (int) when numbered, else its `timestamp` (ISO-8601 UTC str, lexicographically
+# comparable). Deliberately heterogeneous — hence `Any`: the two are never mixed
+# within one split, so values are only ever compared against their own kind.
+_PositionKey = Callable[[dict[str, Any]], Any]
+
+
+def _position_key(by_seq: bool) -> _PositionKey:
+    """The axis to place events on: ordinals when numbered, else wall clock."""
+    if by_seq:
+        return event_seq
+    return lambda e: e.get("timestamp")
+
+
+def _placed(events: list[dict[str, Any]], key: _PositionKey) -> list[tuple[Any, dict[str, Any]]]:
+    """(position, event) for each event that can be placed on the axis.
+
+    Events with no position are dropped — the caller decides which slice those
+    belong to (see `_keep`). Positions are computed once here rather than
+    recomputed per comparison.
+    """
+    out: list[tuple[Any, dict[str, Any]]] = []
+    for ev in events:
+        pos = key(ev)
+        if pos is not None:
+            out.append((pos, ev))
+    return out
 
 
 def _boundary_event(bundle: dict[str, Any]) -> dict[str, Any] | None:
@@ -58,24 +87,21 @@ def _boundary_event(bundle: dict[str, Any]) -> dict[str, Any] | None:
     clicks = [c for c in (bundle.get("click_events") or []) if isinstance(c, dict)]
     url_events = [u for u in (bundle.get("url_events") or []) if isinstance(u, dict)]
     by_seq = merged_order(clicks, url_events)
-    key = event_seq if by_seq else (lambda e: e.get("timestamp"))
+    key = _position_key(by_seq)
 
-    creds = [
-        c for c in clicks if c.get("field_role") in CREDENTIAL_FIELD_ROLES and key(c) is not None
-    ]
+    creds = _placed([c for c in clicks if c.get("field_role") in CREDENTIAL_FIELD_ROLES], key)
     if not creds:
         return None
-    last_cred = max(creds, key=key)
+    last_cred_pos, last_cred = max(creds, key=lambda placed: placed[0])
 
     navs = [
-        u
-        for u in url_events
+        (pos, u)
+        for pos, u in _placed(url_events, key)
         if u.get("to_url")
-        and key(u) is not None
-        and key(u) > key(last_cred)
+        and pos > last_cred_pos
         and not _is_redirect_hop(u.get("from_url", "") or "", u.get("to_url", ""))
     ]
-    boundary = min(navs, key=key) if navs else last_cred
+    boundary = min(navs, key=lambda placed: placed[0])[1] if navs else last_cred
     return {
         "seq": event_seq(boundary) if by_seq else None,
         "timestamp": boundary.get("timestamp") or None,
@@ -135,10 +161,9 @@ def _slice(bundle: dict[str, Any], boundary: dict[str, Any], side: str) -> dict[
     # Ordinals when the boundary was resolved on them, wall clock otherwise. The
     # two must not be mixed: cutting events on seq against a timestamp boundary
     # (or vice versa) compares unrelated scales and drops the whole slice.
-    if boundary["seq"] is not None:
-        key, cut = event_seq, boundary["seq"]
-    else:
-        key, cut = (lambda e: e.get("timestamp")), boundary["timestamp"]
+    by_seq = boundary["seq"] is not None
+    key: _PositionKey = _position_key(by_seq)
+    cut = boundary["seq"] if by_seq else boundary["timestamp"]
 
     passthrough = {
         k: v for k, v in bundle.items() if k not in ("click_events", "url_events", "har", "cookies")

--- a/skills/noui/noui_core/capture/split.py
+++ b/skills/noui/noui_core/capture/split.py
@@ -30,45 +30,71 @@ from __future__ import annotations
 from typing import Any
 
 from noui_core.compile.login_assets import _is_redirect_hop
+from noui_core.event_order import event_seq, merged_order
 
 # Field roles that mark a credential-entry interaction (login-only signal).
 CREDENTIAL_FIELD_ROLES = frozenset({"username", "password", "otp", "unknown_sensitive"})
 
 
-def find_login_boundary(bundle: dict[str, Any]) -> str | None:
-    """Return the ISO timestamp separating login from workflow, or None.
+def _boundary_event(bundle: dict[str, Any]) -> dict[str, Any] | None:
+    """The recorded event at which the login ends, or None if there is no login.
 
-    None means the bundle has no login segment (no credential-field interactions)
-    — e.g. a workflow recorded against an already-authenticated profile. The
-    caller then treats the whole bundle as workflow-only.
+    The boundary is the first stable (non-redirect) URL transition that occurs
+    after the last credential-field interaction; if the login never navigates
+    afterwards, it falls back to that last interaction.
 
-    The boundary is the timestamp of the first stable (non-redirect) URL
-    transition that occurs after the last credential-field interaction; if the
-    login never navigates afterwards, it falls back to that last interaction.
+    "After" is decided by ``seq`` when clicks and URL transitions are BOTH fully
+    numbered — they share one counter, assigned at interaction time. ``timestamp``
+    on a debounced credential fill is its flush, up to 500ms late, which can drag
+    the boundary past the landing navigation and hand the login's own form-submit
+    request to the workflow slice, where it would be compiled into an operation.
+    Bundles without ``seq`` keep the timestamp comparison — the previous
+    behaviour, so pre-``seq`` recordings still compile.
+
+    Returns ``{"seq": int|None, "timestamp": str|None}``: both are carried
+    because the events are sliced on ``seq`` while the HAR — whose entries have
+    no ordinals — is always sliced on wall clock.
     """
-    clicks = bundle.get("click_events") or []
-    cred_ts = [
-        c["timestamp"]
-        for c in clicks
-        if isinstance(c, dict)
-        and c.get("field_role") in CREDENTIAL_FIELD_ROLES
-        and c.get("timestamp")
-    ]
-    if not cred_ts:
-        return None
-    last_cred = max(cred_ts)
+    clicks = [c for c in (bundle.get("click_events") or []) if isinstance(c, dict)]
+    url_events = [u for u in (bundle.get("url_events") or []) if isinstance(u, dict)]
+    by_seq = merged_order(clicks, url_events)
+    key = event_seq if by_seq else (lambda e: e.get("timestamp"))
 
-    url_events = bundle.get("url_events") or []
-    post_login_navs = [
-        u["timestamp"]
+    creds = [
+        c for c in clicks if c.get("field_role") in CREDENTIAL_FIELD_ROLES and key(c) is not None
+    ]
+    if not creds:
+        return None
+    last_cred = max(creds, key=key)
+
+    navs = [
+        u
         for u in url_events
-        if isinstance(u, dict)
-        and u.get("timestamp")
-        and u["timestamp"] > last_cred
-        and u.get("to_url")
+        if u.get("to_url")
+        and key(u) is not None
+        and key(u) > key(last_cred)
         and not _is_redirect_hop(u.get("from_url", "") or "", u.get("to_url", ""))
     ]
-    return min(post_login_navs) if post_login_navs else last_cred
+    boundary = min(navs, key=key) if navs else last_cred
+    return {
+        "seq": event_seq(boundary) if by_seq else None,
+        "timestamp": boundary.get("timestamp") or None,
+    }
+
+
+def find_login_boundary(bundle: dict[str, Any]) -> str | None:
+    """The ISO timestamp separating login from workflow, or None.
+
+    None means the bundle has no login segment (no credential-field
+    interactions) — e.g. a workflow recorded against an already-authenticated
+    profile. The caller then treats the whole bundle as workflow-only.
+
+    This is the boundary's wall clock, for display and for HAR slicing. Event
+    slicing goes through :func:`_boundary_event`, which also carries the ordinal
+    — see there for why the ordinal is the one that decides "after".
+    """
+    boundary = _boundary_event(bundle)
+    return boundary["timestamp"] if boundary else None
 
 
 def split_bundle(bundle: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]] | None:
@@ -77,38 +103,55 @@ def split_bundle(bundle: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
     Returns None when there is no login segment (see `find_login_boundary`), so
     the caller can fall back to compiling the bundle as workflow-only.
 
-    Slicing rule (timestamps are ISO-8601 UTC, lexicographically comparable):
-    the login slice keeps events at or before the boundary (and any event missing
-    a timestamp, so a login request never leaks into the workflow); the workflow
-    slice keeps only events strictly after the boundary with a real timestamp.
-    Top-level `cookies` (captured at drain, representing the authenticated state)
-    go to the login slice, which is the only compiler that reads them.
+    Slicing rule: the login slice keeps events at or before the boundary (and any
+    event that cannot be placed, so a login request never leaks into the
+    workflow); the workflow slice keeps only events strictly after it. Events are
+    cut on ``seq`` when the bundle carries it and on timestamp otherwise; HAR
+    entries are always cut on `startedDateTime` (ISO-8601 UTC, lexicographically
+    comparable) since they carry no ordinal. Top-level `cookies` (captured at
+    drain, representing the authenticated state) go to the login slice, which is
+    the only compiler that reads them.
     """
-    boundary = find_login_boundary(bundle)
+    boundary = _boundary_event(bundle)
     if boundary is None:
         return None
     return _slice(bundle, boundary, "login"), _slice(bundle, boundary, "workflow")
 
 
-def _keep(ts: str | None, boundary: str, side: str) -> bool:
+def _keep(value: Any, boundary: Any, side: str) -> bool:
+    """Which slice an event belongs to, given its position key and the boundary's.
+
+    An unplaceable event (no key, or no boundary key to compare against) goes to
+    the login slice — see the leak rule in `split_bundle`.
+    """
+    if value is None or boundary is None:
+        return side == "login"
     if side == "login":
-        return ts is None or ts <= boundary
-    return ts is not None and ts > boundary
+        return value <= boundary
+    return value > boundary
 
 
-def _slice(bundle: dict[str, Any], boundary: str, side: str) -> dict[str, Any]:
+def _slice(bundle: dict[str, Any], boundary: dict[str, Any], side: str) -> dict[str, Any]:
+    # Ordinals when the boundary was resolved on them, wall clock otherwise. The
+    # two must not be mixed: cutting events on seq against a timestamp boundary
+    # (or vice versa) compares unrelated scales and drops the whole slice.
+    if boundary["seq"] is not None:
+        key, cut = event_seq, boundary["seq"]
+    else:
+        key, cut = (lambda e: e.get("timestamp")), boundary["timestamp"]
+
     passthrough = {
         k: v for k, v in bundle.items() if k not in ("click_events", "url_events", "har", "cookies")
     }
     passthrough["click_events"] = [
         c
         for c in (bundle.get("click_events") or [])
-        if isinstance(c, dict) and _keep(c.get("timestamp"), boundary, side)
+        if isinstance(c, dict) and _keep(key(c), cut, side)
     ]
     passthrough["url_events"] = [
         u
         for u in (bundle.get("url_events") or [])
-        if isinstance(u, dict) and _keep(u.get("timestamp"), boundary, side)
+        if isinstance(u, dict) and _keep(key(u), cut, side)
     ]
 
     har = bundle.get("har") or {}
@@ -117,7 +160,7 @@ def _slice(bundle: dict[str, Any], boundary: str, side: str) -> dict[str, Any]:
     log["entries"] = [
         e
         for e in entries
-        if isinstance(e, dict) and _keep(e.get("startedDateTime"), boundary, side)
+        if isinstance(e, dict) and _keep(e.get("startedDateTime"), boundary["timestamp"], side)
     ]
     passthrough["har"] = {**har, "log": log}
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -32,6 +32,7 @@ from noui_core.compile.login_assets import (
     _first_path_segment,
     _url_origin,
 )
+from noui_core.event_order import event_seq, order_events
 
 
 def _slug_from_path(url: str) -> str:
@@ -97,7 +98,7 @@ def _parse_ts(ts: str) -> datetime | None:
         return None
 
 
-def _nav_clicks_for(from_url: str, to_ts: str, click_events: list[dict]) -> list[dict]:
+def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> list[dict]:
     """The recorded click CHAIN that drove an in-app navigation FROM from_url.
 
     A browser skill must NOT reach a data page with a full-page navigate/goto:
@@ -113,10 +114,18 @@ def _nav_clicks_for(from_url: str, to_ts: str, click_events: list[dict]) -> list
     "Cards" → strict-mode chaos, never reaching the statement). This returns the
     full ordered gesture — parent-expand … child-navigate — so the skill can
     reproduce the whole path. Falls back to the single navigating click when the
-    recording lacks reliable timestamps.
+    recording carries neither ordinals nor reliable timestamps.
+
+    Causality and ordering come from ``seq`` when the bundle carries it: clicks
+    and URL transitions are numbered from one counter assigned at interaction
+    time, which timestamps are not (see noui_core.event_order). The gesture
+    WINDOW stays in wall-clock — "clicks within 20s of each other" has no
+    ordinal equivalent — and simply does not apply when timestamps are absent;
+    the trailing-``_NAV_MAX_CLICKS`` cap below bounds the chain in that case.
     """
     from_key = _page_key(from_url)
-    nav_dt = _parse_ts(to_ts)
+    nav_dt = _parse_ts((nav_ev or {}).get("timestamp") or "")
+    nav_seq = event_seq(nav_ev)
     cands: list[dict] = []
     for c in click_events or []:
         if (c.get("event_type") or "click") != "click":
@@ -128,25 +137,37 @@ def _nav_clicks_for(from_url: str, to_ts: str, click_events: list[dict]) -> list
         if not text:
             continue
         cdt = _parse_ts(c.get("timestamp") or "")
-        if nav_dt and cdt and cdt > nav_dt:  # click happened after the nav — not its cause
+        cseq = event_seq(c)
+        # Drop clicks made AFTER the navigation — they cannot have caused it.
+        if nav_seq is not None and cseq is not None:
+            if cseq > nav_seq:
+                continue
+        elif nav_dt and cdt and cdt > nav_dt:
             continue
-        cands.append({"text": text, "selector": c.get("selector") or "", "dt": cdt})
+        cands.append({"text": text, "selector": c.get("selector") or "", "dt": cdt, "seq": cseq})
     if not cands:
         return []
 
-    # nav_dt is None (a bundle whose url_events carry no timestamp) means the
-    # causality filter above could not run, so the "clicks before the nav" set may
-    # actually be clicks made AFTER it — a recorded "Log out" would then be
-    # compiled into the read recipe. Fall back to the documented single-click
-    # behaviour rather than trusting an unbounded window.
-    if nav_dt is not None and all(c["dt"] is not None for c in cands):
-        cands.sort(key=lambda c: c["dt"])
-        anchor = cands[-1]["dt"]  # the navigating click
-        chain = [c for c in cands if (anchor - c["dt"]).total_seconds() <= _NAV_GESTURE_WINDOW_S]
-    else:
-        # Timestamps unreliable — can't bound the gesture, so keep only the
-        # navigating click (the recording-order last), i.e. the old behaviour.
+    # Neither ordinals nor timestamps means the causality filter above could not
+    # run, so the "clicks before the nav" set may actually be clicks made AFTER
+    # it — a recorded "Log out" would then be compiled into the read recipe. Fall
+    # back to the documented single-click behaviour rather than trusting an
+    # unbounded window.
+    ordered = None
+    if nav_seq is not None and all(c["seq"] is not None for c in cands):
+        ordered = sorted(cands, key=lambda c: c["seq"])
+    elif nav_dt is not None and all(c["dt"] is not None for c in cands):
+        ordered = sorted(cands, key=lambda c: c["dt"])
+
+    if ordered is None:
         chain = cands[-1:]
+    elif all(c["dt"] is not None for c in ordered):
+        anchor = ordered[-1]["dt"]  # the navigating click
+        chain = [c for c in ordered if (anchor - c["dt"]).total_seconds() <= _NAV_GESTURE_WINDOW_S]
+    else:
+        # Ordered by seq but undated (e.g. an agent-driven capture): the order is
+        # trustworthy, so keep the chain and let the trailing cap bound it.
+        chain = ordered
 
     # Collapse consecutive identical labels (double-clicks, re-renders) and cap
     # to the trailing N so only the immediate expand→navigate steps are emitted.
@@ -189,7 +210,11 @@ def derive_browser_pages(
     Empty list means the recording never left the login flow — the caller must
     treat that as "nothing to compile".
     """
-    click_events = click_events or []
+    # Interaction order, not recording order — pages are picked in FIRST-SEEN
+    # order and each page's nav gesture is read off the click list, so both sides
+    # must be sorted before anything positional is read from them.
+    click_events = order_events(click_events)
+    url_events = order_events(url_events)
     app_origin = _url_origin(login_url) if login_url else ""
     seen: set[str] = set()
     pages: list[dict] = []
@@ -218,7 +243,6 @@ def derive_browser_pages(
         # page, it's the post-login landing (auto-redirect) — no nav click. If it
         # came from another app page, replay the click that drove the SPA route.
         from_url = (ev or {}).get("from_url") or ""
-        to_ts = (ev or {}).get("timestamp") or ""
         # Three distinct states, kept apart deliberately:
         #   None  — the post-login LANDING page; the session already lands here.
         #   [...] — the click chain ON from_url that routed here.
@@ -231,7 +255,7 @@ def derive_browser_pages(
         is_landing = not from_url or _is_login_flow_url(from_url)
         nav: list[dict] | None = None
         if not is_landing:
-            nav = _nav_clicks_for(from_url, to_ts, click_events)
+            nav = _nav_clicks_for(from_url, ev or {}, click_events)
         pages.append(
             {
                 "name": f"read_{_slug_from_path(url)}",

--- a/skills/noui/noui_core/compile/login_assets.py
+++ b/skills/noui/noui_core/compile/login_assets.py
@@ -4,7 +4,8 @@ Tabby Application + ServiceProfile drafts plus a review report.
 
 Inputs (loaded by the router before calling generate()):
     - session: LoginSession dict
-    - click_events: list of ClickEvent dicts (chronological)
+    - click_events: list of ClickEvent dicts (re-ordered here by ``seq`` — see
+      noui_core.event_order for why recording order is not interaction order)
     - url_events: list of UrlEvent dicts (chronological)
     - har: HAR dict (log.entries[]) or None
 
@@ -25,6 +26,8 @@ import re
 from fnmatch import fnmatch
 from typing import Any
 from urllib.parse import urlparse
+
+from noui_core.event_order import order_events
 
 # ---------------------------------------------------------------------------
 # Credential-type shape
@@ -694,7 +697,8 @@ def generate(
     session:
         LoginSession as a dict (id, app_name, login_url, ...)
     click_events:
-        List of ClickEvent dicts, chronological order
+        List of ClickEvent dicts. Sorted into interaction order by ``seq``
+        before use; bundles without ``seq`` are consumed in list order.
     url_events:
         List of UrlEvent dicts, chronological order.
         Each dict may have either:
@@ -780,6 +784,15 @@ def generate(
 
     # goto first URL
     steps.append({"action": "goto", "url": first_url})
+
+    # Put the events in INTERACTION order before anything reads their sequence.
+    # The DSL is emitted in list order, and the dedup below only collapses
+    # *consecutive* runs, so a mis-ordered list compiles a mis-ordered login —
+    # e.g. a click on "Sign in" ahead of the fill it submitted. Recording order
+    # is not interaction order: the recorder debounces input by 500ms, so a
+    # field filled and submitted inside that window arrives (and is timestamped)
+    # after its own click. Bundles with no `seq` keep their list order.
+    click_events = order_events(click_events)
 
     # Deduplicate consecutive input events for the same field — keep only the
     # last value per (selector, event_type) run so we don't emit partial

--- a/skills/noui/noui_core/event_order.py
+++ b/skills/noui/noui_core/event_order.py
@@ -6,13 +6,13 @@ recorder AT INTERACTION TIME and rebased onto a session-global sequence by the
 worker. Interaction events additionally carry `event_time`, the wall clock of the
 interaction itself.
 
-`timestamp` cannot order the stream, and is deliberately NOT being changed to.
-The recorder debounces `input` by 500ms and builds the payload inside that
-debounce, so `timestamp` on an input is the FLUSH: a human who fills a field and
-clicks submit within 500ms (the ordinary login) produces a click stamped EARLIER
-than the input that preceded it. That field's meaning is frozen because existing
-consumers — including the login compiler here — read it; `seq` and `event_time`
-were added alongside it instead. `seq` is also immune to clock granularity (two
+`timestamp` cannot order the stream, and its meaning is deliberately left
+unchanged. The recorder debounces `input` by 500ms and builds the payload inside
+that debounce, so `timestamp` on an input is the FLUSH: a human who fills a field
+and clicks submit within 500ms (the ordinary login) produces a click stamped
+EARLIER than the input that preceded it. Rather than redefine that field — which
+existing consumers, including the login compiler here, already read — Tabby added
+`seq` and `event_time` alongside it. `seq` is also immune to clock granularity (two
 events in the same millisecond) and to the delivery order of the no-cors beacon
 channel.
 

--- a/skills/noui/noui_core/event_order.py
+++ b/skills/noui/noui_core/event_order.py
@@ -1,0 +1,70 @@
+"""Ordering recorded interaction/URL events.
+
+Bundles from Tabby schema_version >= 2 carry a `seq` on every click_event and
+url_event: a single strictly-increasing counter, assigned by the injected
+recorder AT INTERACTION TIME and rebased onto a session-global sequence by the
+worker. Interaction events additionally carry `event_time`, the wall clock of the
+interaction itself.
+
+`timestamp` cannot order the stream, and is deliberately NOT being changed to.
+The recorder debounces `input` by 500ms and builds the payload inside that
+debounce, so `timestamp` on an input is the FLUSH: a human who fills a field and
+clicks submit within 500ms (the ordinary login) produces a click stamped EARLIER
+than the input that preceded it. That field's meaning is frozen because existing
+consumers — including the login compiler here — read it; `seq` and `event_time`
+were added alongside it instead. `seq` is also immune to clock granularity (two
+events in the same millisecond) and to the delivery order of the no-cors beacon
+channel.
+
+Bundles predating `seq`, and those synthesized by drivers that do not number
+their events, have none — every helper here degrades to the recorded list order,
+which is what the compilers relied on previously. Detection is per event, not off
+`schema_version`: a bundle can lose `seq` in transit (the `/clicks` ingestion in
+noui_core.capture.bundle projects onto a fixed column list), so the version can
+say 2 while the events in hand carry no ordinal.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def event_seq(ev: Any) -> int | None:
+    """The event's ordinal, or None when it carries none (or a malformed one)."""
+    if not isinstance(ev, dict):
+        return None
+    raw = ev.get("seq")
+    # bool is an int subclass — a `seq: true` is malformed, not ordinal 1.
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 0:
+        return None
+    return raw
+
+
+def has_seq(events: list[dict] | None) -> bool:
+    """True when EVERY event carries an ordinal, so `seq` is a total order.
+
+    All-or-nothing on purpose: a partially-numbered list has no consistent order
+    to sort by, and mixing ordinals with list positions would silently reorder
+    the un-numbered events. Empty lists are trivially ordered.
+    """
+    return all(event_seq(ev) is not None for ev in (events or []))
+
+
+def order_events(events: list[dict] | None) -> list[dict]:
+    """The events in interaction order — by `seq` when available, else as recorded.
+
+    Stable, so events sharing an ordinal keep their recorded order.
+    """
+    evs = [ev for ev in (events or []) if isinstance(ev, dict)]
+    if not has_seq(evs):
+        return evs
+    return sorted(evs, key=lambda ev: event_seq(ev) or 0)
+
+
+def merged_order(*event_lists: list[dict] | None) -> bool:
+    """True when every event across all lists carries an ordinal.
+
+    Use before comparing ordinals ACROSS lists (clicks vs URL transitions): they
+    share one counter only when both sides were numbered by the same recorder.
+    """
+    return all(has_seq(evs) for evs in event_lists)

--- a/tests/test_autopilot_capture.py
+++ b/tests/test_autopilot_capture.py
@@ -59,10 +59,14 @@ def test_session_synthesizes_bundle(monkeypatch):
     # Synthesized bundle is the VNC bundle shape.
     assert bundle["recording_mode"] == "workflow"
     assert bundle["har"] is har
-    assert {"event_type": "click", "selector": "#btn"} in bundle["click_events"]
+    assert {"event_type": "click", "selector": "#btn", "seq": 2} in bundle["click_events"]
     # URL transitions recorded from the navigates.
     tos = [u["to_url"] for u in bundle["url_events"]]
     assert tos == ["https://x.com/a", "https://x.com/b"]
+    # Clicks and navigations are numbered from ONE counter, in driven order, so
+    # the compilers can correlate a route change with the click that caused it.
+    assert [u["seq"] for u in bundle["url_events"]] == [1, 3]
+    assert [c["seq"] for c in bundle["click_events"]] == [2]
 
 
 def test_run_steps_scripted(monkeypatch):
@@ -100,3 +104,54 @@ def test_execute_browser_raises_on_worker_failure(monkeypatch):
     monkeypatch.setattr(tabby_client, "_tabby_http", boom)
     with pytest.raises(RuntimeError, match="no healthy session"):
         tabby_client.execute_browser("p", "navigate", {"url": "https://x"}, token="t")
+
+
+def test_numbered_bundle_still_compiles_as_workflow_only(monkeypatch):
+    """`seq` must not make an autopilot capture look like it has a login.
+
+    The splitter finds a login boundary from credential-field interactions, and
+    an autopilot bundle records none — a driven capture runs against an
+    already-authenticated profile. Numbering the events must not change that:
+    split_bundle returning a pair here would hand the workflow a login slice and
+    an empty HAR.
+    """
+    from noui_core.capture.split import find_login_boundary, split_bundle
+
+    fake = FakeTabby({"log": {"entries": []}})
+    _patch(monkeypatch, fake)
+
+    ap = AutopilotSession("p", token="t")
+    ap.start_capture()
+    ap.navigate("https://x.com/a")
+    ap.click("#btn")
+    bundle = ap.finish()
+
+    assert find_login_boundary(bundle) is None
+    assert split_bundle(bundle) is None
+
+
+def test_clicks_and_navigations_interleave_in_one_total_order(monkeypatch):
+    """The point of numbering: a merged sort of both event lists reproduces the
+    order the driver drove them in. These bundles carry no wall clock, so `seq`
+    is the ONLY thing that can place a click relative to a route change."""
+    from noui_core.event_order import merged_order, order_events
+
+    fake = FakeTabby({"log": {"entries": []}})
+    _patch(monkeypatch, fake)
+
+    ap = AutopilotSession("p", token="t")
+    ap.start_capture()
+    ap.navigate("https://bank.test/home")
+    ap.click_text("Banking")
+    ap.click_text("Accounts")
+    ap.navigate("https://bank.test/accounts")
+    bundle = ap.finish()
+
+    assert merged_order(bundle["click_events"], bundle["url_events"])
+    merged = order_events(bundle["click_events"] + bundle["url_events"])
+    assert [e.get("text") or e.get("to_url") for e in merged] == [
+        "https://bank.test/home",
+        "Banking",
+        "Accounts",
+        "https://bank.test/accounts",
+    ]

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -470,3 +470,101 @@ def test_bare_anchor_is_not_a_route():
         login_url=f"{_B}/login",
     )
     assert [p["name"] for p in pages] == ["read_report"]
+
+
+# ---------------------------------------------------------------------------
+# Nav gestures are correlated by `seq`, not by wall clock
+# ---------------------------------------------------------------------------
+
+
+def _seq_url_ev(frm, to, seq, ts=None):
+    ev = {"from_url": frm, "to_url": to, "seq": seq}
+    if ts:
+        ev["timestamp"] = ts
+    return ev
+
+
+def _seq_click(url, text, seq, ts=None):
+    ev = {"event_type": "click", "url": url, "text_content": text, "seq": seq}
+    if ts:
+        ev["timestamp"] = ts
+    return ev
+
+
+def test_nav_gesture_causality_uses_seq_when_the_bundle_carries_it():
+    """A click made AFTER the route change cannot have caused it. `seq` is the
+    reliable ordering — it is assigned at interaction time, unlike the recorder's
+    input timestamps, and it survives events sharing a millisecond."""
+    pages = derive_browser_pages(
+        [
+            _seq_url_ev(f"{_B}/login", f"{_B}/home", 1),
+            _seq_url_ev(f"{_B}/home", f"{_B}/accounts", 3),
+        ],
+        [
+            _seq_click(f"{_B}/home", "Accounts", 2),
+            # A click back on /home AFTER the nav (browser back, then a re-click
+            # elsewhere) must not be folded into the gesture that reached /accounts.
+            _seq_click(f"{_B}/home", "Log out", 4),
+        ],
+        login_url=f"{_B}/login",
+    )
+    by_name = {p["name"]: p for p in pages}
+    assert [c["text"] for c in by_name["read_accounts"]["nav"]] == ["Accounts"]
+
+
+def test_seq_recovers_the_gesture_when_clicks_share_a_timestamp():
+    """Two clicks in the same millisecond are unorderable by timestamp — the
+    expand→navigate pair then compiles in whichever order they were recorded."""
+    same = "2026-01-01T00:00:04+00:00"
+    pages = derive_browser_pages(
+        [
+            _seq_url_ev(f"{_B}/login", f"{_B}/home", 1, "2026-01-01T00:00:01+00:00"),
+            _seq_url_ev(f"{_B}/home", f"{_B}/accounts", 4, "2026-01-01T00:00:05+00:00"),
+        ],
+        [
+            # Recorded in the wrong order; seq says Banking was clicked first.
+            _seq_click(f"{_B}/home", "Accounts", 3, same),
+            _seq_click(f"{_B}/home", "Banking", 2, same),
+        ],
+        login_url=f"{_B}/login",
+    )
+    by_name = {p["name"]: p for p in pages}
+    assert [c["text"] for c in by_name["read_accounts"]["nav"]] == ["Banking", "Accounts"]
+
+
+def test_undated_but_numbered_capture_recovers_the_whole_chain():
+    """An agent-driven capture numbers its events but records no wall clock. The
+    old code could not bound the gesture without timestamps and kept only the
+    last click; `seq` makes the order trustworthy, so the whole expand→navigate
+    chain survives (bounded by the trailing-click cap)."""
+    pages = derive_browser_pages(
+        [
+            _seq_url_ev(f"{_B}/login", f"{_B}/home", 1),
+            _seq_url_ev(f"{_B}/home", f"{_B}/accounts", 4),
+        ],
+        [
+            _seq_click(f"{_B}/home", "Banking", 2),
+            _seq_click(f"{_B}/home", "Accounts", 3),
+        ],
+        login_url=f"{_B}/login",
+    )
+    by_name = {p["name"]: p for p in pages}
+    assert [c["text"] for c in by_name["read_accounts"]["nav"]] == ["Banking", "Accounts"]
+
+
+def test_unnumbered_bundle_still_uses_timestamps():
+    """Regression guard: bundles recorded before `seq` keep the old behaviour."""
+    pages = derive_browser_pages(
+        [
+            _url_ev(f"{_B}/login", f"{_B}/home", "2026-01-01T00:00:01+00:00"),
+            _url_ev(f"{_B}/home", f"{_B}/accounts", "2026-01-01T00:00:05+00:00"),
+        ],
+        [
+            _click(f"{_B}/home", "Banking", "2026-01-01T00:00:03+00:00"),
+            _click(f"{_B}/home", "Accounts", "2026-01-01T00:00:04+00:00"),
+            _click(f"{_B}/home", "Log out", "2026-01-01T00:00:09+00:00"),  # after the nav
+        ],
+        login_url=f"{_B}/login",
+    )
+    by_name = {p["name"]: p for p in pages}
+    assert [c["text"] for c in by_name["read_accounts"]["nav"]] == ["Banking", "Accounts"]

--- a/tests/test_event_order.py
+++ b/tests/test_event_order.py
@@ -1,0 +1,94 @@
+"""Tests for noui_core.event_order — interaction ordering of recorded events.
+
+The bug these guard: Tabby's injected recorder debounces `input` by 500ms and
+builds the event payload inside that debounce, so `timestamp` records the FLUSH.
+A human who fills a field and clicks submit within 500ms — the ordinary login —
+produces a click stamped EARLIER than the input before it. `timestamp` keeps that
+meaning (existing consumers read it); the recorder now also emits `seq`, assigned
+at interaction time. These tests pin the consumer side to `seq` and to graceful
+degradation for bundles recorded before it existed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+if str(_NOUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(_NOUI_ROOT))
+
+from noui_core.event_order import event_seq, has_seq, merged_order, order_events
+
+
+class TestEventSeq:
+    def test_reads_the_ordinal(self) -> None:
+        assert event_seq({"seq": 7}) == 7
+        assert event_seq({"seq": 0}) == 0
+
+    def test_missing_or_malformed_is_none(self) -> None:
+        assert event_seq({}) is None
+        assert event_seq({"seq": None}) is None
+        assert event_seq({"seq": "3"}) is None
+        assert event_seq({"seq": 1.5}) is None
+        assert event_seq({"seq": -1}) is None
+        assert event_seq("not a dict") is None
+
+    def test_bool_is_not_an_ordinal(self) -> None:
+        # bool subclasses int — `seq: True` is a malformed event, not ordinal 1.
+        assert event_seq({"seq": True}) is None
+
+
+class TestHasSeq:
+    def test_all_numbered(self) -> None:
+        assert has_seq([{"seq": 1}, {"seq": 2}])
+
+    def test_empty_is_trivially_ordered(self) -> None:
+        assert has_seq([])
+        assert has_seq(None)
+
+    def test_partial_numbering_is_not_an_order(self) -> None:
+        # Mixing ordinals with list positions would silently reorder the rest.
+        assert not has_seq([{"seq": 1}, {"tag_name": "INPUT"}])
+
+
+class TestOrderEvents:
+    def test_sorts_by_seq(self) -> None:
+        evs = [{"seq": 3, "n": "c"}, {"seq": 1, "n": "a"}, {"seq": 2, "n": "b"}]
+        assert [e["n"] for e in order_events(evs)] == ["a", "b", "c"]
+
+    def test_recovers_a_debounced_fill_that_arrived_after_its_own_click(self) -> None:
+        # Arrival order: the click beat the 500ms input flush.
+        arrived = [
+            {"seq": 2, "event_type": "click", "text_content": "Sign in"},
+            {"seq": 1, "event_type": "input", "field_role": "password"},
+        ]
+        assert [e["event_type"] for e in order_events(arrived)] == ["input", "click"]
+
+    def test_unnumbered_bundle_keeps_recording_order(self) -> None:
+        evs = [{"n": "a"}, {"n": "b"}, {"n": "c"}]
+        assert [e["n"] for e in order_events(evs)] == ["a", "b", "c"]
+
+    def test_partially_numbered_bundle_keeps_recording_order(self) -> None:
+        evs = [{"seq": 9, "n": "a"}, {"n": "b"}]
+        assert [e["n"] for e in order_events(evs)] == ["a", "b"]
+
+    def test_ties_keep_recording_order(self) -> None:
+        evs = [{"seq": 1, "n": "a"}, {"seq": 1, "n": "b"}]
+        assert [e["n"] for e in order_events(evs)] == ["a", "b"]
+
+    def test_drops_non_dicts(self) -> None:
+        assert order_events([{"seq": 1}, "junk", None]) == [{"seq": 1}]
+
+    def test_does_not_mutate_the_input(self) -> None:
+        evs = [{"seq": 2, "n": "b"}, {"seq": 1, "n": "a"}]
+        order_events(evs)
+        assert [e["n"] for e in evs] == ["b", "a"]
+
+
+class TestMergedOrder:
+    def test_true_only_when_both_sides_are_numbered(self) -> None:
+        clicks = [{"seq": 1}]
+        urls = [{"seq": 2}]
+        assert merged_order(clicks, urls)
+        assert not merged_order(clicks, [{"to_url": "x"}])

--- a/tests/test_login_assets_event_order.py
+++ b/tests/test_login_assets_event_order.py
@@ -1,0 +1,103 @@
+"""The login DSL must follow INTERACTION order, not recording order.
+
+Tabby's injected recorder debounces `input` by 500ms. A human who fills a field
+and clicks submit inside that window flushes the input AFTER the click, so the
+bundle's list order — and its `timestamp`, which records that flush — put "click
+Sign in" before the fill it submitted. A login DSL compiled in that order clicks
+submit on an empty form. `seq`, assigned at interaction time, is the order the
+compiler must use; `timestamp` keeps its flush meaning for existing consumers.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_NOUI_ROOT = Path(__file__).resolve().parent.parent
+if str(_NOUI_ROOT) not in sys.path:
+    sys.path.insert(0, str(_NOUI_ROOT))
+
+from noui_core.compile.login_assets import generate
+
+_SESSION = {"id": "sess-1", "app_name": "acme", "login_url": "https://acme.example.com/login"}
+_URLS = [{"from_url": "", "to_url": "https://acme.example.com/login", "seq": 1}]
+
+
+def _fill(seq: int, name: str, role: str, ts: str) -> dict:
+    return {
+        "event_type": "input",
+        "tag_name": "INPUT",
+        "element_id": name,
+        "field_name": name,
+        "field_role": role,
+        "input_type": "password" if role == "password" else "text",
+        "selector": f"#{name}",
+        "url": "https://acme.example.com/login",
+        "value": "[REDACTED]",
+        "is_redacted": True,
+        "seq": seq,
+        "timestamp": ts,
+    }
+
+
+def _submit_click(seq: int, ts: str) -> dict:
+    return {
+        "event_type": "click",
+        "tag_name": "BUTTON",
+        "element_id": "signin",
+        "text_content": "Sign in",
+        "selector": "#signin",
+        "url": "https://acme.example.com/login",
+        "seq": seq,
+        "timestamp": ts,
+    }
+
+
+def _actions(clicks: list[dict]) -> list[str]:
+    result = generate(_SESSION, clicks, _URLS, manual_credentials=False)
+    return [s["action"] for s in result["application_draft"]["login_config"]["steps"]]
+
+
+def _fill_selectors(clicks: list[dict]) -> list[str]:
+    result = generate(_SESSION, clicks, _URLS, manual_credentials=False)
+    return [
+        s.get("selector")
+        for s in result["application_draft"]["login_config"]["steps"]
+        if s["action"] in ("fill", "click")
+    ]
+
+
+class TestDebouncedFillOrdering:
+    # Arrival order: the click beat the 500ms input flush, and the flush stamped
+    # the fill 400ms AFTER the click it preceded.
+    _AS_RECORDED = [
+        _fill(1, "username", "username", "2026-01-01T00:00:00.100Z"),
+        _submit_click(3, "2026-01-01T00:00:01.000Z"),
+        _fill(2, "password", "password", "2026-01-01T00:00:01.400Z"),
+    ]
+
+    def test_fills_precede_the_submit_click(self) -> None:
+        assert _actions(self._AS_RECORDED) == ["goto", "fill", "fill", "click"]
+
+    def test_password_fill_is_not_stranded_after_the_click(self) -> None:
+        assert _fill_selectors(self._AS_RECORDED) == ["#username", "#password", "#signin"]
+
+    def test_timestamp_order_would_have_compiled_the_click_first(self) -> None:
+        # Guards the premise: sorting this bundle by timestamp — or trusting its
+        # list order — puts the submit ahead of the password it submitted.
+        by_ts = sorted(self._AS_RECORDED, key=lambda e: e["timestamp"])
+        assert [e["event_type"] for e in by_ts] == ["input", "click", "input"]
+
+
+class TestUnnumberedBundles:
+    """Bundles recorded before `seq` existed keep the previous behaviour."""
+
+    def test_recording_order_is_preserved(self) -> None:
+        clicks = [
+            {**_fill(0, "username", "username", "2026-01-01T00:00:00.100Z"), "seq": None},
+            {**_fill(0, "password", "password", "2026-01-01T00:00:00.500Z"), "seq": None},
+            {**_submit_click(0, "2026-01-01T00:00:01.000Z"), "seq": None},
+        ]
+        for c in clicks:
+            del c["seq"]
+        assert _actions(clicks) == ["goto", "fill", "fill", "click"]

--- a/tests/test_split_bundle.py
+++ b/tests/test_split_bundle.py
@@ -120,6 +120,63 @@ class TestSplit:
         assert login["session_id"] == workflow["session_id"] == "sess-1234abcd"
 
 
+class TestSeqOrdering:
+    """`seq` decides the boundary when the bundle carries it — timestamps place a
+    debounced credential fill up to 500ms late, which can drag the boundary past
+    the landing nav and hand the login's own submit to the workflow slice."""
+
+    @staticmethod
+    def _numbered() -> dict:
+        """The merged bundle, with the password fill's TIMESTAMP flushed late.
+
+        The 500ms debounce stamps the password at T[5] — after the landing nav at
+        T[4] — while `seq` records that the human typed it before submitting.
+        """
+        b = _merged_bundle()
+        order = [
+            (b["url_events"][0], 1),  # → /login
+            (b["click_events"][0], 2),  # username
+            (b["url_events"][1], 3),  # → /enterpassword
+            (b["click_events"][1], 4),  # password (timestamp lands at T[5])
+            (b["click_events"][2], 5),  # submit
+            (b["url_events"][2], 6),  # → /dashboard   ← the boundary
+            (b["url_events"][3], 7),  # → /reports
+            (b["click_events"][3], 8),  # workflow interaction
+        ]
+        for ev, seq in order:
+            ev["seq"] = seq
+        b["click_events"][1]["timestamp"] = T[5]
+        return b
+
+    def test_boundary_uses_seq_not_the_late_flush_timestamp(self) -> None:
+        # On timestamps alone the last credential is T[5], past every nav, so the
+        # boundary would collapse onto the fill itself.
+        assert find_login_boundary(self._numbered()) == T[4]
+
+    def test_login_slice_keeps_the_late_stamped_password_fill(self) -> None:
+        login, workflow = split_bundle(self._numbered())
+        assert "password" in {c.get("field_role") for c in login["click_events"]}
+        assert "password" not in {c.get("field_role") for c in workflow["click_events"]}
+
+    def test_workflow_slice_still_excludes_the_login_submit(self) -> None:
+        _, workflow = split_bundle(self._numbered())
+        wf_urls = [e["request"]["url"] for e in workflow["har"]["log"]["entries"]]
+        assert "https://app.example.com/login" not in wf_urls
+
+    def test_slices_still_partition_without_overlap(self) -> None:
+        b = self._numbered()
+        login, workflow = split_bundle(b)
+        assert len(login["click_events"]) + len(workflow["click_events"]) == len(b["click_events"])
+        assert len(login["url_events"]) + len(workflow["url_events"]) == len(b["url_events"])
+
+    def test_partially_numbered_bundle_falls_back_to_timestamps(self) -> None:
+        # One un-numbered event means seq is not a total order for this bundle.
+        b = self._numbered()
+        b["click_events"][1]["timestamp"] = T[2]  # undo the late flush
+        del b["url_events"][0]["seq"]
+        assert find_login_boundary(b) == T[4]
+
+
 class TestRealFixture:
     """Sanity check against a real captured bundle (recorded recording_mode=login)."""
 


### PR DESCRIPTION
## Why

Tabby's injected DOM recorder debounces `input` by 500ms and builds the event payload **inside** that debounce, so an input's `timestamp` is the **flush**, not the keystroke. A field filled and submitted inside that window — the ordinary login — is stamped *after* the click that submitted it, and arrives after it too.

The login compiler emits its DSL in list order, so that recording compiled to:

```
goto, fill, click, fill
```

It clicks "Sign in" on a half-empty form, then fills the password. Verified directly against `login_assets.generate` — the same events with and without ordinals:

```
pre-fix (list/timestamp order): ['goto', 'fill', 'click', 'fill']
with seq:                       ['goto', 'fill', 'fill', 'click']
```

Tabby now also emits `seq` — a single strictly-increasing ordinal assigned at interaction time and shared by click and url events (adoptai/tabby#claude/relaxed-goldberg-fc2059). This consumes it.

## What changed

New **`noui_core/event_order.py`** — `event_seq` / `has_seq` / `order_events` / `merged_order`. `has_seq` is all-or-nothing on purpose: a partially numbered list has no consistent order, and mixing ordinals with list positions would silently reorder the un-numbered events.

- **`login_assets.generate`** sorts `click_events` by `seq` before the dedup and step-mapping loop. This is what fixes the DSL order above — the dedup only collapses *consecutive* runs, so a mis-ordered list compiles a mis-ordered login.
- **`browser_skill._nav_clicks_for`** now takes the url event rather than just its timestamp, and decides both causality (*a click after the nav cannot have caused it*) and ordering on `seq`. The 20s gesture window stays wall-clock — it has no ordinal equivalent — and when a capture is numbered but undated the trailing-`_NAV_MAX_CLICKS` cap bounds the chain instead. `derive_browser_pages` orders both lists first, since page selection is first-seen order and nav gestures are read positionally.
- **`capture.split`** resolves the login/workflow boundary on `seq`. This is the case timestamps actively break: a debounced credential fill stamped up to 500ms late drags the boundary *past* the landing nav and hands the login's own form-submit request to the workflow slice, where it would be compiled into an operation. New `_boundary_event()` returns both keys; events cut on `seq`, HAR entries still cut on `startedDateTime` since they carry no ordinal. `find_login_boundary()` keeps its `str | None` signature, so `classify.py` and its callers are untouched.
- **`autopilot`** numbers its driven clicks and navigations from one shared counter, so agent-driven captures are orderable too — they record no wall clock at all, making `seq` the only thing that can place a click relative to a route change.

## Backward compatibility

`timestamp` is untouched on the Tabby side, so this is a *preference*, not a switch. `event_order` detects `seq` **per event** and falls back to the previous list/timestamp behaviour, so pre-`seq` recordings compile exactly as before — `split` falls back to the timestamp comparison, `_nav_clicks_for` to the timestamp window.

Detection is per event rather than off the bundle's `schema_version` because `capture.bundle`'s `/clicks` projection can drop `seq` in transit: the bundle can say version 2 while the events in hand carry no ordinal.

## Tests

684 pass; `ruff check` and `ruff format --check` clean. New coverage:

- `tests/test_event_order.py` — the helpers, including that a partially numbered list is not treated as an order and that `seq: True` is malformed rather than ordinal 1.
- `tests/test_login_assets_event_order.py` — fills precede the submit click; the timestamp-order premise is pinned so the test can't quietly stop discriminating.
- `test_split_bundle.py::TestSeqOrdering` — a bundle whose password fill is flushed *after* the landing nav. Confirmed the assertion discriminates: boundary is `T[6]` without `seq`, `T[4]` with.
- `test_browser_skill.py` — seq-based causality, two clicks sharing a millisecond, undated-but-numbered captures, and a regression guard that unnumbered bundles still use timestamps.
- `test_autopilot_capture.py` — interleaved numbering, and a guard that a numbered autopilot bundle still yields `split_bundle is None` (it records no `field_role`). Without that guard, numbering could have made a driven capture look like it had a login segment and handed the workflow compiler an empty HAR.

## Two things left deliberately undone

**`capture/bundle.py::_CLICK_FIELDS`** does not project `seq`. The comment there explains why: it maps onto a backend `ClickEventCreate` schema that isn't in this repo, so I couldn't verify it accepts the field, and adding it risked a 422. The direct bundle → compiler path keeps `seq`; only a round trip through `/clicks` loses it, degrading to list order. Worth adding once the backend column exists.

**Autopilot click events don't match the compiler's field shape** — a pre-existing gap, unrelated to `seq` and not fixed by it. They carry `text` where the compiler reads `text_content`, and no `url` at all, so `_nav_clicks_for` never sees them:

```
clicks: [{'event_type': 'click', 'text': 'Banking', 'seq': 2}, ...]
pages:  [('read_home', None)]
```

An autopilot capture of home → Banking → Accounts compiles to just `read_home`; every non-landing page gets `nav = []` and is dropped by `_resolve_nav_chains`. Making `_record_click` emit `text_content` and stamp `self._current_url` would close it, but that changes what autopilot-driven browser skills compile to, so it's left as a separate call. (`_CLICK_FIELDS` shows the same divergence — it lists `text_content`, not `text`.)

I first wrote a test claiming `seq` unlocked gesture recovery for autopilot; it only passed because it rewrote the events, so I pulled it and replaced it with one that pins what numbering actually buys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
