### PR TITLE
feat(noui): compile browser skills from recorded evidence, and prove them by replay

### DIFF
--- a/docs/browser-skill-evidence-STATUS.md
+++ b/docs/browser-skill-evidence-STATUS.md
@@ -1,0 +1,118 @@
+# Browser-Skill Evidence: Compile & Prove-by-Replay — Status & Gaps
+
+**PR:** [adoptai/noui#139](https://github.com/adoptai/noui/pull/139) ·
+**Branch:** `feat/browser-skill-evidence` · **Updated:** 2026-08-14
+
+Companion feature in tabby:
+[adoptai/tabby#163](https://github.com/adoptai/tabby/pull/163) (records the
+evidence this branch compiles from). See that PR's
+`docs/workflow-recording-capture-STATUS.md` for the capture side.
+
+A living reference: what the feature does, what we hardened, and the gaps still
+worth fixing. Update it as gaps close.
+
+---
+
+## What this feature delivers
+
+Turn a **recording of a human doing a workflow** into a **browser skill**
+(`operations.json` + `SKILL.md`), then **prove it by replaying against a live
+session** before anything installs — so a skill is backed by observed evidence,
+not hand-written selectors.
+
+- **Compile from evidence** — each recorded page becomes a read operation;
+  downloads/submits become terminal operations; the click chain to reach a page
+  is reused so the session is never reloaded.
+- **Parameters from recorded inputs** — recorded dates/years/amounts/selects
+  become operation parameters (recorded value as default), so "last month"'s
+  capture can fetch "last year". Credentials and placeholder `<select>` values are
+  never parameters.
+- **Locator provenance** — the compiled skill is bound to the recording by digest;
+  `unobserved_locators` refuses a skill whose steps target controls the recording
+  never saw (catches hand-edited/fabricated operations). Digest vectors are pinned
+  in **both repos**.
+- **Replay = the real thing** — replay starts where a real run starts (session
+  provisioned from profile, post-login landing), runs each operation, and shows
+  the human what happened.
+- **Risk gate** — `classify_risk` stops a step that moves money / is irreversible
+  / touches a control the human never touched, and hands it back for explicit
+  approval, so an improvising agent can't reach Pay/Transfer while hunting a
+  statement.
+- **Goal check** — `goal_reached` judges a download by its *file*, not by "every
+  step passed" (an all-green download that produced no file has not succeeded).
+- **Member approval + amendments** — install is gated on a member approving the
+  replay; `check_installable` refuses unapproved amendments, matching the harness
+  gate.
+- **Segments** — each operation replays as its own segment (no full-chain
+  duplication).
+
+Honours tabby recording **`schema_version 5`**; pre-5 bundles must compile exactly
+as they did.
+
+---
+
+## What we hardened (this review round → `c26680c`)
+
+| Ref | Area | Fix |
+|----|------|-----|
+| N1 | `compile/login_assets.py` | `_before_first_click` dropped the post-login landing for the **standard form login** (the "Log In" click itself triggers the redirect). Now extends the login segment to that redirect when nothing landed before the first click; SSO/auto-submit unchanged. |
+| N2 | `verify/replay.py` | `classify_risk` **failed open** on a control it couldn't identify — `click_at` (coords) / `press_key` (focused element) carry no selector/label/text, so both risk grounds skipped them. Now fail-closed for any control action with no identity; page/browser commands (navigate, scroll, har, get_download) are allow-listed. |
+| N3 | `verify/replay.py` | `_RISKY_TEXT` widened: `withdraw, payee, beneficiary, loan, purchase, buy, sell, invest, redeem, wire`. |
+| N4 | `compile/parameters.py` | `_CREDENTIAL_ROLES` was `{password, otp}`, narrower than canonical `CREDENTIAL_FIELD_ROLES` — an unredacted `unknown_sensitive` field (a re-entered PIN) could compile to a plaintext default. Now reuses the canonical set (adds `username`, `unknown_sensitive`). |
+| N5 | `compile/browser_skill.py` | `_terminal_kind` gated `download` on `outcome` but not `submit`, so a pre-schema-5 non-login submit compiled a **new** operation, breaking backward-compat. Now gates `submit` on `outcome` presence too. |
+| N6 | `compile/provenance.py`, `scripts/verify_replay.py` | Added `unbacked_control_steps`: a control-acting step with **no locator** would contribute nothing to `unobserved_locators` and "verify" against any bundle. Now refused. (Latent — the compiler never emits such steps — defense-in-depth.) |
+
+Earlier hardening already on the branch (highlights): dropdown = chosen not
+clicked (`dba2795`, `5a68999`), radio bound to the submitting gesture (`2586503`,
+`5d7decd`), account numbers refused into skills (`cf4af67`), hover-reveal folded
+into one step (`954b966`, `4ca4ff4`), replay judged by the file and this-run
+freshness (`84d68e4`, `655fbdc`), segments replacing full-chain duplication
+(`98fe50b`, `6d34e4c`), Tabby-unreachable no longer crashes/loses amendments
+(`fb0e395`, `ea8327f`), `check_installable` refuses unapproved amendments
+(`c8a45c1`).
+
+---
+
+## Open gaps that need attention
+
+| ID | Sev | Location | Issue | Recommended direction | Status |
+|----|-----|----------|-------|-----------------------|--------|
+| **G1** | Med / correctness | `compile/browser_skill.py` (terminal ops for the ICICI statement) | **Inter-operation statement toggling.** The ICICI infinity flow reloads the statement page (defaults to *Monthly*) and sets *Annual* in `submit_..._2` and again in `download_...`, so replay cycles monthly→annual→monthly→annual. An intra-op de-dupe was tried and **abandoned** (validated only against *stale* accumulated downloads; it does **not** stop the *inter-operation* toggling). | Needs a fresh-download validation and a cross-operation approach — likely collapsing the redundant reload+set when a later terminal subsumes an earlier one, or checking `_truncate_reads_at_terminals` for the subsumed case. Not a clean intra-op fix. | **OPEN** (experiment reverted; not on branch) |
+| **G2** | Med / limitation | `verify/session.py` `_return_to_entry` | **Cross-origin replay reset.** On navigate-forbidden apps (ICICI) the replay can't reset between operations: `navigate` is blocked, `go_back` kills the session, and there's no way-back link from corp/Finacle to corp/AuthenticationController. Download works because it starts where the browser already sits. | Fundamental for such portals. Options: replay operations in an order that never needs a reverse jump, or accept per-portal "cannot reset" and segment accordingly. (User deferred: "ignore" for now.) | **OPEN / deferred** |
+| **G3** | Med / cross-repo | install path (workflows/webui/design-system) | **Member-approval token not produced in Studio Playground.** The install gate (`_member_approved_replay`, workflows #1552) requires a fingerprint-bound approval token in the member's turn, minted by the **skill-replay card** (design-system #17, wired in webui #1631). In the Studio Playground run, the card was **never emitted** (0 in transcript) and the local frontend pins `genui-components 0.1.76` while the card shipped in `0.1.78`, so approval fell back to a plain-text "yes install" → no token → install refused ~24×. | Ensure the Studio/Playground path emits the skill-replay card and the frontend ships the card version, OR provide an alternate token path for that flow. This blocks install end-to-end in that environment even when record→compile→replay→approve all pass. | **OPEN** (RCA done this session) |
+| **G4** | Low / follow-up | amendments | **Amendment-baking follow-up.** Tracked separately (scheduled). | Land the amendment-baking PR. | **OPEN / scheduled** |
+
+---
+
+## Known limits (deliberate, not bugs)
+
+- **N2 fail-closed scope.** The risk gate only allow-lists `navigate, scroll_page,
+  wait_for_url, har_*, get_download` as legitimately control-less. A genuinely new
+  control-less command added later would be treated as risky until added to the
+  list — intentional (fail closed), but worth remembering when adding commands.
+- **N6 is latent.** The shipped compiler never emits keyless control actions, so
+  `unbacked_control_steps` only ever fires on hand-authored operations. Kept as a
+  guard, not a hot path.
+
+---
+
+## Cross-repo dependency chain
+
+Record (tabby #163) → **compile + replay (this PR)** → replay card
+(design-system #17) → card wiring (adoptwebui #1631) → install gate
+(adoptai-workflows #1552). The provenance **fingerprint/digest vectors are pinned
+in both this repo and adoptai-workflows** — if the two implementations drift,
+every real skill is refused. See G3 for the current end-to-end install blocker.
+
+---
+
+## Verify
+
+```bash
+poetry run python -m pytest tests/test_replay.py tests/test_parameters.py \
+  tests/test_login_landing_url.py tests/test_browser_skill.py \
+  tests/test_provenance.py tests/test_compile_is_stable.py \
+  tests/test_nothing_recorded_is_silently_dropped.py tests/test_migrate_provenance.py -q
+poetry run ruff check skills/noui/ && poetry run ruff format --check skills/noui/ tests/
+poetry run mypy skills/noui/noui_core/          # optional group
+```

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -220,6 +220,39 @@ The same goes for selectors: never substitute your own for a recorded one. The
 recorded one was verified to match a single element on the live page; yours was
 not.
 
+### Replay before installing — this is a GATE, not a report
+
+A browser skill installs only after a member has seen it run. `install_skill`
+REFUSES one that carries no approved replay, so this is not optional:
+
+```bash
+# 1. Replay the compiled draft against a live session. Writes replay_report.json.
+python scripts/verify_replay.py workbench/skills/<app> --profile-slug <slug>
+#    Exit 2 = no signed-in session: show the sign-in card, then run it again.
+#    Nothing is installed, and the report is never self-approving.
+
+# 2. SHOW the member the report (the skill-replay card) and get their answer.
+
+# 3. Only if they approve:
+python scripts/verify_approve.py workbench/skills/<app>
+
+# 4. Now install.
+```
+
+If they ask for a change, amend the workflow, recompile, and **replay again** —
+the approval is tied to a fingerprint of the plan, so an amended skill no longer
+matches and the installer refuses. That is what makes their confirmation
+binding rather than advisory.
+
+Replay uses the profile's own Tabby session, which means one sign-in the member
+has to do. That is deliberate: it is exactly how the skill will run once
+installed, so a pass means what it appears to mean, and it also proves the
+profile's login and keepalive can sustain a session on this app at all.
+
+Do not approve on the member's behalf. The file is the record of a human
+decision; writing it because the replay looked fine to you defeats the whole
+gate, and the failures this exists to catch are the ones that look fine.
+
 ### Check these before installing
 
 0. **Is the goal in there at all?** Before anything else: does an operation
@@ -311,6 +344,8 @@ the ICICI build, twice.
 | `compile_login.py` | 2 | Compile a saved login bundle → App/ServiceProfile drafts |
 | `activate_register.py` | 3 | Register a compiled login result with Tabby as a tenant-wide App Template |
 | `activate_verify.py` | 3 | Deterministic auth dry-run on a generated MCP server |
+| `verify_replay.py` | 2→3 | Replay a compiled browser draft against a live session; writes `replay_report.json` |
+| `verify_approve.py` | 3 | Record the member's approval of a replay, so the skill may be installed |
 | `activate_install.py` | 3 | Install a generated skill into an agent (agnostic) |
 
 ---

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -400,6 +400,28 @@ rather than left to review.
 Never hand-write `operations.json`, `manifest.json`, `recording_bundle.json` or
 `replay_approval.json`. Record, compile, replay, and let the member approve.
 
+### After compiling, do not "generalize" the operations
+
+Renaming an operation, rewording a description, adding a parameter: fine. Those
+do not change what runs.
+
+Rewriting the steps is not. Locators, step order and which operations exist come
+from the recording, and nothing else can supply them. A rewritten step targets a
+control nobody watched resolve, so at replay the run misses, improvises, and
+wanders — clicking, screenshotting, hunting a nav it will not find. Both the
+replay gate and the installer now refuse operations whose steps were never
+observed, so a rewrite costs a whole live session and installs nothing.
+
+**A URL containing a session token is NOT a bug to fix.** A browser skill never
+navigates to the URL in an operation — the URL only names the page, and the page
+is reached by replaying the recorded click chain. One build saw a `UX_TOKEN` in a
+compiled URL, concluded the operation was broken, rewrote all three operations
+into four (inventing two that were never recorded), and lost the click chains
+that were the only thing that worked. It fixed a non-bug and broke the skill.
+
+If a compiled operation really is wrong, the fix is to re-record that part. It is
+never to write the steps you think it should have had.
+
 ### Migrating a browser skill compiled before provenance
 
 A browser skill built before the installer started checking provenance has no

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -158,6 +158,86 @@ Full playbook: `references/generalize.md`.
 
 ---
 
+## Browser-driven skills: what the recording gives you, and what not to hand-write
+
+Some apps cannot be replayed — they encrypt request bodies in page JavaScript or
+mint per-session headers, so a recorded request is dead the moment the recording
+ends (ICICI is the canonical case: 40 replayed operations that all 403). Those
+compile **browser-driven**: the skill drives the live page and reads what it
+renders. `detect_unreplayable` decides this automatically; `--browser-driven`
+forces it, `--no-auto-browser` disables the detection.
+
+### Declare it at capture time when you already know
+
+Pass `browser_driven=True` when provisioning the recording (or `--browser-driven`
+to `capture_record.py`) **only when the kind is already known** — the user asked
+for a browser skill, or replay is known to fail on this app. It tells Tabby to
+reduce the workflow HAR to metadata, which keeps a bank's balances, account
+numbers and live tokens out of the bundle.
+
+Leave it off for anything unknown. It is the skill KIND, not the capture phase: a
+workflow recording of an ordinary REST app compiles by replay and needs the full
+HAR. Record full, let `detect_unreplayable` decide, re-record with the flag if
+you want the reduction.
+
+### What a workflow recording now carries
+
+Bundles from Tabby `schema_version >= 5` capture far more than a click list:
+
+- **`candidates`** on each interaction — several ways to address the element
+  (test-id, id, name, aria-label, role+name, label, text, css path), each with
+  `match_count`: how many nodes it matched **at record time**. A candidate that
+  matched more than one node cannot identify that element, and the compiler will
+  not silently prefer it.
+- **`element`** — role, accessible name, visibility, and whether something was
+  painted over it (the overlay that swallows a click).
+- **`outcome`** — what the interaction caused: navigation and where to, requests
+  fired, when they settled, whether a download started.
+- **`download_events`** and popup/new-tab capture, with `page_id` per document.
+
+### What the compiler emits from it
+
+- **read** operations — one per data page, reached by replaying the recorded
+  click chain (never a `navigate`; see below).
+- **download** and **submit** operations — goals that finish *without* landing on
+  a new page. A download closes with `list_downloads`, because the file is the
+  result.
+- **parameters** — values the human typed become arguments, with the recorded
+  value as the default. Steps carry `{{placeholders}}`.
+- **expectations** — the URL a step should reach, whether a file should arrive,
+  how long traffic took to settle.
+
+### Do not hand-write what the compiler can emit
+
+If the download operation you expect is missing, that means **the recording did
+not capture the evidence** — not that you should write the operation yourself. A
+hand-written operation has no verified selector, no expectation and no parameter,
+so it is exactly the thing that fails in production while looking fine at build
+time. Re-record the flow so the click that produces the file is captured, then
+recompile.
+
+The same goes for selectors: never substitute your own for a recorded one. The
+recorded one was verified to match a single element on the live page; yours was
+not.
+
+### Check these before installing
+
+1. **Ambiguous steps.** SKILL.md lists any whose locator matched several
+   elements. Those misclick. Re-record them rather than shipping them.
+2. **Missing parameters.** If the user will ask for "last year" and the operation
+   has no parameter, the recording did not include a field the value came from —
+   check whether the app uses a date picker (clicks, not a typed value), which
+   cannot be parameterised from the recording alone.
+3. **Dropped pages.** A page whose click chain could not be recovered is dropped
+   deliberately, because an operation that claims to read one page and reads
+   another is worse than a missing one. Re-record the hop.
+4. **`block_navigate`.** For portals that die on a reload (ICICI, HSBCnet), set
+   `browser_policy.block_navigate` on the App Template. `navigate` is a full page
+   load; on those apps it destroys the session mid-task. With the flag set Tabby
+   refuses the command and tells the agent to click instead.
+
+---
+
 ## Script reference
 
 | Script | Pillar | Purpose |
@@ -199,7 +279,7 @@ capture's content. It prints which source won.
 
 ## Capture bundles are always saved (keep them)
 
-Every capture (`capture_autopilot.py` and `capture_import.py`) **persists the raw bundle** — `{har, click_events, url_events}` — to `workbench/bundles/<name>.json`. **Do not discard it.** The bundle, not the compiled asset, is the source of truth for *generalizing* and *regenerating* the asset later: renaming tools, parameterizing request bodies (e.g. recovering a GraphQL query body), dropping telemetry/ad calls, or fixing anti-bot issues. A compiled MCP/Skill cannot be re-generalized; its bundle can — recompile with `compile_workflow.py <bundle.json>`. Recording bundles also expire server-side (Tabby TTL), so the local copy is the only durable one.
+Every capture (`capture_autopilot.py` and `capture_import.py`) **persists the raw bundle** — `{har, click_events, url_events, download_events}` — to `workbench/bundles/<name>.json`. **Do not discard it.** The bundle, not the compiled asset, is the source of truth for *generalizing* and *regenerating* the asset later: renaming tools, parameterizing request bodies (e.g. recovering a GraphQL query body), dropping telemetry/ad calls, or fixing anti-bot issues. A compiled MCP/Skill cannot be re-generalized; its bundle can — recompile with `compile_workflow.py <bundle.json>`. Recording bundles also expire server-side (Tabby TTL), so the local copy is the only durable one.
 
 ---
 

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -222,6 +222,10 @@ not.
 
 ### Check these before installing
 
+0. **Is the goal in there at all?** Before anything else: does an operation
+   exist that does what the user asked for? A missing `download` operation means
+   the recording missed it — re-record, never hand-write. See "Telling the human
+   what to record".
 1. **Ambiguous steps.** SKILL.md lists any whose locator matched several
    elements. Those misclick. Re-record them rather than shipping them.
 2. **Missing parameters.** If the user will ask for "last year" and the operation
@@ -235,6 +239,63 @@ not.
    `browser_policy.block_navigate` on the App Template. `navigate` is a full page
    load; on those apps it destroys the session mid-task. With the flag set Tabby
    refuses the command and tells the agent to click instead.
+
+---
+
+## Telling the human what to record
+
+You are about to hand a person a viewer link and a list of steps. What you write
+there decides what the recording contains, and therefore what the skill can ever
+do. A real ICICI build failed entirely at this step: the agent had never seen the
+app, but wrote
+
+> Click the PDF format toggle → Click the DOWNLOAD button
+> ⚠️ Don't click "View Statement", "E-Statement" …
+
+The actual route to an annual statement is *Past → Download Previous Statement →
+a second host → Annual → PDF*. The instruction prescribed a flow that fetches
+only the current month and **explicitly forbade the one that works**, so the human
+followed it, the capture missed the whole download path, and the compiled skill
+could not do the one thing it existed for. Nobody noticed until run time.
+
+**Describe the GOAL, not the clicks.** You have not seen this app. Any specific
+control you name is inferred, and a wrong guess is worse than no guess because
+the human will follow it. "Download the annual credit-card statement for the last
+financial year" is a complete instruction. "Click the PDF toggle, then DOWNLOAD"
+is a guess wearing the clothes of an instruction.
+
+**Never tell the human to avoid part of the app.** You cannot know which link is
+the dead end and which is the route. A prohibition you got backwards removes the
+only path there is.
+
+**Say to keep going until the thing actually happens** — the file lands, the
+confirmation renders, the value appears on screen. A recording that stops one
+step short compiles into a skill that stops one step short, and that is exactly
+the shape of the failure that is hardest to see afterwards: everything looks
+captured, and the last step is missing.
+
+**Warn about what breaks a capture, not about which buttons to press.** The
+useful warnings are: stay in the same window, do not reload or close it, let slow
+pages finish loading (a bank often hands off to a second host, and that hop must
+be recorded), and click "Finish & export" only once the goal is complete.
+
+**Ask rather than assume.** If you genuinely need the route — because the goal is
+ambiguous, not because you want to script it — ask the human how they normally do
+it, then repeat it back as *their* description. Do not convert it into a click
+list of your own invention.
+
+### After compiling, check the goal is actually in there
+
+Read the compiled operations before installing and ask: **is there an operation
+that does the thing the user asked for?**
+
+If the goal was "download the statement" and no `download` operation was
+emitted, the recording did not capture it — the human stopped early, or was sent
+down the wrong path. **Re-record.** Do not write the operation by hand: a
+hand-written operation has no verified selector, no expectation and no parameter,
+it is never replayed against the live page before shipping, and it fails in
+production while looking correct in review. That is precisely what happened on
+the ICICI build, twice.
 
 ---
 

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -384,6 +384,22 @@ Do NOT run `capture_record.py`. Do NOT open a `?mode=recording` viewer. If you
 find yourself about to say "click Finish & export" when the member asked to sign
 in, you have reached for the wrong session.
 
+### A browser skill must come from a recording — the installer checks
+
+The compiler writes `recording_bundle.json` beside the skill and stamps its
+digest into `manifest.json` as `provenance`. The installer verifies both: that
+the recording is there and still hashes to the stamp, and that **every locator
+the operations drive was actually observed in it**.
+
+So a browser skill cannot be authored by hand, and adding the provenance fields
+by hand does not help — there is no recording behind them. A selector written
+from how a page probably looks reads exactly as plausibly as a real one; only
+the recording knows which ever resolved, which is why this is checked by machine
+rather than left to review.
+
+Never hand-write `operations.json`, `manifest.json`, `recording_bundle.json` or
+`replay_approval.json`. Record, compile, replay, and let the member approve.
+
 ### A missing session is a WAIT, not a failure to work around
 
 When replay reports `login_required`, the correct next action is to **tell the

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -167,18 +167,30 @@ compile **browser-driven**: the skill drives the live page and reads what it
 renders. `detect_unreplayable` decides this automatically; `--browser-driven`
 forces it, `--no-auto-browser` disables the detection.
 
-### Declare it at capture time when you already know
+### Declare it at capture time when the user already told you
 
-Pass `browser_driven=True` when provisioning the recording (or `--browser-driven`
-to `capture_record.py`) **only when the kind is already known** — the user asked
-for a browser skill, or replay is known to fail on this app. It tells Tabby to
-reduce the workflow HAR to metadata, which keeps a bank's balances, account
-numbers and live tokens out of the bundle.
+**If the request says "browser based", "browser-driven", or names an app you
+already know cannot be replayed, pass `--browser-driven` to `capture_record.py`.**
+The user saying so IS the kind being known — there is nothing further to wait
+for, and `detect_unreplayable` will only agree with them later.
 
-Leave it off for anything unknown. It is the skill KIND, not the capture phase: a
-workflow recording of an ordinary REST app compiles by replay and needs the full
-HAR. Record full, let `detect_unreplayable` decide, re-record with the flag if
-you want the reduction.
+This was missed on a request that opened with the words "NOUI BROWSER BASED
+skill", because the guidance below reads as an argument for leaving it off. It is
+not: the caution applies to captures whose kind is genuinely unknown.
+
+What it buys, on a bank especially: Tabby reduces the workflow HAR to metadata,
+keeping balances, account numbers and live tokens out of the bundle entirely.
+That is a privacy property you cannot add afterwards — the bodies are either
+captured or they are not.
+
+Locator evidence is captured either way now (a combined capture always requests
+it), so forgetting the flag no longer makes a recording uncompilable. It did
+once: a capture came back with 718 HAR entries and no click interactions, and the
+whole recording had to be done again.
+
+Leave it off only when the kind is genuinely unknown. It is the skill KIND, not
+the capture phase: a workflow recording of an ordinary REST app compiles by
+replay and needs the full HAR. Record full, let `detect_unreplayable` decide.
 
 ### What a workflow recording now carries
 

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -412,6 +412,26 @@ rather than left to review.
 Never hand-write `operations.json`, `manifest.json`, `recording_bundle.json` or
 `replay_approval.json`. Record, compile, replay, and let the member approve.
 
+### Confirm the KIND at import, before installing
+
+The import prints one of:
+
+```
+KIND: browser-driven — ...
+KIND: replay (call_web_api) — auto-detected: ...
+```
+
+Auto-detection is the default and is usually right, but nobody chose it. When
+the line is followed by CONFIRM THE KIND, say which was chosen and why, and ask
+the member before installing. If they asked for a browser skill — or the app
+signs or encrypts requests in the page, so replay will 403 later — re-import
+with `--browser-driven`.
+
+This is not a formality. A capture asked for as a "BROWSER BASED skill" compiled
+to two replayed Finacle POSTs, and nothing said a decision had been taken.
+Changing the kind afterwards means compiling again, and a replay skill that
+looks fine today fails the first time the app rotates what it signs.
+
 ### After compiling, do not "generalize" the operations
 
 Renaming an operation, rewording a description, adding a parameter: fine. Those

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -231,13 +231,32 @@ python scripts/verify_replay.py workbench/skills/<app> --profile-slug <slug>
 #    Exit 2 = no signed-in session: show the sign-in card, then run it again.
 #    Nothing is installed, and the report is never self-approving.
 
-# 2. SHOW the member the report (the skill-replay card) and get their answer.
+# 2. SHOW the member what happened, and get their answer. (see below)
 
 # 3. Only if they approve:
 python scripts/verify_approve.py workbench/skills/<app>
 
 # 4. Now install.
 ```
+
+**Step 2 is not optional and does not depend on a card.** Where the
+`skill-replay` card is available the host renders it; where it is not, present
+the report in the conversation yourself. Either way the member must be able to
+see, before they answer:
+
+- **for each operation, whether it reached its GOAL** — not how many steps ran. A
+  download whose every step passed and which produced no file has NOT reached
+  its goal, and a step count would call that a success.
+- **which steps were blocked**, and what the error said.
+- **which steps the agent improvised** rather than replaying from the recording.
+  Those are the ones nobody has ever verified; that is where their attention
+  belongs.
+- **anything held for approval** — a control that moves money, is irreversible,
+  or that the human never touched during the recording.
+
+Then ask plainly whether it looks right, or which step to change. Do not
+summarise it as "the replay passed" and move on: the failures this gate exists
+to catch are the ones that look fine in summary.
 
 If they ask for a change, amend the workflow, recompile, and **replay again** —
 the approval is tied to a fingerprint of the plan, so an amended skill no longer

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -400,6 +400,25 @@ rather than left to review.
 Never hand-write `operations.json`, `manifest.json`, `recording_bundle.json` or
 `replay_approval.json`. Record, compile, replay, and let the member approve.
 
+### Migrating a browser skill compiled before provenance
+
+A browser skill built before the installer started checking provenance has no
+`recording_bundle.json` and no `manifest.provenance`, so its next install is
+refused. It was compiled from a real recording, and capture always saves the
+bundle, so re-attach that recording rather than re-recording:
+
+```
+python scripts/migrate_provenance.py workbench/skills/<app>
+```
+
+It finds the bundle by the session id in the manifest, verifies every locator the
+operations drive appears in it, and only then stamps. The operations do not
+change, so an existing approval stays valid.
+
+If it refuses, believe it. Either that is the wrong recording (try `--bundle`),
+or the steps were never observed in any recording — and attaching one would only
+disguise that. This tool verifies; it does not bless.
+
 ### A missing session is a WAIT, not a failure to work around
 
 When replay reports `login_required`, the correct next action is to **tell the

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -384,6 +384,25 @@ Do NOT run `capture_record.py`. Do NOT open a `?mode=recording` viewer. If you
 find yourself about to say "click Finish & export" when the member asked to sign
 in, you have reached for the wrong session.
 
+### A missing session is a WAIT, not a failure to work around
+
+When replay reports `login_required`, the correct next action is to **tell the
+member you are waiting for their sign-in, and then stop**.
+
+Do not approve. Do not install. Do not re-run the replay on a timer. None of
+those can succeed without a session — the installer refuses an unapproved
+browser skill and the approver refuses a replay that never ran — so every
+attempt fails, and the failures bury the one line the member actually needs to
+read: that you are waiting for them.
+
+Observed: a build attempted "marking skill approved and installing" and
+"installing approved skill into org catalog" repeatedly while replay was still
+returning `login_required`. Nothing shipped, because the gates held, but the
+member could not tell that the whole thing was blocked on them.
+
+One clear sentence — "I need you to sign in via the card above; I will replay
+and install once you have" — is the entire correct behaviour.
+
 ### How to tell which one you are looking at
 
 A recording viewer URL carries `?mode=recording` and shows "Finish & export". A

--- a/skills/noui/SKILL.md
+++ b/skills/noui/SKILL.md
@@ -351,6 +351,47 @@ the ICICI build, twice.
 
 ---
 
+## Two sessions, two sign-ins — never confuse them
+
+Building a browser skill involves **two different browser sessions**, and mixing
+them up has cost more time on this project than any other single mistake.
+
+| | **Recording session** | **Runtime session** |
+|---|---|---|
+| What it is | a human drives a browser so NoUI can capture what they do | the profile's own authenticated session, the one the installed skill drives |
+| Created by | `capture_record.py` | Tabby, on demand — never by you |
+| Viewer | a VNC link with a **"Finish & export"** button | a sign-in card the platform renders |
+| Exists to | produce a bundle | run operations |
+
+**A live sign-in is never satisfied by a recording session.** When something
+reports `login_required` — replay, a verification call, an installed skill — the
+member needs a RUNTIME sign-in. Handing them a recording link instead gives them
+a viewer with a "Finish & export" button, which is not what they were asked for,
+and the sign-in they perform there does nothing for the session that needed it.
+
+This happened: the member asked for a fresh login, was handed a fresh
+*recording*, signed in, drove the whole flow, and said "I didn't know you gave
+fresh recording session". A full walkthrough for nothing.
+
+### How to get a runtime sign-in
+
+Call the skill's own operation through `call_web_browser`. It returns
+`status=login_required` with a sign-in link; the platform renders the sign-in
+card; the member signs in there. The session then stays warm, so replays after
+the first sign-in are free.
+
+Do NOT run `capture_record.py`. Do NOT open a `?mode=recording` viewer. If you
+find yourself about to say "click Finish & export" when the member asked to sign
+in, you have reached for the wrong session.
+
+### How to tell which one you are looking at
+
+A recording viewer URL carries `?mode=recording` and shows "Finish & export". A
+runtime sign-in has neither. If the link you are about to hand over has them and
+you are not asking the member to record something, stop.
+
+---
+
 ## Script reference
 
 | Script | Pillar | Purpose |

--- a/skills/noui/noui_core/capture/classify.py
+++ b/skills/noui/noui_core/capture/classify.py
@@ -40,7 +40,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from noui_core.capture.split import CREDENTIAL_FIELD_ROLES, find_login_boundary, split_bundle
+from noui_core.capture.split import (
+    CREDENTIAL_FIELD_ROLES,
+    SplitError,
+    find_login_boundary,
+    split_bundle,
+)
 from noui_core.compile.login_assets import _is_redirect_hop
 
 # The three shapes a capture can have. "combined" holds both halves and is split
@@ -81,7 +86,13 @@ def bundle_signals(bundle: dict[str, Any]) -> dict[str, Any]:
     if boundary is None:
         return signals
 
-    parts = split_bundle(bundle)
+    try:
+        parts = split_bundle(bundle)
+    except SplitError:
+        # Classification only reports what it can see. A split that cannot be
+        # used yields no post-login signal, which is exactly what the caller
+        # should weigh -- it is not a reason to fail mode detection.
+        return signals
     if parts is None:  # pragma: no cover — boundary implies a split
         return signals
     _, workflow_slice = parts

--- a/skills/noui/noui_core/capture/ledger.py
+++ b/skills/noui/noui_core/capture/ledger.py
@@ -42,6 +42,7 @@ def record(
     profile: str = "",
     from_session: str = "",
     residential: bool = False,
+    browser_driven: bool = False,
 ) -> Path:
     """Persist what this session was provisioned as. Returns the written path."""
     if declared_mode not in MODES:
@@ -58,6 +59,7 @@ def record(
                 "profile": profile,
                 "from_session": from_session,
                 "residential": residential,
+                "browser_driven": bool(browser_driven),
                 "created_at": datetime.now(UTC).isoformat(),
             },
             indent=2,
@@ -77,6 +79,20 @@ def lookup(session_id: str) -> dict[str, Any] | None:
     except (OSError, ValueError):
         return None
     return entry if isinstance(entry, dict) else None
+
+
+def declared_browser_driven(session_id: str) -> bool:
+    """Was this session recorded FOR a browser-driven skill?
+
+    The kind is a decision, usually the member's own words ("a browser based
+    skill"), and it was taken at record time and then thrown away: capture_record
+    used the flag to provision and never wrote it down, so capture_import had to
+    be told again on its own command line. Forget it there -- easily done, since
+    nothing in the recording says so -- and an app that must be driven compiles
+    to replayed API calls instead. An ICICI capture asked for as a BROWSER BASED
+    skill shipped as two Finacle POSTs.
+    """
+    return bool((lookup(session_id) or {}).get("browser_driven"))
 
 
 def declared_mode(session_id: str) -> str:

--- a/skills/noui/noui_core/capture/recording.py
+++ b/skills/noui/noui_core/capture/recording.py
@@ -16,7 +16,7 @@ import urllib.parse
 
 from noui_core import tabby_client
 from noui_core.capture.bundle import count_sensitive_unredacted, validate_bundle
-from noui_core.capture.classify import classify_bundle
+from noui_core.capture.classify import COMBINED, WORKFLOW, classify_bundle
 from noui_core.config import settings
 
 _MISSING_CREDS = (
@@ -234,4 +234,40 @@ def fetch_bundle(session_id: str) -> tuple[str, dict]:
         raise RuntimeError(
             f"Refusing to import: {leaks} password/OTP value(s) were not redacted in the bundle."
         )
-    return classify_bundle(bundle), bundle
+    classification = classify_bundle(bundle)
+    warn_if_capture_was_downgraded(bundle, classification)
+    return classification, bundle
+
+
+def warn_if_capture_was_downgraded(bundle: dict, classification: str) -> None:
+    """Warn when a workflow capture came back with login-shaped capture.
+
+    Tabby gates its workflow-only capture on the pod's recording mode: locator
+    candidates with match counts, element state, interaction outcomes, downloads
+    and popup attachment. A pooled spare boots as a login recording and adopts
+    its real mode at bind — if that ever regresses, the recording still succeeds
+    and still compiles, just from far poorer evidence, and the resulting skill
+    misbehaves in ways that look like a bad recording rather than a bug.
+
+    Checked from CONTENT, not from the mode stamp: the classifier already decided
+    the human kept driving after signing in, so a bundle that then carries no
+    workflow-shaped capture is the signature of that regression.
+
+    A warning, never an error. A poor bundle is still worth compiling, and this
+    also fires harmlessly for bundles recorded before the rich capture existed.
+    """
+    if classification not in (WORKFLOW, COMBINED):
+        return
+    version = bundle.get("schema_version")
+    if not isinstance(version, int) or version < 4:
+        return  # recorded before rich capture existed — nothing to expect
+    if "download_events" in bundle:
+        return  # workflow-shaped: the pod knew what it was
+    print(
+        "WARNING: this looks like a workflow capture, but the bundle carries no "
+        "workflow-only capture (no download_events). The recording pod most likely "
+        "ran in 'login' mode, so locator candidates, element state and interaction "
+        "outcomes were never recorded. The skill will still compile, from weaker "
+        "evidence. Check that the recording session was provisioned with "
+        "recording_mode=workflow and that Tabby applied it at bind."
+    )

--- a/skills/noui/noui_core/capture/recording.py
+++ b/skills/noui/noui_core/capture/recording.py
@@ -274,7 +274,11 @@ def warn_if_capture_was_downgraded(bundle: dict, classification: str) -> None:
     if classification not in (WORKFLOW, COMBINED):
         return
     version = bundle.get("schema_version")
-    if not isinstance(version, int) or version < 4:
+    # Rich capture is schema_version 5 (the recorder's RECORDING_SCHEMA_VERSION,
+    # and what SKILL.md/pillar-1 document). Anything older, or absent, predates it
+    # and carries nothing to expect -- treating < 4 as the cutoff would demand rich
+    # fields of a bundle that never had them and warn spuriously.
+    if not isinstance(version, int) or version < 5:
         return  # recorded before rich capture existed — nothing to expect
     if "download_events" in bundle:
         return  # workflow-shaped: the pod knew what it was

--- a/skills/noui/noui_core/capture/recording.py
+++ b/skills/noui/noui_core/capture/recording.py
@@ -162,6 +162,7 @@ def provision_live_link(
     profile: str = "",
     from_session: str = "",
     residential: bool = False,
+    browser_driven: bool = False,
 ) -> dict:
     """Provision a recording session and return its payload with a ``login_url``
     that is **verified live** — never a stale/dead link, and never handed over
@@ -186,7 +187,14 @@ def provision_live_link(
     ``"restart"`` | ``"reprovision"`` when a refresh was needed).
     """
     token = resolve_agent_token()
-    result = start(mode, url, profile=profile, from_session=from_session, residential=residential)
+    result = start(
+        mode,
+        url,
+        profile=profile,
+        from_session=from_session,
+        residential=residential,
+        browser_driven=browser_driven,
+    )
 
     stream_token = _stream_token(result.get("vnc_url", ""))
     sid = result.get("session_id", "")

--- a/skills/noui/noui_core/capture/recording.py
+++ b/skills/noui/noui_core/capture/recording.py
@@ -66,6 +66,7 @@ def start(
     profile: str = "",
     from_session: str = "",
     residential: bool = False,
+    browser_driven: bool = False,
 ) -> dict:
     """Provision a Tabby VNC recording session.
 
@@ -79,6 +80,11 @@ def start(
         from_session: (workflow) seed cookies from a prior login recording (its
             session id) just captured in this same flow — session reuse, no
             stored credentials. Use --profile instead when a profile already exists.
+        browser_driven: this recording will be compiled into a browser-driven
+            skill, so Tabby reduces the HAR to metadata. Independent of ``mode``
+            — a workflow recording of an ordinary REST app still compiles by HAR
+            replay and needs the full HAR. Leave False unless the kind is already
+            known; ``detect_unreplayable`` decides it at compile time otherwise.
         residential: route the recorded browser's egress through Tabby's
             residential proxy (US residential IP) instead of datacenter egress.
             Use for sites that block datacenter IPs (e.g. bank portals).
@@ -95,6 +101,7 @@ def start(
         profile,
         source_session_id=from_session,
         residential_proxy=residential,
+        browser_driven=browser_driven,
     )
 
 

--- a/skills/noui/noui_core/capture/split.py
+++ b/skills/noui/noui_core/capture/split.py
@@ -123,6 +123,52 @@ def find_login_boundary(bundle: dict[str, Any]) -> str | None:
     return boundary["timestamp"] if boundary else None
 
 
+def split_diagnosis(bundle: dict[str, Any]) -> str:
+    """One line explaining what the splitter saw, and what it concluded.
+
+    The split turns on ONE thing -- whether any interaction was tagged as a
+    credential field -- and when that tagging fails the bundle is declared
+    login-free however plainly its URL timeline shows a sign-in. The member is
+    then asked to record a login they already recorded, and nothing anywhere
+    says why. This is the sentence that says why.
+    """
+    clicks = [c for c in (bundle.get("click_events") or []) if isinstance(c, dict)]
+    urls = [u for u in (bundle.get("url_events") or []) if isinstance(u, dict)]
+    creds = [c for c in clicks if c.get("field_role") in CREDENTIAL_FIELD_ROLES]
+    roles = sorted({str(c.get("field_role")) for c in clicks if c.get("field_role")})
+    login_urls = [
+        u
+        for u in urls
+        if any(
+            w in str(u.get("to_url") or "").lower() for w in ("login", "signin", "sign-in", "logon")
+        )
+    ]
+
+    boundary = _boundary_event(bundle)
+    if boundary is not None:
+        return (
+            f"split: login ends at seq={boundary.get('seq')} "
+            f"({boundary.get('timestamp')}); {len(creds)} credential interaction(s) "
+            f"of {len(clicks)} clicks, {len(urls)} url transitions."
+        )
+
+    detail = (
+        f"split: NO login segment. {len(clicks)} clicks, {len(urls)} url transitions, "
+        f"0 tagged as credential fields"
+    )
+    if roles:
+        detail += f" (field roles seen: {', '.join(roles)})"
+    if login_urls:
+        detail += (
+            f"; but {len(login_urls)} url(s) look like a sign-in "
+            f"(e.g. {str(login_urls[0].get('to_url'))[:70]}). The recorder did not tag the "
+            f"credential inputs -- a virtual keyboard, a masked custom control, or fields "
+            f"inside a frame will do that -- so the login cannot be sliced off even though "
+            f"it was recorded."
+        )
+    return detail
+
+
 def split_bundle(bundle: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]] | None:
     """Split a merged bundle into (login_bundle, workflow_bundle) at the boundary.
 

--- a/skills/noui/noui_core/capture/split.py
+++ b/skills/noui/noui_core/capture/split.py
@@ -65,6 +65,64 @@ def _placed(events: list[dict[str, Any]], key: _PositionKey) -> list[tuple[Any, 
     return out
 
 
+#: Path words that mean "still proving who you are".
+LOGIN_FLOW_WORDS = (
+    "login",
+    "log-in",
+    "password",
+    "passcode",
+    "credential",
+    "signin",
+    "sign-in",
+    "logon",
+    "auth",
+    "sso",
+    "saml",
+    "oauth",
+    "otp",
+    "mfa",
+    "2fa",
+    "verify",
+    "challenge",
+)
+
+
+def _is_login_flow_url(url: str) -> bool:
+    """Is this URL part of the sign-in flow rather than the app proper?"""
+    low = str(url or "").lower()
+    if not low:
+        return False
+    path = low.split("://", 1)[-1]
+    path = path[path.find("/") :] if "/" in path else ""
+    return any(w in path for w in LOGIN_FLOW_WORDS)
+
+
+def _boundary_from_login_exit(
+    url_events: list[dict[str, Any]], key: Any, by_seq: bool
+) -> dict[str, Any] | None:
+    """The last hop OUT of the sign-in flow, for logins that type nothing.
+
+    The LAST such hop, not the first: a sign-in commonly bounces through an OTP
+    or consent screen and back, and only the final exit leaves the human inside
+    the app.
+    """
+    exits = [
+        (pos, u)
+        for pos, u in _placed(url_events, key)
+        if u.get("to_url")
+        and _is_login_flow_url(u.get("from_url", "") or "")
+        and not _is_login_flow_url(u.get("to_url", "") or "")
+        and not _is_redirect_hop(u.get("from_url", "") or "", u.get("to_url", "") or "")
+    ]
+    if not exits:
+        return None
+    boundary = max(exits, key=lambda placed: placed[0])[1]
+    return {
+        "seq": event_seq(boundary) if by_seq else None,
+        "timestamp": boundary.get("timestamp") or None,
+    }
+
+
 def _boundary_event(bundle: dict[str, Any]) -> dict[str, Any] | None:
     """The recorded event at which the login ends, or None if there is no login.
 
@@ -91,7 +149,20 @@ def _boundary_event(bundle: dict[str, Any]) -> dict[str, Any] | None:
 
     creds = _placed([c for c in clicks if c.get("field_role") in CREDENTIAL_FIELD_ROLES], key)
     if not creds:
-        return None
+        # No credentials were typed -- which is not the same as no login.
+        #
+        # ICICI offers a QR sign-in: the human scans it with the bank's mobile
+        # app and the web session becomes authenticated without a single field
+        # being filled. SSO redirects, magic links and biometric approval are
+        # the same shape. Defining "a login happened" as "credentials were
+        # typed" made those recordings permanently unsplittable, and the member
+        # was asked to record a login they had already recorded and could never
+        # record in the expected way.
+        #
+        # What every one of them DOES leave is the transition out of the sign-in
+        # page into the app. That is the boundary, and it is observable without
+        # knowing how the human proved who they were.
+        return _boundary_from_login_exit(url_events, key, by_seq)
     last_cred_pos, last_cred = max(creds, key=lambda placed: placed[0])
 
     navs = [

--- a/skills/noui/noui_core/capture/split.py
+++ b/skills/noui/noui_core/capture/split.py
@@ -264,6 +264,16 @@ def split_diagnosis(bundle: dict[str, Any]) -> str:
     return detail
 
 
+class SplitError(RuntimeError):
+    """The split ran and produced a result that cannot be compiled.
+
+    Distinct from `split_bundle` returning None, which means "there is no login
+    segment here" -- an ordinary answer the caller handles by compiling the
+    bundle workflow-only. This is the other case: a boundary was found, and
+    applying it destroyed the workflow half.
+    """
+
+
 def split_bundle(bundle: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]] | None:
     """Split a merged bundle into (login_bundle, workflow_bundle) at the boundary.
 
@@ -282,7 +292,34 @@ def split_bundle(bundle: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]
     boundary = _boundary_event(bundle)
     if boundary is None:
         return None
-    return _slice(bundle, boundary, "login"), _slice(bundle, boundary, "workflow")
+
+    login, workflow = _slice(bundle, boundary, "login"), _slice(bundle, boundary, "workflow")
+
+    # A workflow slice with NOTHING in it is a failed split, not a split.
+    #
+    # Not "no clicks": a workflow half can legitimately be navigations only.
+    # What cannot happen is a half with neither.
+    #
+    # `_keep` sends anything it cannot PLACE to the login side, deliberately, so
+    # a login request never leaks into the workflow. But a boundary carrying a
+    # null position places nothing -- every event goes left, the workflow slice
+    # comes out empty, and the compiler is handed a capture of a journey that
+    # was never sliced off. It compiled to nothing and said nothing, and the
+    # agent reading that concluded the RECORDING was wrong: it asked a member to
+    # sign in and drive the whole journey again, twice, to route around a bug
+    # that had already thrown their capture away.
+    #
+    # The recording is intact in these cases -- only the slicing lost it -- so
+    # refusing here costs a re-run of the import, not a re-run of the human.
+    placed = (workflow.get("click_events") or []) or (workflow.get("url_events") or [])
+    if not placed:
+        raise SplitError(
+            "the login/workflow split produced an empty workflow half: the boundary "
+            f"({boundary!r}) placed every interaction on the login side. The recording "
+            "itself is intact -- this is the split, not the capture. Import it as "
+            "workflow-only, or record the halves explicitly with --mode."
+        )
+    return login, workflow
 
 
 def _keep(value: Any, boundary: Any, side: str) -> bool:

--- a/skills/noui/noui_core/capture/split.py
+++ b/skills/noui/noui_core/capture/split.py
@@ -97,6 +97,14 @@ def _is_login_flow_url(url: str) -> bool:
     return any(w in path for w in LOGIN_FLOW_WORDS)
 
 
+def _origin_of(url: str) -> str:
+    low = str(url or "")
+    if "://" not in low:
+        return ""
+    rest = low.split("://", 1)[1]
+    return rest.split("/", 1)[0].lower()
+
+
 def _boundary_from_login_exit(
     url_events: list[dict[str, Any]], key: Any, by_seq: bool
 ) -> dict[str, Any] | None:
@@ -105,14 +113,30 @@ def _boundary_from_login_exit(
     The LAST such hop, not the first: a sign-in commonly bounces through an OTP
     or consent screen and back, and only the final exit leaves the human inside
     the app.
+
+    Bounded to the origin the recording STARTED on. ICICI's statement portal
+    lives at infinity.icici.bank.in/corp/AuthenticationController -- a deep app
+    route whose path contains "auth", so it read as a sign-in page, and the last
+    "exit" from it fell at the end of the workflow. The whole statement journey
+    was then sliced into the login half and the workflow half came out empty.
+    A sign-in bounces within its own host; a different host reached by clicking
+    around inside the app is the app.
     """
+    placed = _placed(url_events, key)
+    start_origin = ""
+    for _pos, u in placed:
+        start_origin = _origin_of(u.get("to_url", "") or u.get("from_url", "") or "")
+        if start_origin:
+            break
+
     exits = [
         (pos, u)
-        for pos, u in _placed(url_events, key)
+        for pos, u in placed
         if u.get("to_url")
         and _is_login_flow_url(u.get("from_url", "") or "")
         and not _is_login_flow_url(u.get("to_url", "") or "")
         and not _is_redirect_hop(u.get("from_url", "") or "", u.get("to_url", "") or "")
+        and (not start_origin or _origin_of(u.get("from_url", "") or "") == start_origin)
     ]
     if not exits:
         return None

--- a/skills/noui/noui_core/compile/amendments.py
+++ b/skills/noui/noui_core/compile/amendments.py
@@ -56,13 +56,30 @@ def load(raw: bytes | str | None) -> list[dict[str, Any]]:
     return out
 
 
+def is_verified(a: dict[str, Any]) -> bool:
+    """Did the replay that recorded this amendment actually RUN the new step?
+
+    An amendment is only worth what the replay proved about it. One build
+    confirmed a single control by hand and then amended the same step across six
+    operations; two of those ran, four were blocked long before reaching the
+    amended step, and all six went into the file saying "confirmed working in
+    live session". Absent means unverified: an amendment written before this
+    field existed has no evidence either.
+    """
+    return bool(a.get("verified"))
+
+
 def describe(a: dict[str, Any]) -> str:
     """One line a member can decide on."""
     rep = a.get("replacement") or {}
     params = rep.get("params") or {}
     target = params.get("selector") or params.get("text") or params.get("label") or "?"
     why = str(a.get("why") or "the recorded locator matched nothing")
+    if is_verified(a):
+        mark = "ran OK in the replay"
+    else:
+        mark = "NOT EXERCISED — the replay never reached this step"
     return (
         f"{a.get('operation')} step {a.get('step_index')}: "
-        f"{rep.get('command', '?')} {target} — {why}"
+        f"{rep.get('command', '?')} {target} — {why} [{mark}]"
     )

--- a/skills/noui/noui_core/compile/amendments.py
+++ b/skills/noui/noui_core/compile/amendments.py
@@ -1,0 +1,68 @@
+"""Steps discovered at replay, kept apart from the ones that were recorded.
+
+WHY A SEPARATE FILE. `operations.json` is what a human was observed doing, and
+the digest stamped over it is what makes that claim checkable. The moment
+anything else is written into it the claim is gone -- which is exactly what kept
+happening: a compiled locator died at replay, the agent found a control that
+worked, and wrote it into operations.json. The skill then had no provenance and
+the gate refused it, so the discovery was lost along with the evidence.
+
+The discovery was not worthless. It was just a different KIND of evidence:
+observed working once, at replay, rather than observed being used by a human.
+Two classes, never merged silently -- so a member approving the skill can see
+precisely which steps nobody watched a human perform.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+AMENDMENTS_FILE = "amendments.json"
+
+
+def amendment_id(a: dict[str, Any]) -> str:
+    """A stable id for one amendment, so an approval names what it approved."""
+    material = {
+        "operation": a.get("operation"),
+        "step_index": a.get("step_index"),
+        "replacement": a.get("replacement"),
+    }
+    blob = json.dumps(material, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+
+def load(raw: bytes | str | None) -> list[dict[str, Any]]:
+    """Parse an amendments file, tolerating absence and malformation.
+
+    A malformed file reads as none: an amendment nobody can interpret must never
+    become an amendment nobody reviewed.
+    """
+    if not raw:
+        return []
+    try:
+        text = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+        doc = json.loads(text)
+    except (ValueError, UnicodeDecodeError, AttributeError):
+        return []
+    items = doc.get("amendments") if isinstance(doc, dict) else doc
+    if not isinstance(items, list):
+        return []
+    out = []
+    for a in items:
+        if isinstance(a, dict) and a.get("operation") and a.get("replacement"):
+            out.append(a)
+    return out
+
+
+def describe(a: dict[str, Any]) -> str:
+    """One line a member can decide on."""
+    rep = a.get("replacement") or {}
+    params = rep.get("params") or {}
+    target = params.get("selector") or params.get("text") or params.get("label") or "?"
+    why = str(a.get("why") or "the recorded locator matched nothing")
+    return (
+        f"{a.get('operation')} step {a.get('step_index')}: "
+        f"{rep.get('command', '?')} {target} — {why}"
+    )

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -2014,7 +2014,15 @@ def _terminal_kind(ev: dict) -> str | None:
     outcome = ev.get("outcome")
     if isinstance(outcome, dict) and outcome.get("download"):
         return "download"
-    if (ev.get("event_type") or "") == "submit":
+    # Gate submit on the PRESENCE of an outcome too, not on event_type alone. A
+    # `submit` event predates schema 5 -- login_assets reads it for login-form
+    # detection -- so keying a terminal operation on event_type alone made a
+    # pre-schema-5 bundle carrying a non-login submit (a "Save Note" form, say)
+    # compile a brand-new operation, breaking this module's "older captures
+    # compile exactly as they did" promise (the download branch is already
+    # outcome-gated). An outcome means the recorder was schema 5, i.e. a capture
+    # from this PR onward.
+    if isinstance(outcome, dict) and (ev.get("event_type") or "") == "submit":
         return "submit"
     return None
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -848,6 +848,11 @@ def _step_for_click(click: dict) -> dict | None:
         if not (locator and locator.get("is_css")):
             return None
         hover: dict = {"command": "hover", "params": {"selector": locator["value"]}}
+        # Carried so _fold_hover_into_click can tell a reveal from a hover the
+        # pointer merely passed through. Stripped from behaviour comparisons by
+        # _behaviour, like the other underscore-prefixed provenance.
+        if click.get("reveal"):
+            hover["_reveal"] = True
         element = click.get("element") or {}
         if isinstance(element, dict) and element.get("in_iframe"):
             for key in ("frame_url", "frame_name"):
@@ -1023,8 +1028,20 @@ def _fold_hover_into_click(steps: list[dict]) -> list[dict]:
     while i < len(steps):
         step = steps[i]
         nxt = steps[i + 1] if i + 1 < len(steps) else None
+        # `_reveal` is required, not merely preferred. An incidental hover is
+        # ALSO hover-immediately-then-click -- the pointer crosses one nav box on
+        # its way to another -- so adjacency cannot tell the two apart. An ICICI
+        # capture holds both pairs, and folding on position alone produced a step
+        # that hovered Deposits and clicked Cards.
+        #
+        # Bundles recorded before the recorder stamped this carry no `_reveal` at
+        # all, so their hovers stay as separate steps: the pair is not merged and
+        # nothing is invented. That is the safe direction -- an unfolded hover
+        # costs a round trip, a wrongly folded one aims the gesture at the wrong
+        # control.
         if (
             step.get("command") == "hover"
+            and step.get("_reveal")
             and nxt is not None
             and nxt.get("command") == "click_element"
             and (step.get("params") or {}).get("selector")

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -113,6 +113,15 @@ def _same_target(a: dict, b: dict) -> bool:
     return bool(a.get("selector")) and a.get("selector") == b.get("selector")
 
 
+#: How far AFTER a navigation its driving click may still be recorded.
+#:
+#: An SPA route change is observed when the URL changes, which can be stamped
+#: before the click handler that caused it. Small on purpose: this absorbs an
+#: ordering inversion, not a gap between two human actions.
+_NAV_SEQ_SLACK = 3
+_NAV_TIME_SLACK_S = 1.5
+
+
 def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> list[dict]:
     """The recorded click CHAIN that drove an in-app navigation FROM from_url.
 
@@ -142,6 +151,7 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
     nav_dt = _parse_ts((nav_ev or {}).get("timestamp") or "")
     nav_seq = event_seq(nav_ev)
     cands: list[dict] = []
+    late_cands: list[dict] = []
     for c in click_events or []:
         # A hover that opened a menu is part of the gesture, not noise: the
         # click after it targets something that does not exist until the pointer
@@ -164,12 +174,31 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
         cdt = _parse_ts(c.get("timestamp") or "")
         cseq = event_seq(c)
         # Drop clicks made AFTER the navigation — they cannot have caused it.
+        # A click and the navigation it causes are near-simultaneous, and their
+        # recorded order can INVERT: an SPA route change is observed when the
+        # URL changes, which for ICICI's overview -> credit-card hop landed at
+        # seq 4 while the "Credit Cards" click that drove it landed at seq 6.
+        # A strict "before the navigation" rule found no driving click, so the
+        # credit-card page compiled with an empty chain -- the one hop that has
+        # failed in every run -- while later hops, whose clicks happened to be
+        # recorded first, compiled correctly.
+        #
+        # Allow a small window on the far side. Wide enough to absorb the
+        # inversion, far narrower than the gap to the human's next action, so a
+        # click belonging to the NEXT page is still never claimed by this one.
         if nav_seq is not None and cseq is not None:
-            if cseq > nav_seq:
+            if cseq > nav_seq + _NAV_SEQ_SLACK:
                 continue
-        elif nav_dt and cdt and cdt > nav_dt:
-            continue
-        cands.append(
+            late = cseq > nav_seq
+        elif nav_dt and cdt:
+            delta = (cdt - nav_dt).total_seconds()
+            if delta > _NAV_TIME_SLACK_S:
+                continue
+            late = delta > 0
+        else:
+            late = False
+
+        (late_cands if late else cands).append(
             {
                 "text": text,
                 # The OTHER ways this control was seen. choose_locator collapses
@@ -183,6 +212,14 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
                 "seq": cseq,
             }
         )
+    if not cands and late_cands:
+        # Nothing preceded the navigation, so the click that caused it was
+        # recorded just after: an SPA route change is observed when the URL
+        # changes, and ICICI stamped the overview -> credit-card hop at seq 4
+        # while the "Credit Cards" click that drove it landed at seq 6. Taking
+        # these only as a last resort keeps an ordinary later click -- a "Log
+        # out" back on the same page -- out of the gesture.
+        cands = late_cands
     if not cands:
         return []
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -2076,6 +2076,7 @@ def apply_fold(
     # subtract and the decomposition yields an empty skill. Those fold exactly
     # as they always did.
     segmented = a.get("segment_steps") is not None and b.get("segment_steps") is not None
+    starts = [a.get("starts_from"), b.get("starts_from")]
     merged_steps = (
         shared + _merge_branches(*work, param, values)
         if segmented
@@ -2102,6 +2103,22 @@ def apply_fold(
         # is the way to the fork; whatever they do not is the branch choosing
         # itself, and belongs with the branch.
         "segment_steps": _merge_branches(*work, param, values),
+        # Each variant begins where ITS OWN work happens.
+        #
+        # The folded operation inherits its scalar fields from A, and
+        # `starts_from` is not shared: ICICI's monthly statement is produced on
+        # /corp/AuthenticationController, and choosing Annual navigates to
+        # /corp/Finacle -- so the annual variant carried the monthly page as its
+        # precondition and its guard refused it every time, on the page it was
+        # supposed to run on.
+        #
+        # Only when the two actually differ, so nothing changes for a fold whose
+        # variants share a page.
+        **(
+            {"starts_from_by": {"param": param, "by": dict(zip(values, starts))}}
+            if len(set(starts)) > 1
+            else {}
+        ),
         "parameters": [
             *(a.get("parameters") or []),
             {

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -785,13 +785,24 @@ def entry_url_for(url_events: list[dict], pages: list[dict]) -> str:
     A page whose own nav is None is that page by definition, and is preferred
     when one survived compilation.
     """
+    # url_events FIRST. `nav is None` looked like a clean signal for "the
+    # landing page" and is not: _resolve_nav_chains re-roots chains onto the
+    # first surviving page, so when /overview was dropped, /credit-card came
+    # back with nav None and the compiler stamped the destination again. The
+    # recorded transitions cannot be re-rooted by anything downstream.
+    # The page in effect before the FIRST transition of the slice being
+    # compiled -- literally "the page the first step acts on". The compiler is
+    # handed the WORKFLOW slice, whose first event is already /overview ->
+    # /credit-card, so the login->landing transition is not in it and a rule
+    # that looked for one fell through to the destination twice.
+    for ev in url_events or []:
+        frm = str((ev or {}).get("from_url") or "")
+        if not frm or frm == "about:blank" or _is_login_flow_url(frm):
+            continue  # the browser opening, or the sign-in nobody replays
+        return frm
     for p in pages or []:
         if p.get("nav") is None and p.get("url"):
             return str(p["url"])
-    for ev in url_events or []:
-        frm, to = str((ev or {}).get("from_url") or ""), str((ev or {}).get("to_url") or "")
-        if to and frm and _is_login_flow_url(frm) and not _is_login_flow_url(to):
-            return to
     return str((pages or [{}])[0].get("url") or "")
 
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -658,8 +658,15 @@ def _collapse_repeats(steps: list[dict]) -> list[dict]:
 
 
 def _is_css_kind(kind: str) -> bool:
-    """Kinds whose value is a CSS selector rather than human-visible text."""
-    return kind in ("css", "testid", "id", "name", "css_path")
+    """Kinds whose value is a CSS selector rather than human-visible text.
+
+    `row_scoped` and `container_label` are selectors too -- Playwright's
+    `:has-text()` dialect rather than plain CSS, but selectors, and they must
+    never be emitted as click_by_text. Omitting them compiled
+    `tr:has-text("31 Jan 2025") button[...]` into a TEXT param, which is a string
+    no page has ever displayed, so the step could only ever fail.
+    """
+    return kind in ("css", "testid", "id", "name", "css_path", "row_scoped", "container_label")
 
 
 _LOGIN_CONTROL = re.compile(r"\|\s*(log ?in|sign ?in|login|signin|continue to login)\s*$", re.I)

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -399,9 +399,30 @@ def _resolve_nav_chains(pages: list[dict]) -> list[dict]:
             # out) means we are already at the start of the in-app path.
             cur = by_key.get(parent_key)
         out = {k: v for k, v in page.items() if not k.startswith("_")}
-        if not ok:
-            continue
         out["nav"] = chain if chain else None
+        if not ok:
+            # Keep the page with the PARTIAL chain instead of discarding it.
+            #
+            # Dropping was meant to avoid a worse bug: a page with no chain
+            # looked like the landing page, so its recipe became a bare
+            # get_page_summary and the operation claimed to read /accounts while
+            # returning the landing DOM. Confidently wrong data is worse than a
+            # missing operation, and that reasoning still holds.
+            #
+            # But on a bank it discards the whole workflow. An ICICI recording
+            # captured 15 clicks -- Cards, Credit Cards, Past, download previous
+            # statement -- crossed to the Finacle host, and every hop there was an
+            # unlabelled control whose driving click could not be recovered. One
+            # unresolvable hop dropped every statement page, the compile emitted
+            # a single overview operation, and three re-recordings could not fix
+            # data that was already correct.
+            #
+            # So keep what was resolved and make the uncertainty explicit: the
+            # page is marked partial, and the operation asserts the URL it is
+            # supposed to reach. If the partial chain does not arrive, replay
+            # blocks on that expectation -- which is the honest failure the drop
+            # was protecting against, without throwing the workflow away.
+            out["nav_partial"] = True
         resolved.append(out)
     return resolved
 
@@ -569,6 +590,24 @@ def _steps_for_page(p: dict) -> list[dict]:
         if expect:
             step["expect"] = expect
         steps.append(step)
+
+    # A page reached by a PARTIAL chain must prove it arrived.
+    #
+    # This is what makes keeping the page safe. Without it, a chain that stops
+    # short leaves the run on whatever page it managed to reach and
+    # get_page_summary returns THAT -- the operation claims to read the
+    # statements page and hands back the landing DOM, which is the failure the
+    # old drop was protecting against. Asserting the url turns a silent wrong
+    # answer into a blocked step naming the page it did not reach.
+    if p.get("nav_partial") and p.get("url"):
+        steps.append(
+            {
+                "command": "get_page_info",
+                "expect": {"url": p["url"]},
+                "note": "the recorded path to this page was incomplete — verify arrival",
+            }
+        )
+
     steps.append({"command": "get_page_summary"})
     return steps
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -225,6 +225,12 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
         (late_cands if late else cands).append(
             {
                 "text": text,
+                # Carried, or a hover becomes indistinguishable from a click the
+                # moment it passes through here -- and _step_for_click emitted
+                # click_element for ICICI's nav hover, on the same selector the
+                # real click used. Third field this function has been caught
+                # dropping, after candidates and is_opener.
+                "event_type": (c.get("event_type") or "click"),
                 "is_opener": event_seq(c) in opener_seqs,
                 # The OTHER ways this control was seen. choose_locator collapses
                 # them to one winner above; the runtime needs the rest to fall
@@ -276,11 +282,25 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
         # Collapse consecutive identical labels — but only when they are really
         # the same control. Two different icon buttons both have empty text, and
         # merging them would silently drop a step in the gesture.
-        if out and out[-1]["text"] == c["text"] and (c["text"] or _same_target(out[-1], c)):
+        # A hover and the click it revealed are NOT a repeat, even though they
+        # share a target and both have empty text: ICICI's nav hover and the
+        # submenu click both resolve to #scroll-container > div:nth-of-type(5).
+        # Collapsing them left a gesture that opens the menu and clicks nothing
+        # in it -- or, once event_type was lost below, one click_element that
+        # never opened anything.
+        same_kind = out and out[-1].get("event_type") == c.get("event_type")
+        if same_kind and out[-1]["text"] == c["text"] and (c["text"] or _same_target(out[-1], c)):
             continue
         out.append(
             {
                 "text": c["text"],
+                # Carried through the projection, not just built above it. This
+                # is where the hover lost the one field that made it a hover --
+                # the same class of gap that had already cost candidates and
+                # is_opener at the other builder.
+                "event_type": c.get("event_type") or "click",
+                "is_opener": c.get("is_opener"),
+                "candidates": c.get("candidates"),
                 "selector": c["selector"],
                 "locator": c["locator"],
                 "outcome": c["outcome"],

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -2329,9 +2329,7 @@ def _terminal_starts_from(op: dict) -> str | None:
 # (matched inside "CustomView"), a bare "go" -- are gone; and only clicks are
 # tested (see below), so the value-scoped set_checked whose selector says
 # "CustomView...PERIOD_TYPE" is excluded by command before this ever runs.
-_ACTIVATION_CONTROL = re.compile(
-    r"(download|e-?statement|estatement|pdf|export|submit)", re.I
-)
+_ACTIVATION_CONTROL = re.compile(r"(download|e-?statement|estatement|pdf|export|submit)", re.I)
 
 
 def _is_activation_step(step: dict) -> bool:
@@ -2391,7 +2389,8 @@ def _steps_for_terminal(op: dict) -> list[dict]:
     # A click whose own label names a download/submit control is activation; the
     # parameter fills must precede it, exactly as a person sets the period before
     # pressing the button.
-    activation, setup = [], []
+    activation: list[dict] = []
+    setup: list[dict] = []
     for step in lead:
         (activation if _is_activation_step(step) else setup).append(step)
     steps.extend(setup)

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -424,6 +424,30 @@ def _step_for_click(click: dict) -> dict | None:
     locator = click.get("locator")
     text = (click.get("text") or "").strip()
 
+    # A radio or checkbox is SET, not clicked.
+    #
+    # Portals style these as images or spans over a hidden input, so a click
+    # lands on the decoration and the input never changes -- ICICI's Monthly /
+    # Annual period is exactly that, and a replay that "clicked Annual" was
+    # still asking for the monthly statement. set_checked drives the control and
+    # verifies the state actually changed, which a click cannot promise.
+    element = click.get("element") or {}
+    role = str(element.get("role") or "").lower() if isinstance(element, dict) else ""
+    if role in ("radio", "checkbox") and locator and locator.get("is_css"):
+        step = {
+            "command": "set_checked",
+            "params": {"selector": locator["value"], "checked": True},
+        }
+        if element.get("in_iframe"):
+            for key in ("frame_url", "frame_name"):
+                value = str(element.get(key) or "").strip()
+                if value:
+                    step["params"][key] = value
+        expect = _expect_for_click(click)
+        if expect:
+            step["expect"] = expect
+        return step
+
     step: dict | None = None
     if locator and locator.get("is_css"):
         step = {"command": "click_element", "params": {"selector": locator["value"]}}

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -226,6 +226,58 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
     return [out[0]] + out[-(_NAV_MAX_CLICKS - 1) :]
 
 
+def app_origins_from(
+    url_events: list[dict], login_url: str, click_events: list[dict] | None = None
+) -> set[str]:
+    """Every origin that is part of THIS app, discovered from the recording.
+
+    The compiler used to keep only pages on the exact login origin, to drop the
+    third-party telemetry that poisoned earlier HAR-replay compiles. That is too
+    strict for a bank: ICICI serves its portal from
+    ``retailnetbanking.icici.bank.in`` and its statement download from
+    ``infinity.icici.bank.in``. The entire e-Statements page — the one that
+    actually produces the PDF — was discarded before any operation could be built
+    from it, so the compiled skill had no way to reach the file at all.
+
+    Decided from evidence rather than by matching domains. A registrable-domain
+    heuristic is guesswork (``bank.in`` is a public suffix, so "share the last two
+    labels" would make every Indian bank the same app), but the recording already
+    knows: an origin the human reached BY NAVIGATING FROM a page of this app is
+    part of this app. Telemetry, analytics and consent widgets never appear as a
+    main-frame navigation a human clicked into; a bank's second host always does.
+
+    TWO pieces of evidence are required, not one. Being navigated to from the app
+    is not enough by itself: a consent wall, an SSO hop or a payment gateway is
+    reached exactly that way, and so is any third party that redirects the main
+    frame. The origin must ALSO be somewhere the human then did something — a
+    click or an input recorded on it. A beacon has no interactions; the page
+    where you pick "Annual" and press download has plenty.
+
+    Seeded with the login origin and grown in interaction order, so a two-hop
+    path (portal -> statements host -> a page within it) is picked up too.
+    """
+    interacted = {
+        _url_origin(c.get("url") or "")
+        for c in click_events or []
+        if (c.get("url") or "").startswith(("http://", "https://"))
+    }
+    origins: set[str] = set()
+    if login_url:
+        origins.add(_url_origin(login_url))
+    for ev in order_events(url_events):
+        to_url = (ev or {}).get("to_url") or ""
+        from_url = (ev or {}).get("from_url") or ""
+        if not to_url.startswith(("http://", "https://")):
+            continue
+        to_origin = _url_origin(to_url)
+        if to_origin in origins:
+            continue
+        if _url_origin(from_url) in origins and to_origin in interacted:
+            origins.add(to_origin)
+    origins.discard("")
+    return origins
+
+
 def derive_browser_pages(
     url_events: list[dict],
     click_events: list[dict] | None = None,
@@ -255,17 +307,19 @@ def derive_browser_pages(
     # must be sorted before anything positional is read from them.
     click_events = order_events(click_events)
     url_events = order_events(url_events)
-    app_origin = _url_origin(login_url) if login_url else ""
+    # Every origin this app spans, not just the login one — see app_origins_from.
+    app_origins = app_origins_from(url_events, login_url, click_events)
     seen: set[str] = set()
     pages: list[dict] = []
     for ev in url_events:
         url = (ev or {}).get("to_url") or ""
         if not url or not url.startswith(("http://", "https://")):
             continue
-        # Same-origin as the login page only. Third-party widget/telemetry origins
-        # (the DevRev/Dynatrace noise that poisoned the HAR-replay skill's
-        # identity) must not be treated as pages to read.
-        if app_origin and _url_origin(url) != app_origin:
+        # Belongs to this app — the login origin, or an origin the human
+        # navigated to FROM this app. Third-party widget/telemetry origins (the
+        # DevRev/Dynatrace noise that poisoned the HAR-replay skill's identity)
+        # never appear that way and are still dropped.
+        if app_origins and _url_origin(url) not in app_origins:
             continue
         if _is_login_flow_url(url):
             continue
@@ -880,7 +934,12 @@ def derive_terminal_operations(
     exactly as they did.
     """
     click_events = order_events(click_events)
-    app_origin = _url_origin(login_url) if login_url else ""
+    # Same multi-origin rule as the pages themselves: an interaction on the
+    # app's second host (ICICI's statement portal) is still this app's.
+    app_origins = {_url_origin(p["url"]) for p in pages}
+    if login_url:
+        app_origins.add(_url_origin(login_url))
+    app_origins.discard("")
     by_key = {_page_key(p["url"]): p for p in pages}
     out: list[dict] = []
     seen: set[str] = set()
@@ -890,7 +949,7 @@ def derive_terminal_operations(
         if kind is None:
             continue
         url = ev.get("url") or ""
-        if not url or (app_origin and _url_origin(url) != app_origin):
+        if not url or (app_origins and _url_origin(url) not in app_origins):
             continue
         if _is_login_flow_url(url):
             continue

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -168,6 +168,10 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
         cands.append(
             {
                 "text": text,
+                # The OTHER ways this control was seen. choose_locator collapses
+                # them to one winner above; the runtime needs the rest to fall
+                # back on when that winner stops matching.
+                "candidates": c.get("candidates"),
                 "selector": c.get("selector") or "",
                 "locator": locator,
                 "outcome": c.get("outcome") if isinstance(c.get("outcome"), dict) else None,
@@ -1095,6 +1099,7 @@ def derive_terminal_operations(
             {
                 "text": (ev.get("text_content") or "").strip(),
                 "locator": choose_locator(ev.get("candidates")),
+                "candidates": ev.get("candidates"),
                 "outcome": ev.get("outcome"),
             }
         )
@@ -1143,6 +1148,7 @@ def derive_terminal_operations(
                 {
                     "text": (c.get("text_content") or "").strip(),
                     "locator": choose_locator(c.get("candidates")),
+                    "candidates": c.get("candidates"),
                     "outcome": c.get("outcome"),
                 }
             )

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1697,11 +1697,14 @@ def _terminal_starts_from(op: dict) -> str | None:
     None means the landing page -- a terminal reached without any nav, which a
     fresh session is already positioned for.
     """
-    for click in reversed(op.get("nav") or []):
-        outcome = click.get("outcome")
-        if isinstance(outcome, dict) and outcome.get("to_url"):
-            return str(outcome["to_url"])
-    return None
+    # The operation's OWN page, which it already carries. Walking the nav chain
+    # for a recorded outcome was wrong: a cross-origin hop completes after the
+    # click returns, so it is never stamped on that click, and the walk fell
+    # back to the last hop that WAS stamped. download_statement came out
+    # starting from /credit-card while it runs on the statement portal, and its
+    # starts_from guard refused it every time.
+    url = str(op.get("url") or "").strip()
+    return url or None
 
 
 def _steps_for_terminal(op: dict) -> list[dict]:

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1478,3 +1478,78 @@ def _terminal_description(op: dict) -> str:
     if op.get("kind") == "download":
         return f"Download the file produced from {op['url']}"
     return f"Submit the form on {op['url']} and read the result"
+
+
+def _common_prefix_len(a: list[dict], b: list[dict]) -> int:
+    """How many leading steps two operations perform identically."""
+    n = 0
+    for x, y in zip(a, b):
+        if x != y:
+            break
+        n += 1
+    return n
+
+
+def _common_suffix_len(a: list[dict], b: list[dict], skip: int) -> int:
+    """How many trailing steps match, without eating into the shared prefix."""
+    n = 0
+    limit = min(len(a), len(b)) - skip
+    while n < limit and a[len(a) - 1 - n] == b[len(b) - 1 - n]:
+        n += 1
+    return n
+
+
+#: A fold has to rest on a real shared journey, not a coincidence. Two steps in
+#: common is the sort of overlap any two operations on one site have -- both open
+#: with the same nav click -- and folding on that would merge workflows that have
+#: nothing to do with each other.
+_MIN_FOLD_PREFIX = 3
+
+
+def fold_candidates(operations: list[dict]) -> list[dict]:
+    """Operations that are one workflow with a choice in the middle.
+
+    ICICI's monthly and annual statements share four steps to reach the download
+    page -- hover the nav, Credit Cards, Past, download previous statement -- then
+    diverge: annual clicks a radio and picks a financial year, monthly does not.
+    They also END the same way, on the download button and list_downloads. The
+    compiler emits them as two operations, each replaying the whole journey, so
+    every one of them needs the browser returned to the landing page first.
+
+    Reported, not applied. What the divergent branches should be CALLED is a
+    judgement this function cannot make: "corp_finacle" is the recorded page
+    name and means nothing to a caller choosing between monthly and annual. A
+    fold that emits a meaningless parameter is worse than two honest operations.
+
+    Returns one entry per foldable pair::
+
+        {"operations": [nameA, nameB], "prefix": int, "suffix": int,
+         "branches": [[steps...], [steps...]]}
+    """
+    out: list[dict] = []
+    ops = [o for o in operations or [] if (o.get("steps") or [])]
+    for i, a in enumerate(ops):
+        for b in ops[i + 1 :]:
+            if (a.get("kind") or "read") != (b.get("kind") or "read"):
+                continue
+            sa, sb = a.get("steps") or [], b.get("steps") or []
+            pre = _common_prefix_len(sa, sb)
+            if pre < _MIN_FOLD_PREFIX:
+                continue
+            suf = _common_suffix_len(sa, sb, pre)
+            if not suf:
+                # No shared ending means they do different things, however
+                # similarly they start.
+                continue
+            mid_a, mid_b = sa[pre : len(sa) - suf], sb[pre : len(sb) - suf]
+            if not mid_a and not mid_b:
+                continue  # identical operations; a fold is not what they need
+            out.append(
+                {
+                    "operations": [a.get("name"), b.get("name")],
+                    "prefix": pre,
+                    "suffix": suf,
+                    "branches": [mid_a, mid_b],
+                }
+            )
+    return out

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -859,13 +859,17 @@ def entry_urls_by_origin(url_events: list[dict]) -> dict:
     """
     out: dict = {}
     for ev in url_events or []:
-        to = str((ev or {}).get("to_url") or "")
-        if not to or to == "about:blank" or _is_login_flow_url(to):
-            continue
-        m = re.match(r"^[a-z]+://[^/]+", to, re.I)
-        if not m:
-            continue
-        out.setdefault(m.group(0).lower(), to)
+        # from_url BEFORE to_url. The compiler is handed the workflow slice,
+        # whose first transition is already /overview -> /credit-card, so
+        # reading destinations alone made the net-banking entry /credit-card --
+        # the page the first step is trying to REACH. The same trap entry_url
+        # fell into.
+        for url in (str((ev or {}).get("from_url") or ""), str((ev or {}).get("to_url") or "")):
+            if not url or url == "about:blank" or _is_login_flow_url(url):
+                continue
+            m = re.match(r"^[a-z]+://[^/]+", url, re.I)
+            if m:
+                out.setdefault(m.group(0).lower(), url)
     return out
 
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -27,6 +27,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import urlparse
 
+from noui_core.compile.locators import AMBIGUOUS, choose_locator
 from noui_core.compile.login_assets import (
     _LOGIN_FLOW_SEGMENTS,
     _first_path_segment,
@@ -98,6 +99,19 @@ def _parse_ts(ts: str) -> datetime | None:
         return None
 
 
+def _same_target(a: dict, b: dict) -> bool:
+    """Do two recorded clicks address the same control?
+
+    Only consulted for TEXT-LESS clicks, where equal (empty) labels are no
+    evidence at all: a bank nav's hamburger and its chevrons all have empty text,
+    and collapsing them as duplicates would drop steps out of the gesture.
+    """
+    la, lb = a.get("locator"), b.get("locator")
+    if la and lb:
+        return la.get("kind") == lb.get("kind") and la.get("value") == lb.get("value")
+    return bool(a.get("selector")) and a.get("selector") == b.get("selector")
+
+
 def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> list[dict]:
     """The recorded click CHAIN that drove an in-app navigation FROM from_url.
 
@@ -134,7 +148,13 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
         if not cu or _page_key(cu) != from_key:
             continue
         text = (c.get("text_content") or "").strip()
-        if not text:
+        locator = choose_locator(c.get("candidates"))
+        # A click with no visible text used to be discarded outright, which threw
+        # away every icon/SVG control — the hamburger toggle and the chevrons that
+        # open a bank nav's accordions. With recorded candidates such a control is
+        # addressable (test-id, aria-label, role+name), so it is only dropped when
+        # there is no way to address it at all.
+        if not text and locator is None:
             continue
         cdt = _parse_ts(c.get("timestamp") or "")
         cseq = event_seq(c)
@@ -144,7 +164,16 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
                 continue
         elif nav_dt and cdt and cdt > nav_dt:
             continue
-        cands.append({"text": text, "selector": c.get("selector") or "", "dt": cdt, "seq": cseq})
+        cands.append(
+            {
+                "text": text,
+                "selector": c.get("selector") or "",
+                "locator": locator,
+                "outcome": c.get("outcome") if isinstance(c.get("outcome"), dict) else None,
+                "dt": cdt,
+                "seq": cseq,
+            }
+        )
     if not cands:
         return []
 
@@ -173,9 +202,19 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
     # to the trailing N so only the immediate expand→navigate steps are emitted.
     out: list[dict] = []
     for c in chain:
-        if out and out[-1]["text"] == c["text"]:
+        # Collapse consecutive identical labels — but only when they are really
+        # the same control. Two different icon buttons both have empty text, and
+        # merging them would silently drop a step in the gesture.
+        if out and out[-1]["text"] == c["text"] and (c["text"] or _same_target(out[-1], c)):
             continue
-        out.append({"text": c["text"], "selector": c["selector"]})
+        out.append(
+            {
+                "text": c["text"],
+                "selector": c["selector"],
+                "locator": c["locator"],
+                "outcome": c["outcome"],
+            }
+        )
     if len(out) <= _NAV_MAX_CLICKS:
         return out
     # Keep the FIRST click plus the most recent ones. A plain trailing slice drops
@@ -312,14 +351,84 @@ def _resolve_nav_chains(pages: list[dict]) -> list[dict]:
     return resolved
 
 
+def _step_for_click(click: dict) -> dict | None:
+    """One compiled step for one recorded click.
+
+    Prefers the recorded locator CANDIDATE that matched exactly one node, which
+    is the only kind known to identify the control. CSS-expressible candidates
+    become `click_element`; semantic ones (role+name, label, visible text) become
+    `click_by_text`, which is what the runtime can resolve.
+
+    `exact: true` is set on text clicks. The recorder tells us the text matched a
+    single control, so a substring match can only widen that back into the
+    ambiguity we just eliminated — the HSBCnet misclick.
+
+    Falls back to the recorded text when there is no usable candidate, which is
+    what every pre-schema-4 recording will hit.
+    """
+    locator = click.get("locator")
+    text = (click.get("text") or "").strip()
+
+    step: dict | None = None
+    if locator and locator.get("is_css"):
+        step = {"command": "click_element", "params": {"selector": locator["value"]}}
+    elif locator:
+        # role_name candidates carry "role|name"; the runtime matches on the name.
+        value = locator["value"]
+        if locator["kind"] == "role_name" and "|" in value:
+            value = value.split("|", 1)[1]
+        step = {"command": "click_by_text", "params": {"text": value, "exact": True}}
+    elif text:
+        step = {"command": "click_by_text", "params": {"text": text}}
+
+    if step is None:
+        return None
+
+    if locator:
+        # Carried for the human reading the recipe and for a future repair pass:
+        # an AMBIGUOUS step is the one to re-point first when a skill misbehaves.
+        step["locator"] = {
+            "kind": locator["kind"],
+            "confidence": locator["confidence"],
+            "match_count": locator["match_count"],
+        }
+        if text and not locator.get("is_css"):
+            step["locator"]["recorded_text"] = text
+    return step
+
+
+def _expect_for_click(click: dict) -> dict | None:
+    """The postcondition a step should assert, from what the recorder observed.
+
+    A linear script cannot tell that it has gone wrong; it just keeps clicking.
+    An expectation turns that into a stop: "after this click the URL becomes X"
+    is checkable in one step, instead of the failure surfacing five clicks later
+    on the wrong page with confidently wrong data.
+    """
+    outcome = click.get("outcome")
+    if not isinstance(outcome, dict):
+        return None
+    expect: dict = {}
+    if outcome.get("navigated") and outcome.get("to_url"):
+        expect["url"] = outcome["to_url"]
+    if outcome.get("download"):
+        expect["download"] = True
+    settled = outcome.get("settled_ms")
+    if isinstance(settled, int) and settled > 0:
+        # Observed, not guessed. Rounded up to a whole second and given headroom,
+        # because a recorded settle is one sample from one network.
+        expect["settle_ms"] = min(15000, max(1000, settled * 2))
+    return expect or None
+
+
 def _steps_for_page(p: dict) -> list[dict]:
     """Recipe to read a page WITHOUT a reload.
 
     - landing page (nav is None): just get_page_summary — the session already
       lands here after login.
-    - in-app page (nav is a click chain): one click_by_text per click in the
-      gesture (e.g. expand "Cards" → click "Credit Card") — each a client-side
-      route change, no reload — then get_page_summary.
+    - in-app page (nav is a click chain): one click step per click in the gesture
+      (e.g. expand "Cards" → click "Credit Card") — each a client-side route
+      change, no reload — then get_page_summary.
 
     A full-page navigate/goto is deliberately never emitted: it reloads the page,
     and refresh-sensitive portals expire the session on it (the ICICI failure —
@@ -327,10 +436,31 @@ def _steps_for_page(p: dict) -> list[dict]:
     """
     steps: list[dict] = []
     for click in p.get("nav") or []:
-        if click.get("text"):
-            steps.append({"command": "click_by_text", "params": {"text": click["text"]}})
+        step = _step_for_click(click)
+        if step is None:
+            continue
+        expect = _expect_for_click(click)
+        if expect:
+            step["expect"] = expect
+        steps.append(step)
     steps.append({"command": "get_page_summary"})
     return steps
+
+
+def ambiguous_steps(pages: list[dict]) -> list[dict]:
+    """Steps whose locator is known to match more than one node.
+
+    Surfaced rather than hidden: these are exactly the steps that compile
+    cleanly and then misclick, and they are the first thing to re-point when a
+    skill misbehaves.
+    """
+    out: list[dict] = []
+    for p in pages:
+        for click in p.get("nav") or []:
+            loc = click.get("locator")
+            if loc and loc.get("confidence") == AMBIGUOUS:
+                out.append({"page": p["name"], "text": click.get("text") or "", "locator": loc})
+    return out
 
 
 def render_browser_operations_json(pages: list[dict], *, profile_slug: str) -> str:
@@ -375,10 +505,19 @@ def render_browser_skill_md(
         f"`call_web_browser` tool rather than calling APIs directly."
     )
 
+    def _describe(c: dict) -> str:
+        text = (c.get("text") or "").strip()
+        if text:
+            return f'click "{text}"'
+        loc = c.get("locator") or {}
+        # An icon/SVG control has no label to quote; name it by how the step
+        # addresses it, so the line stays readable instead of `click ""`.
+        return f"click the control matching `{loc.get('kind', 'selector')}`"
+
     def _page_line(p: dict) -> str:
         nav = p.get("nav")
         if nav:
-            clicks = " then ".join(f'click "{c["text"]}"' for c in nav if c.get("text"))
+            clicks = " then ".join(_describe(c) for c in nav)
             how = clicks or "the page you land on after login"
         else:
             how = "the page you land on after login"
@@ -388,6 +527,26 @@ def render_browser_skill_md(
         "\n".join(_page_line(p) for p in pages)
         or "- (no data pages were captured; re-record reaching the target screen)"
     )
+
+    # Name the ambiguous steps outright. A compile that quietly ships a locator
+    # known to match several elements is the exact failure this redesign exists
+    # to remove; the human re-recording is the one who can fix it.
+    flagged = ambiguous_steps(pages)
+    if flagged:
+        lines = "\n".join(
+            f"- `{f['page']}` — {f['locator']['kind']} "
+            f"matched {f['locator']['match_count']} elements"
+            + (f' (text: "{f["text"]}")' if f["text"] else "")
+            for f in flagged
+        )
+        ambiguity_note = (
+            "\n\n### Known ambiguous steps in this skill\n\n"
+            f"{lines}\n\n"
+            "These were recorded against a page where the control could not be "
+            "pinned down uniquely. Re-record those steps if this skill misbehaves."
+        )
+    else:
+        ambiguity_note = ""
 
     frontmatter = (
         "---\n"
@@ -426,11 +585,31 @@ full-page navigate. This app expires the session on a page reload, so a
 click is a client-side route change that preserves the session.
 
 For each readable page below:
-1. If it lists a click, `call_web_browser` with `command: "click_by_text"`,
-   `params: {{ "text": "<the menu item>" }}` to route there in-app.
+1. If it lists a click, run the step exactly as `operations.json` gives it —
+   `click_element` with the recorded selector where there is one, otherwise
+   `click_by_text`. Do not substitute your own selector or text: the recorded
+   one was verified to match a single control at record time.
 2. `call_web_browser` with `command: "get_page_summary"` — returns the page's
    headings, links, buttons and inputs (the rendered account/card/transaction
    values live in `headings`).
+
+## Checking each step
+
+Steps in `operations.json` may carry an `expect` block describing what was
+OBSERVED when this flow was recorded:
+
+- `url` — the page you should be on after the click. If you are somewhere else,
+  **stop and report it**. Do not keep clicking: the remaining steps were recorded
+  for a different page, and continuing produces confidently wrong data.
+- `settle_ms` — how long the recorded page took to finish loading, with headroom.
+  Give it that long before reading rather than reading immediately.
+- `download` — this step produced a file. That is the operation's success
+  condition; if no download starts, the step did not work.
+
+A step may also carry a `locator` block. When its `confidence` is `ambiguous`,
+the recorded way of addressing that control matched several elements on the page,
+so it may well click the wrong one — treat a surprising result there as the
+likely cause, and report it rather than working around it.{ambiguity_note}
 
 The landing page needs no click — just read it. If a value you need is not in the
 summary, `command: "click_by_text"` on the relevant control (e.g. a "view all"

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -143,7 +143,11 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
     nav_seq = event_seq(nav_ev)
     cands: list[dict] = []
     for c in click_events or []:
-        if (c.get("event_type") or "click") != "click":
+        # A hover that opened a menu is part of the gesture, not noise: the
+        # click after it targets something that does not exist until the pointer
+        # is over the parent. Dropping it left the compiled path with no step
+        # that opens the menu.
+        if (c.get("event_type") or "click") not in ("click", "hover"):
             continue
         cu = c.get("url") or ""
         if not cu or _page_key(cu) != from_key:
@@ -477,6 +481,21 @@ def _step_for_click(click: dict) -> dict | None:
         if expect:
             step["expect"] = expect
         return step
+
+    if (click.get("event_type") or "") == "hover":
+        # Hover is addressed like any other control, but it opens rather than
+        # activates. Only a CSS-expressible locator can be hovered: there is no
+        # hover-by-text, and guessing one would hover the wrong thing.
+        if not (locator and locator.get("is_css")):
+            return None
+        hover: dict = {"command": "hover", "params": {"selector": locator["value"]}}
+        element = click.get("element") or {}
+        if isinstance(element, dict) and element.get("in_iframe"):
+            for key in ("frame_url", "frame_name"):
+                value = str(element.get(key) or "").strip()
+                if value:
+                    hover["params"][key] = value
+        return hover
 
     step: dict | None = None
     if locator and locator.get("is_css"):
@@ -1137,7 +1156,8 @@ def derive_terminal_operations(
         # the caller passes.
         lead_steps: list[dict] = []
         for c in click_events or []:
-            if (c.get("event_type") or "click") != "click":
+            # A hover that opened a menu is part of the gesture, not noise.
+            if (c.get("event_type") or "click") not in ("click", "hover"):
                 continue
             if _page_key(c.get("url") or "") != _page_key(url):
                 continue

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1021,6 +1021,41 @@ def derive_terminal_operations(
         ]
         parameters = derive_parameters(page_inputs)
 
+        # The clicks the human made ON THIS PAGE before the terminal one.
+        #
+        # Only the final click was kept, so a statement download compiled to
+        # "click Download" alone -- losing the "Past Statements" tab and the
+        # "Annual" period that decide WHAT is downloaded. At replay the click
+        # landed on whatever the page happened to show, which is how a run ended
+        # up hunting a control that was one tab away.
+        #
+        # Bounded to the same page and to before the terminal interaction, so a
+        # later screen's clicks never leak in. Inputs are excluded: those become
+        # parameters above, and replaying them as clicks would fight the values
+        # the caller passes.
+        lead_steps: list[dict] = []
+        for c in click_events or []:
+            if (c.get("event_type") or "click") != "click":
+                continue
+            if _page_key(c.get("url") or "") != _page_key(url):
+                continue
+            c_seq = event_seq(c)
+            if term_seq is None or c_seq is None or c_seq >= term_seq:
+                continue
+            lead = _step_for_click(
+                {
+                    "text": (c.get("text_content") or "").strip(),
+                    "locator": choose_locator(c.get("candidates")),
+                    "outcome": c.get("outcome"),
+                }
+            )
+            if lead is None:
+                continue
+            lead_expect = _expect_for_click({"outcome": c.get("outcome")})
+            if lead_expect:
+                lead["expect"] = lead_expect
+            lead_steps.append(lead)
+
         name = _op_name(kind, ev, _slug_from_path(url))
         if name in seen:
             continue
@@ -1034,6 +1069,7 @@ def derive_terminal_operations(
                 # Reach the page exactly the way the read operation for it does.
                 "nav": list(page.get("nav") or []),
                 "parameters": parameters,
+                "lead": lead_steps,
                 "terminal": step,
             }
         )
@@ -1053,6 +1089,10 @@ def _steps_for_terminal(op: dict) -> list[dict]:
         steps.append(step)
     # Values the caller can override. Templated on the parameter name, so the
     # operation does exactly what was recorded when nothing is passed.
+    # Set the page up the way the human did — tab, period, filter — before the
+    # values the caller can override, so a passed parameter lands on the screen
+    # those clicks produced rather than on whatever loaded first.
+    steps.extend(op.get("lead") or [])
     steps.extend(fill_steps(op.get("parameters") or []))
     steps.append(op["terminal"])
     if op.get("kind") == "download":

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -37,6 +37,77 @@ from noui_core.compile.login_assets import (
 from noui_core.compile.parameters import derive_parameters, fill_steps
 from noui_core.event_order import event_seq, order_events
 
+# 12-19 digits is the ISO/IEC 7812 PAN range and covers bank account numbers too;
+# separators are allowed because portals print cards grouped ("4315 8105 5762 5005").
+_ACCOUNT_NUMBER = re.compile(r"\d(?:[ .\-]?\d){11,18}")
+
+
+def _carries_account_number(value: str) -> bool:
+    """Whether a locator value would put an account/card number in the artifact.
+
+    The recorder masks displayed text at capture (see `maskSensitive` in
+    tabby's dom-recorder), so new bundles arrive clean. This is the compiler's
+    own guard, and it earns its place twice: bundles recorded BEFORE that fix
+    still hold raw numbers -- the icici-cc-v6 capture compiled a `click_by_text`
+    fallback reading "Credit Card Number Select 4315810557625005(INR) - NAVJOT
+    SINGH" -- and re-recording a bank journey to undo a leak is an expensive way
+    to fix a file we can simply refuse to write.
+
+    Matching '[REDACTED]' as well means a masked candidate is dropped rather
+    than compiled into a step that can never match anything.
+    """
+    return "[REDACTED]" in value or bool(_ACCOUNT_NUMBER.search(value))
+
+
+def _scrub_account_numbers(click_events: list[dict] | None) -> list[dict] | None:
+    """Strip account/card numbers from a capture before anything compiles it.
+
+    Applied once, at the browser compiler's only public entry, rather than at
+    each of the four places that read `text_content` -- one of those was missed
+    the first time and that is precisely how the number reached the artifact.
+
+    Text is dropped, not masked: every consumer here already handles a textless
+    event by falling back to the structural candidates (that is how icon-only
+    controls compile), whereas a "[REDACTED]" label would compile into a
+    `click_by_text` that matches nothing and costs a replay timeout to discover.
+
+    Copies rather than mutating -- the caller's bundle is also what gets written
+    to disk as recording_bundle.json, and a scrub is not a reason to rewrite the
+    evidence of what was recorded.
+
+    Only click events are scrubbed. url_events carry URLs, where a number is
+    part of the address the skill must actually request; the login/HAR compiler
+    is not on this path at all.
+    """
+    if not click_events:
+        return click_events
+    out: list[dict] = []
+    for ev in click_events:
+        if not isinstance(ev, dict):
+            out.append(ev)
+            continue
+        clean = dict(ev)
+        for field in ("text_content", "aria_label", "placeholder"):
+            value = clean.get(field)
+            if isinstance(value, str) and _carries_account_number(value):
+                clean[field] = None
+        cands = clean.get("candidates")
+        if isinstance(cands, list):
+            clean["candidates"] = [
+                c
+                for c in cands
+                if not (isinstance(c, dict) and _carries_account_number(str(c.get("value") or "")))
+            ]
+        element = clean.get("element")
+        if isinstance(element, dict):
+            name = element.get("accessible_name")
+            if isinstance(name, str) and _carries_account_number(name):
+                element = dict(element)
+                element["accessible_name"] = None
+                clean["element"] = element
+        out.append(clean)
+    return out
+
 
 def _slug_from_path(url: str) -> str:
     """A stable, readable operation-name stem from a URL's path.
@@ -836,6 +907,8 @@ def _step_for_click(click: dict) -> dict | None:
         kind = str(cand.get("kind") or "")
         if kind == "role_name" and "|" in value:
             value = value.split("|", 1)[1]
+        if _carries_account_number(value):
+            continue
         alts.append({"selector": value} if _is_css_kind(kind) else {"text": value})
     if alts:
         step["params"]["fallbacks"] = alts[:4]
@@ -1646,6 +1719,7 @@ def generate_browser_skill(
 
     Returns the manifest dict.
     """
+    click_events = _scrub_account_numbers(click_events)
     if not profile_slug:
         raise ValueError(
             "generate_browser_skill requires a profile_slug: a browser skill "

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -2003,6 +2003,30 @@ def generate_browser_skill(
 _TERMINAL_KINDS = ("download", "submit")
 
 
+#: A control whose own label or selector says it fetches a file. Mirrors the
+#: recorder's download-word heuristic (tabby recording-outcomes.ts).
+_DOWNLOAD_WORDS = re.compile(r"download|\bpdf\b|\.pdf|\bexport\b", re.IGNORECASE)
+
+
+def _looks_like_download_control(ev: dict) -> bool:
+    """Does this control plainly download a file, whatever the outcome recorded?
+
+    A flaky or slow file server -- ICICI's e-statement PDF routinely needs a
+    retry and often does not finish inside the recorder's attribution window --
+    leaves ``outcome.download`` unset even though the control IS a download. Read
+    the control's own words (label, chosen locator, candidate selectors) so such
+    a terminal is still judged as a download.
+    """
+    parts = [str(ev.get("text_content") or "")]
+    loc = ev.get("locator")
+    if isinstance(loc, dict) and loc.get("value"):
+        parts.append(str(loc["value"]))
+    for c in ev.get("candidates") or []:
+        if isinstance(c, dict) and c.get("value"):
+            parts.append(str(c["value"]))
+    return bool(_DOWNLOAD_WORDS.search(" ".join(parts)))
+
+
 def _terminal_kind(ev: dict) -> str | None:
     """What goal, if any, this interaction completed.
 
@@ -2023,6 +2047,16 @@ def _terminal_kind(ev: dict) -> str | None:
     # outcome-gated). An outcome means the recorder was schema 5, i.e. a capture
     # from this PR onward.
     if isinstance(outcome, dict) and (ev.get("event_type") or "") == "submit":
+        # A submit whose control plainly downloads a file (its label/selector says
+        # "download"/"PDF") is a download whose server was too slow/flaky for
+        # outcome.download to land. Judge it as a download -- goal_reached then
+        # asks for a FRESH file (see the download-freshness baseline), not for a
+        # visibility-gated click that a not-yet-rendered PDF panel blocks. This is
+        # exactly the ICICI #PDF_Download / #DOWNLOAD_ESTATEMENT_PDF case: the
+        # file arrives, but the terminal button is hidden while the panel loads,
+        # so as a `submit` the op failed on a blocked step it did not need.
+        if _looks_like_download_control(ev):
+            return "download"
         return "submit"
     return None
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -769,8 +769,38 @@ def ambiguous_steps(pages: list[dict]) -> list[dict]:
     return out
 
 
+def entry_url_for(url_events: list[dict], pages: list[dict]) -> str:
+    """Where the journey starts: the page the FIRST step acts on.
+
+    Not pages[0]["url"] -- that is a DESTINATION. A page's recipe begins with
+    the click chain that reached it, and that chain is performed on an earlier
+    page. On a recording whose split kept /overview as a readable page the two
+    happened to coincide; on one that did not, entry_url came out as
+    /credit-card while every operation's step 0 was `click_by_text "Credit
+    Cards"` -- a click you make FROM /overview. Resetting there and then
+    clicking would land nowhere, which is the drift bug from the other side.
+
+    So: the first page reached from the login flow -- the post-login landing
+    page, which is where the session itself lands and where the chains start.
+    A page whose own nav is None is that page by definition, and is preferred
+    when one survived compilation.
+    """
+    for p in pages or []:
+        if p.get("nav") is None and p.get("url"):
+            return str(p["url"])
+    for ev in url_events or []:
+        frm, to = str((ev or {}).get("from_url") or ""), str((ev or {}).get("to_url") or "")
+        if to and frm and _is_login_flow_url(frm) and not _is_login_flow_url(to):
+            return to
+    return str((pages or [{}])[0].get("url") or "")
+
+
 def render_browser_operations_json(
-    pages: list[dict], *, profile_slug: str, terminal_ops: list[dict] | None = None
+    pages: list[dict],
+    *,
+    profile_slug: str,
+    terminal_ops: list[dict] | None = None,
+    entry_url: str = "",
 ) -> str:
     """operations.json for a browser skill — a click+read recipe per page.
 
@@ -803,13 +833,14 @@ def render_browser_operations_json(
             }
         )
     doc = {"schema_version": "1", "style": "browser", "operations": operations}
-    if pages:
+    if entry_url:
         # Where the journey starts. These operations are one recorded journey cut
         # into pieces -- op N+1 begins on the page op N left behind -- so replaying
-        # them means reproducing that journey from its first page, which is the
-        # post-login landing page and the only one reachable without the steps
-        # that precede it.
-        doc["entry_url"] = pages[0]["url"]
+        # them means reproducing that journey from the page its first step acts
+        # on, which is the post-login landing page and the only one reachable
+        # without the steps that precede it. See entry_url_for: this is NOT the
+        # first readable page, which is a destination.
+        doc["entry_url"] = entry_url
     return json.dumps(doc, indent=2, ensure_ascii=False)
 
 
@@ -1057,7 +1088,10 @@ def generate_browser_skill(
     (out_path / "SKILL.md").write_text(skill_md, encoding="utf-8")
 
     operations_json = render_browser_operations_json(
-        pages, profile_slug=profile_slug, terminal_ops=terminal_ops
+        pages,
+        profile_slug=profile_slug,
+        terminal_ops=terminal_ops,
+        entry_url=entry_url_for(url_events, pages),
     )
     (out_path / "operations.json").write_text(operations_json, encoding="utf-8")
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -802,11 +802,15 @@ def render_browser_operations_json(
                 "steps": _steps_for_terminal(op),
             }
         )
-    return json.dumps(
-        {"schema_version": "1", "style": "browser", "operations": operations},
-        indent=2,
-        ensure_ascii=False,
-    )
+    doc = {"schema_version": "1", "style": "browser", "operations": operations}
+    if pages:
+        # Where the journey starts. These operations are one recorded journey cut
+        # into pieces -- op N+1 begins on the page op N left behind -- so replaying
+        # them means reproducing that journey from its first page, which is the
+        # post-login landing page and the only one reachable without the steps
+        # that precede it.
+        doc["entry_url"] = pages[0]["url"]
+    return json.dumps(doc, indent=2, ensure_ascii=False)
 
 
 def render_browser_skill_md(

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -762,11 +762,49 @@ def _steps_for_page(p: dict) -> list[dict]:
     the skill's own read landed on /session-expire).
     """
     steps: list[dict] = []
+    carried: dict = {}
     for click in p.get("nav") or []:
         step = _step_for_click(click)
         if step is None:
             continue
-        expect = _expect_for_click(click)
+        expect = _expect_for_click(click) or {}
+        if step.get("command") == "hover":
+            # A hover cannot navigate or download -- it opens the thing that
+            # does. The recorder stamps a hover and the click it reveals at the
+            # same millisecond, so the arrival outcome was attributed to the
+            # hover, and the compiled step asserted "you are now on /credit-card"
+            # immediately after opening a menu. The replay failed there every
+            # time, on an assertion no hover could ever satisfy.
+            #
+            # Carry those parts to the step that does cause them rather than
+            # discarding: the assertion is the only thing that stops a linear
+            # script walking on after a hop silently failed.
+            for key in ("url", "download"):
+                if key in expect:
+                    carried[key] = expect.pop(key)
+        elif carried:
+            expect = {**carried, **expect}
+            carried = {}
+            # The click cannot share the hover's target.
+            #
+            # Both events resolved to the same single candidate --
+            # #scroll-container > div > div:nth-of-type(5), the CARDS nav block --
+            # because the recorder's candidate builder climbed to the same
+            # actionable ancestor for the submenu link as for the icon box that
+            # opens it. The compiled click then clicked the thing that had just
+            # been hovered and nothing navigated.
+            #
+            # They cannot both be right: a hover opens, and the click lands on
+            # what it revealed. The click's own recorded selector describes the
+            # element that was actually hit, so prefer it when the candidates
+            # collide. Only then -- an ordinary click keeps its chosen locator,
+            # which is ranked for a reason.
+            prev = steps[-1] if steps else None
+            if prev is not None and prev.get("command") == "hover":
+                same = (prev.get("params") or {}).get("selector")
+                own = str(click.get("selector") or "").strip()
+                if same and own and (step.get("params") or {}).get("selector") == same:
+                    step["params"]["selector"] = own
         if expect:
             step["expect"] = expect
         steps.append(step)

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1332,9 +1332,27 @@ def render_browser_operations_json(
         # over is a separate change, and until it happens nothing here moves.
         # Note `starts_from: null` means the landing page, where a fresh session
         # already is.
-        if p.get("starts_from") is not None or p.get("segment") is not None:
-            op["starts_from"] = p.get("starts_from")
-            op["segment_steps"] = _steps_for_page({**p, "nav": p.get("segment")})
+        # EVERY page operation carries a segment, even an empty one.
+        #
+        # The landing page has no steps of its own -- a fresh session is already
+        # there -- so this used to leave `segment_steps` absent entirely. That
+        # made it the one unsegmented operation in an otherwise segmented skill,
+        # and `run_replay` refuses a MIXTURE (it decides how the whole replay
+        # executes, so a mixture would silently run everything the legacy way).
+        # Every combined import therefore compiled to a skill that could not be
+        # replayed, could not be approved, and could not be installed -- and
+        # recompiling reproduced it. Seen on a harness run that spent two hours
+        # pruning and amending to get around it.
+        #
+        # An empty segment is the honest answer: this operation IS segmented,
+        # and its own work is nothing. The refusal still catches what it was
+        # written for, a genuinely unsegmented operation among segmented ones.
+        op["starts_from"] = p.get("starts_from")
+        op["segment_steps"] = (
+            _steps_for_page({**p, "nav": p.get("segment")})
+            if p.get("segment") is not None
+            else []
+        )
         # How long the page AFTER this operation took to become usable, measured
         # from the human's own gap. Stamped on the operation that CAUSES the
         # arrival, because that is the click the gap was measured from.

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -753,6 +753,8 @@ def generate_browser_skill(
     session_id: str = "",
     start_url: str = "",
     description_override: str = "",
+    bundle: dict | None = None,
+    bundle_file: str = "",
 ) -> dict:
     """Compile a recording into an installable browser-driven skill directory.
 
@@ -856,6 +858,22 @@ def generate_browser_skill(
             "generator_version": "v1-browser-skill",
         },
     }
+    # Bind the skill to the recording it came from. The installer verifies this
+    # against the bundle itself, which is the only artifact here that a skill
+    # written from imagination cannot produce. See compile/provenance.py.
+    if bundle is not None:
+        from noui_core.compile import provenance as _provenance
+
+        # Write the exact bundle that was compiled, beside the skill. Pointing at
+        # the saved capture instead would not survive a combined import, where the
+        # bundle is split and only a HALF reaches this compiler — the digest would
+        # never match the file on disk and every real skill would be rejected.
+        (out_path / _provenance.BUNDLE_FILE).write_text(
+            json.dumps(bundle, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        manifest["provenance"] = _provenance.build(
+            bundle, bundle_file=bundle_file or _provenance.BUNDLE_FILE
+        )
     (out_path / "manifest.json").write_text(
         json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
     )

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -968,6 +968,12 @@ def render_browser_operations_json(
                 "kind": op["kind"],
                 "parameters": op.get("parameters") or [],
                 "steps": _steps_for_terminal(op),
+                # Alongside steps, exactly as for page operations: the work this
+                # operation does on its own page, and the page it starts on.
+                # Nothing reads these yet -- wiring the replay to run segments in
+                # recorded order is a separate change.
+                "starts_from": _terminal_starts_from(op),
+                "segment_steps": _terminal_segment(op),
             }
         )
     doc = {"schema_version": "1", "style": "browser", "operations": operations}
@@ -1497,6 +1503,35 @@ def derive_terminal_operations(
             }
         )
     return out
+
+
+def _terminal_segment(op: dict) -> list[dict]:
+    """A terminal operation's own work, without the journey that reaches it.
+
+    `_steps_for_terminal` prefixes the whole nav chain from the landing page, so
+    a download repeats four clicks the previous operation already made. The
+    segment is what actually happens ON the page: the lead-in that sets it up
+    (tab, period, filter), the parameter fills, and the terminal action itself.
+
+    Built by the real recipe with the journey removed, not by re-listing its
+    parts: a hand-mirrored version already dropped the trailing list_downloads
+    that confirms a download actually arrived, which is the operation's whole
+    success condition.
+    """
+    return _steps_for_terminal({**op, "nav": []})
+
+
+def _terminal_starts_from(op: dict) -> str | None:
+    """The page a terminal operation begins on: where its nav chain arrived.
+
+    None means the landing page -- a terminal reached without any nav, which a
+    fresh session is already positioned for.
+    """
+    for click in reversed(op.get("nav") or []):
+        outcome = click.get("outcome")
+        if isinstance(outcome, dict) and outcome.get("to_url"):
+            return str(outcome["to_url"])
+    return None
 
 
 def _steps_for_terminal(op: dict) -> list[dict]:

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1608,11 +1608,25 @@ def derive_terminal_operations(
         # a search term. Bounded to the same page and to interactions preceding
         # the terminal one, so a later screen's fields never leak in.
         term_seq = event_seq(ev)
+        # The page the WORK happened on, which is not always the operation's
+        # url. A download click navigates: download_corp_finacle was keyed to
+        # /corp/Finacle, where the navigation landed, while its terminal click
+        # and every step that decides WHAT is downloaded -- the Annual radio,
+        # the GO button, the PDF icon -- happened on the statement page before
+        # it. Filtering by the landing page dropped all of them into `nav`,
+        # where the segment builder strips them.
+        #
+        # The consequence was not a failing step. Without the Annual radio the
+        # form stays on Monthly, so `timeframe=annual` picked a different month
+        # and returned a MONTHLY statement, with every check passing.
+        #
+        # Naming still uses the operation's url, so no name changes here.
+        work_url = str(ev.get("url") or url)
         page_inputs = [
             c
             for c in click_events or []
             if (c.get("event_type") or "") in ("input", "change")
-            and _page_key(c.get("url") or "") == _page_key(url)
+            and _page_key(c.get("url") or "") == _page_key(work_url)
             and (term_seq is None or (event_seq(c) or 0) < term_seq)
         ]
         parameters = derive_parameters(page_inputs)
@@ -1634,7 +1648,7 @@ def derive_terminal_operations(
             # A hover that opened a menu is part of the gesture, not noise.
             if (c.get("event_type") or "click") not in ("click", "hover"):
                 continue
-            if _page_key(c.get("url") or "") != _page_key(url):
+            if _page_key(c.get("url") or "") != _page_key(work_url):
                 continue
             c_seq = event_seq(c)
             if term_seq is None or c_seq is None or c_seq >= term_seq:
@@ -1665,6 +1679,8 @@ def derive_terminal_operations(
                 "name": name,
                 "kind": kind,
                 "url": url,
+                # Where its work happens -- what starts_from must name.
+                "work_url": work_url,
                 # Reach the page exactly the way the read operation for it does.
                 "nav": list(page.get("nav") or []),
                 "parameters": parameters,
@@ -1703,7 +1719,7 @@ def _terminal_starts_from(op: dict) -> str | None:
     # back to the last hop that WAS stamped. download_statement came out
     # starting from /credit-card while it runs on the statement portal, and its
     # starts_from guard refused it every time.
-    url = str(op.get("url") or "").strip()
+    url = str(op.get("work_url") or op.get("url") or "").strip()
     return url or None
 
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1741,7 +1741,26 @@ def _steps_for_terminal(op: dict) -> list[dict]:
     # those clicks produced rather than on whatever loaded first.
     steps.extend(op.get("lead") or [])
     steps.extend(fill_steps(op.get("parameters") or []))
-    steps.append(op["terminal"])
+    # The terminal asserts WHICH PAGE it fires on.
+    #
+    # ICICI's annual and monthly statement pages are identically designed:
+    # #PDF_Download and #DOWNLOAD_ESTATEMENT_PDF exist on both and behave the
+    # same. So the monthly steps run happily on either and return whatever that
+    # page is showing -- timeframe=annual returned a MONTHLY statement with
+    # every check green, because every check we had looked at selectors.
+    #
+    # The pages differ in one thing the recording captured: their URL. The
+    # annual flow is reached by a radio click that navigates to /corp/Finacle;
+    # monthly downloads happen on /corp/AuthenticationController. Asserting the
+    # page the terminal was RECORDED on turns a silent wrong document into a
+    # failed postcondition, which expectation_unmet already enforces.
+    terminal = dict(op["terminal"])
+    page_url = str(op.get("work_url") or op.get("url") or "").strip()
+    if page_url:
+        expect = dict(terminal.get("expect") or {})
+        expect.setdefault("url", page_url)
+        terminal["expect"] = expect
+    steps.append(terminal)
     steps = _collapse_repeats(steps)
     if op.get("kind") == "download":
         # The artifact IS the result, so the operation ends by naming it rather

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -846,6 +846,29 @@ def ambiguous_steps(pages: list[dict]) -> list[dict]:
     return out
 
 
+def entry_urls_by_origin(url_events: list[dict]) -> dict:
+    """The first page the journey reached on EACH host it visited.
+
+    A reset must not change hosts. The recording went forward only --
+    /overview -> /credit-card -> the statement portal -- and never walked back,
+    so no route home across origins was ever observed and any we invent is a
+    guess. Staying on the host you are already on keeps a reset to something the
+    recording actually saw: the first page it reached there.
+
+    Sign-in pages are excluded; they are not where a journey resumes.
+    """
+    out: dict = {}
+    for ev in url_events or []:
+        to = str((ev or {}).get("to_url") or "")
+        if not to or to == "about:blank" or _is_login_flow_url(to):
+            continue
+        m = re.match(r"^[a-z]+://[^/]+", to, re.I)
+        if not m:
+            continue
+        out.setdefault(m.group(0).lower(), to)
+    return out
+
+
 def entry_url_for(url_events: list[dict], pages: list[dict]) -> str:
     """Where the journey starts: the page the FIRST step acts on.
 
@@ -889,6 +912,7 @@ def render_browser_operations_json(
     profile_slug: str,
     terminal_ops: list[dict] | None = None,
     entry_url: str = "",
+    entry_by_origin: dict | None = None,
 ) -> str:
     """operations.json for a browser skill — a click+read recipe per page.
 
@@ -921,6 +945,9 @@ def render_browser_operations_json(
             }
         )
     doc = {"schema_version": "1", "style": "browser", "operations": operations}
+    if entry_by_origin:
+        # One per host. A reset must not change hosts -- see entry_urls_by_origin.
+        doc["entry_urls"] = entry_by_origin
     if entry_url:
         # Where the journey starts. These operations are one recorded journey cut
         # into pieces -- op N+1 begins on the page op N left behind -- so replaying
@@ -1180,6 +1207,7 @@ def generate_browser_skill(
         profile_slug=profile_slug,
         terminal_ops=terminal_ops,
         entry_url=entry_url_for(url_events, pages),
+        entry_by_origin=entry_urls_by_origin(url_events),
     )
     (out_path / "operations.json").write_text(operations_json, encoding="utf-8")
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -2321,6 +2321,39 @@ def _terminal_starts_from(op: dict) -> str | None:
     return url or None
 
 
+# A control whose own label names a download or a form submit. These ACTIVATE
+# the operation, so they run after the parameters are set, not before.
+# Specific download/submit terms, matched as substrings because selectors run
+# them together with underscores (#DOWNLOAD_ESTATEMENT_PDF) where a trailing word
+# boundary would never fire. The loose words that caused false hits -- "view"
+# (matched inside "CustomView"), a bare "go" -- are gone; and only clicks are
+# tested (see below), so the value-scoped set_checked whose selector says
+# "CustomView...PERIOD_TYPE" is excluded by command before this ever runs.
+_ACTIVATION_CONTROL = re.compile(
+    r"(download|e-?statement|estatement|pdf|export|submit)", re.I
+)
+
+
+def _is_activation_step(step: dict) -> bool:
+    """Whether a lead step submits/downloads rather than sets the page up.
+
+    Only a CLICK can activate. set_checked and select_option set a control's
+    state -- they are always setup and must precede the fills, whatever their
+    selector happens to spell. Restricting to clicks is what keeps the
+    value-scoped radio (selector `...CustomView...PERIOD_TYPE...`) from being
+    mistaken for a "view" control and deferred after the period it precedes.
+
+    Matched on the selector and any text the click carries -- #PDF_Download,
+    #DOWNLOAD_ESTATEMENT_PDF, a "Download" button. A setup click (a tab) does not
+    match and stays ahead of the fills.
+    """
+    if step.get("command") not in ("click_element", "click_by_text"):
+        return False
+    params = step.get("params") or {}
+    haystack = " ".join(str(params.get(k) or "") for k in ("selector", "text"))
+    return bool(_ACTIVATION_CONTROL.search(haystack))
+
+
 def _steps_for_terminal(op: dict) -> list[dict]:
     """Recipe for a terminal operation: reach the page, then do the thing."""
     steps: list[dict] = []
@@ -2342,8 +2375,28 @@ def _steps_for_terminal(op: dict) -> list[dict]:
     # means the fragile half runs first -- and on ICICI the first of them clicked
     # "Monthly" immediately after Annual had been set.
     superseded = set(op.get("superseded_seqs") or [])
-    steps.extend([s for s in (op.get("lead") or []) if s.get("_seq") not in superseded])
+    lead = [s for s in (op.get("lead") or []) if s.get("_seq") not in superseded]
+
+    # Setup before the fills, download-triggers AFTER them.
+    #
+    # Lead clicks are of two kinds: SETUP that puts the page into the state the
+    # fills need (the "Past" tab, the period-type), and ACTIVATION that submits
+    # or downloads. Emitting all of lead before fill_steps was right for setup
+    # and wrong for activation: on ICICI the recording clicked #PDF_Download and
+    # #DOWNLOAD_ESTATEMENT_PDF as ordinary clicks, so they landed in lead and
+    # fired BEFORE select_option chose the period. The form was submitted at its
+    # Monthly default, then the period was set on a page that had already
+    # downloaded -- the "Annual reverted to Monthly" a human watched happen.
+    #
+    # A click whose own label names a download/submit control is activation; the
+    # parameter fills must precede it, exactly as a person sets the period before
+    # pressing the button.
+    activation, setup = [], []
+    for step in lead:
+        (activation if _is_activation_step(step) else setup).append(step)
+    steps.extend(setup)
     steps.extend(fill_steps(op.get("parameters") or []))
+    steps.extend(activation)
     # The terminal asserts WHICH PAGE it fires on.
     #
     # ICICI's annual and monthly statement pages are identically designed:

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -317,6 +317,14 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
                 # real click used. Third field this function has been caught
                 # dropping, after candidates and is_opener.
                 "event_type": (c.get("event_type") or "click"),
+                # Whether this hover OPENED the click after it, as the recorder
+                # decided at capture time. Fourth field this function has been
+                # caught dropping. Without it _step_for_click cannot stamp
+                # _reveal, _fold_hover_into_click refuses to merge the pair, and
+                # the gesture replays as two round trips -- which cannot work
+                # here: ICICI's flyout is back to display:none within 500ms of
+                # the pointer leaving the box.
+                "reveal": c.get("reveal"),
                 "is_opener": event_seq(c) in opener_seqs,
                 # The OTHER ways this control was seen. choose_locator collapses
                 # them to one winner above; the runtime needs the rest to fall
@@ -395,6 +403,13 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
                 # skill quietly missing something it had recorded.
                 "seq": c.get("seq"),
                 "url": c.get("url"),
+                # FIFTH field lost here, after candidates, is_opener, event_type
+                # and seq. Without it the hover reaches _step_for_click looking
+                # incidental, no _reveal is stamped, _fold_hover_into_click
+                # declines, and the gesture replays as two round trips -- which
+                # cannot work: ICICI's flyout returns to display:none within
+                # 500ms of the pointer leaving the box.
+                "reveal": c.get("reveal"),
                 "is_opener": c.get("is_opener"),
                 "candidates": c.get("candidates"),
                 "selector": c["selector"],
@@ -1043,7 +1058,21 @@ def _fold_hover_into_click(steps: list[dict]) -> list[dict]:
             step.get("command") == "hover"
             and step.get("_reveal")
             and nxt is not None
-            and nxt.get("command") == "click_element"
+            # click_by_text folds too. The click's command was never the point --
+            # only the HOVER has to be css-addressable, since there is no
+            # hover-by-text. Restricting to click_element was accidental: before
+            # evidence was gathered from the clicked element, a nav item had no
+            # text candidate, so it always compiled to click_element and the
+            # restriction never bit. Once it gained one and compiled to
+            # click_by_text, the pair stopped folding and the menu shut between
+            # the two round trips.
+            #
+            # Measured on ICICI: the flyout is display:none, goes to block while
+            # the pointer rests on the box, and returns to none within 500ms of
+            # it leaving -- so two steps cannot work. Hovering the box and then
+            # clicking the revealed item as ONE gesture navigates to
+            # /credit-card, so one step can.
+            and nxt.get("command") in ("click_element", "click_by_text")
             and (step.get("params") or {}).get("selector")
         ):
             merged = {

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -33,6 +33,7 @@ from noui_core.compile.login_assets import (
     _first_path_segment,
     _url_origin,
 )
+from noui_core.compile.parameters import derive_parameters, fill_steps
 from noui_core.event_order import event_seq, order_events
 
 
@@ -492,6 +493,7 @@ def render_browser_operations_json(
                 "tool": "call_web_browser",
                 "profile_slug": profile_slug,
                 "kind": op["kind"],
+                "parameters": op.get("parameters") or [],
                 "steps": _steps_for_terminal(op),
             }
         )
@@ -551,15 +553,36 @@ def render_browser_skill_md(
     # file, a submitted form. Named explicitly so the agent asks for them by name
     # instead of trying to reconstruct the click path from the read pages.
     if terminal_ops:
-        lines = "\n".join(
-            f"- **{op['name']}** — {_terminal_description(op)}" for op in terminal_ops
-        )
+
+        def _op_line(op: dict) -> str:
+            head = f"- **{op['name']}** — {_terminal_description(op)}"
+            params = op.get("parameters") or []
+            if not params:
+                return head
+            bits = []
+            for prm in params:
+                shown = f'`{prm["name"]}` ({prm["type"]}, recorded as "{prm["default"]}")'
+                if not prm.get("settable"):
+                    # Honest about the gap: no browser command can set a native
+                    # <select>, so the agent has to open it and pick, and being
+                    # told that beats a step that silently does nothing.
+                    shown += " — a dropdown; open it and choose, no step is emitted"
+                bits.append(shown)
+            return head + "\n  - accepts: " + "; ".join(bits)
+
+        lines = "\n".join(_op_line(op) for op in terminal_ops)
         terminal_section = (
             "## Operations that produce a result\n\n"
             "These finish with an artifact or a submission rather than a page to "
             "read. Run the steps exactly as `operations.json` gives them; for a "
             "download the file itself is the result, reported by the closing "
             "`list_downloads` step.\n\n"
+            "Where an operation lists parameters, its steps carry "
+            "`{{placeholders}}` — substitute the value the user asked for before "
+            "running the step. Pass nothing and the recorded value is used, "
+            "which reproduces the run the skill was built from rather than what "
+            "was asked for, so always check whether the request names a period, "
+            "an account or a search term.\n\n"
             f"{lines}\n\n"
         )
     else:
@@ -892,6 +915,20 @@ def derive_terminal_operations(
         if expect:
             step["expect"] = expect
 
+        # The values the human entered on this page BEFORE acting are what the
+        # operation should accept as arguments — a statement period, an account,
+        # a search term. Bounded to the same page and to interactions preceding
+        # the terminal one, so a later screen's fields never leak in.
+        term_seq = event_seq(ev)
+        page_inputs = [
+            c
+            for c in click_events or []
+            if (c.get("event_type") or "") in ("input", "change")
+            and _page_key(c.get("url") or "") == _page_key(url)
+            and (term_seq is None or (event_seq(c) or 0) < term_seq)
+        ]
+        parameters = derive_parameters(page_inputs)
+
         name = _op_name(kind, ev, _slug_from_path(url))
         if name in seen:
             continue
@@ -904,6 +941,7 @@ def derive_terminal_operations(
                 "url": url,
                 # Reach the page exactly the way the read operation for it does.
                 "nav": list(page.get("nav") or []),
+                "parameters": parameters,
                 "terminal": step,
             }
         )
@@ -921,6 +959,9 @@ def _steps_for_terminal(op: dict) -> list[dict]:
         if expect:
             step["expect"] = expect
         steps.append(step)
+    # Values the caller can override. Templated on the parameter name, so the
+    # operation does exactly what was recorded when nothing is passed.
+    steps.extend(fill_steps(op.get("parameters") or []))
     steps.append(op["terminal"])
     if op.get("kind") == "download":
         # The artifact IS the result, so the operation ends by naming it rather

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1051,8 +1051,8 @@ def _expect_for_click(click: dict) -> dict | None:
         expect["download"] = True
     settled = outcome.get("settled_ms")
     if isinstance(settled, int) and settled > 0:
-        # Observed, not guessed. Rounded up to a whole second and given headroom,
-        # because a recorded settle is one sample from one network.
+        # Observed, not guessed: doubled for headroom, floored at a second and
+        # capped at fifteen, because a recorded settle is one sample from one network.
         expect["settle_ms"] = min(15000, max(1000, settled * 2))
     return expect or None
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -313,6 +313,12 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
                 # the same class of gap that had already cost candidates and
                 # is_opener at the other builder.
                 "event_type": c.get("event_type") or "click",
+                # seq, because the arrival budget is measured from WHEN this
+                # click happened. Fourth field this projection has been caught
+                # dropping, after candidates, is_opener and event_type -- each
+                # time the loss showed up somewhere far away, as a compiled
+                # skill quietly missing something it had recorded.
+                "seq": c.get("seq"),
                 "is_opener": c.get("is_opener"),
                 "candidates": c.get("candidates"),
                 "selector": c["selector"],

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -2241,9 +2241,36 @@ def derive_terminal_operations(
                 "nav": list(page.get("nav") or []),
                 "parameters": parameters,
                 "lead": lead_steps,
+                # Seqs the recorder says were a dropdown widget's own clicks.
+                # See _steps_for_terminal, which drops them.
+                "superseded_seqs": sorted(_superseded_seqs(click_events)),
                 "terminal": step,
             }
         )
+    return out
+
+
+def _superseded_seqs(click_events: list[dict] | None) -> set[int]:
+    """Clicks the recorder attributed to a dropdown widget it also recorded.
+
+    A portal draws a styled div over a native <select>: the human clicks the
+    overlay, picks an option, and the select's value changes a moment later. The
+    recorder stamps that change with `supersedes: [seq, ...]` naming the clicks
+    that were the widget, because only it can see the two are one act.
+
+    Without this the compiler emitted both -- an ICICI download clicked a
+    container labelled "Monthly" straight after setting Annual, then opened a
+    panel and hunted a floating option, before finally issuing the select_option
+    that would have done it outright. Every one of those clicks either undid the
+    step before it or burned a timeout, identically on four consecutive replays.
+    """
+    out: set[int] = set()
+    for ev in click_events or []:
+        if not isinstance(ev, dict):
+            continue
+        for seq in ev.get("supersedes") or []:
+            if isinstance(seq, int):
+                out.add(seq)
     return out
 
 
@@ -2295,7 +2322,14 @@ def _steps_for_terminal(op: dict) -> list[dict]:
     # Set the page up the way the human did — tab, period, filter — before the
     # values the caller can override, so a passed parameter lands on the screen
     # those clicks produced rather than on whatever loaded first.
-    steps.extend(op.get("lead") or [])
+    # Drive each control ONCE. A click the recorder marked as a dropdown's own
+    # widget is the same act as the select_option that follows, so emitting both
+    # means the fragile half runs first -- and on ICICI the first of them clicked
+    # "Monthly" immediately after Annual had been set.
+    superseded = set(op.get("superseded_seqs") or [])
+    steps.extend(
+        [s for s in (op.get("lead") or []) if s.get("_seq") not in superseded]
+    )
     steps.extend(fill_steps(op.get("parameters") or []))
     # The terminal asserts WHICH PAGE it fires on.
     #

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -255,6 +255,9 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
                 "outcome": c.get("outcome") if isinstance(c.get("outcome"), dict) else None,
                 "dt": cdt,
                 "seq": cseq,
+                # The page it happened on. Carried for the same reason as seq:
+                # a folded variant needs to know where it BEGINS.
+                "url": cu,
             }
         )
     if not cands and late_cands:
@@ -319,6 +322,7 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
                 # time the loss showed up somewhere far away, as a compiled
                 # skill quietly missing something it had recorded.
                 "seq": c.get("seq"),
+                "url": c.get("url"),
                 "is_opener": c.get("is_opener"),
                 "candidates": c.get("candidates"),
                 "selector": c["selector"],
@@ -620,8 +624,14 @@ def _stamp_source(step: dict | None, click: dict) -> dict | None:
     `_behaviour`, which keeps it from making two identical actions look
     different.
     """
-    if step is not None and click.get("seq") is not None:
+    if step is None:
+        return step
+    if click.get("seq") is not None:
         step["_seq"] = click["seq"]
+    # And the page it ran on. A folded variant begins where its FIRST step runs,
+    # which is not always where its terminal lands.
+    if click.get("url"):
+        step["_url"] = str(click["url"])
     return step
 
 
@@ -1815,14 +1825,15 @@ def derive_terminal_operations(
         if page is None:
             continue
 
-        step = _step_for_click(
-            {
-                "text": (ev.get("text_content") or "").strip(),
-                "locator": choose_locator(ev.get("candidates")),
-                "candidates": ev.get("candidates"),
-                "outcome": ev.get("outcome"),
-            }
-        )
+        terminal_source = {
+            "text": (ev.get("text_content") or "").strip(),
+            "locator": choose_locator(ev.get("candidates")),
+            "candidates": ev.get("candidates"),
+            "outcome": ev.get("outcome"),
+            "url": ev.get("url"),
+            "seq": event_seq(ev),
+        }
+        step = _stamp_source(_step_for_click(terminal_source), terminal_source)
         if step is None:
             continue
         expect = _expect_for_click({"outcome": ev.get("outcome")})
@@ -1879,15 +1890,20 @@ def derive_terminal_operations(
             c_seq = event_seq(c)
             if term_seq is None or c_seq is None or c_seq >= term_seq:
                 continue
-            lead = _step_for_click(
-                {
-                    "text": (c.get("text_content") or "").strip(),
-                    "locator": choose_locator(c.get("candidates")),
-                    "candidates": c.get("candidates"),
-                    "is_opener": event_seq(c) in term_opener_seqs,
-                    "outcome": c.get("outcome"),
-                }
-            )
+            source = {
+                "text": (c.get("text_content") or "").strip(),
+                "locator": choose_locator(c.get("candidates")),
+                "candidates": c.get("candidates"),
+                "is_opener": event_seq(c) in term_opener_seqs,
+                "outcome": c.get("outcome"),
+                # Provenance, as at the other two build sites. Without it a
+                # folded variant could not say which page it BEGINS on, only
+                # where its terminal landed -- and for ICICI's annual statement
+                # those differ by a whole origin.
+                "url": c.get("url"),
+                "seq": event_seq(c),
+            }
+            lead = _stamp_source(_step_for_click(source), source)
             if lead is None:
                 continue
             lead_expect = _expect_for_click({"outcome": c.get("outcome")})
@@ -2231,6 +2247,24 @@ def apply_fold(
     # as they always did.
     segmented = a.get("segment_steps") is not None and b.get("segment_steps") is not None
     starts = [a.get("starts_from"), b.get("starts_from")]
+
+    def _origin(branch_steps: list, fallback: object) -> object:
+        """Where this variant BEGINS -- the page its first step runs on.
+
+        Not where its terminal landed. `starts_from` comes from the terminal's
+        own page, and for ICICI's annual statement those differ: the radio and
+        GO happen on /corp/AuthenticationController and only that submit reaches
+        /corp/Finacle. Guarding the variant on its destination refused it while
+        standing on the page it was supposed to start from -- which only became
+        visible once the page read stopped navigating there as a side effect.
+        """
+        for step in branch_steps:
+            url = step.get("_url") if isinstance(step, dict) else None
+            if url:
+                return url
+        return fallback
+
+    origins = [_origin(work[0], starts[0]), _origin(work[1], starts[1])]
     merged_steps = (
         shared + _merge_branches(*work, param, values)
         if segmented
@@ -2269,8 +2303,8 @@ def apply_fold(
         # Only when the two actually differ, so nothing changes for a fold whose
         # variants share a page.
         **(
-            {"starts_from_by": {"param": param, "by": dict(zip(values, starts))}}
-            if len(set(starts)) > 1
+            {"starts_from_by": {"param": param, "by": dict(zip(values, origins))}}
+            if len(set(origins)) > 1
             else {}
         ),
         "parameters": [

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1527,7 +1527,11 @@ def fold_candidates(operations: list[dict]) -> list[dict]:
          "branches": [[steps...], [steps...]]}
     """
     out: list[dict] = []
-    ops = [o for o in operations or [] if (o.get("steps") or [])]
+    # `operations` is a count in some result shapes, not a list of steps -- and
+    # a report that raises would fail an import that otherwise succeeded.
+    ops = [
+        o for o in operations or [] if isinstance(o, dict) and isinstance(o.get("steps"), list)
+    ]
     for i, a in enumerate(ops):
         for b in ops[i + 1 :]:
             if (a.get("kind") or "read") != (b.get("kind") or "read"):
@@ -1552,4 +1556,57 @@ def fold_candidates(operations: list[dict]) -> list[dict]:
                     "branches": [mid_a, mid_b],
                 }
             )
+    return out
+
+
+def apply_fold(
+    operations: list[dict], fold: dict, *, name: str, param: str, values: list[str]
+) -> list[dict]:
+    """Replace a foldable pair with one operation the member has named.
+
+    The names come from a person, not from the recording: "corp_finacle" is the
+    page the annual statement happened to be served from, and a caller choosing
+    between a monthly and an annual statement can make nothing of it. The
+    compiler finds the fold; the member says what it is.
+
+    The shared prefix and ending run for every variant; each divergent middle is
+    tagged with ``when`` so only its own steps run. Nothing is invented -- every
+    step is the one that was recorded, in the order it was recorded.
+    """
+    a_name, b_name = fold["operations"]
+    by_name = {o.get("name"): o for o in operations}
+    a, b = by_name.get(a_name), by_name.get(b_name)
+    if a is None or b is None or len(values) != 2:
+        return operations
+
+    steps_a = a.get("steps") or []
+    pre, suf = fold["prefix"], fold["suffix"]
+    merged = list(steps_a[:pre])
+    for branch, value in zip(fold["branches"], values):
+        for step in branch:
+            merged.append({**step, "when": {param: value}})
+    merged.extend(steps_a[len(steps_a) - suf :] if suf else [])
+
+    folded = {
+        **a,
+        "name": name,
+        "steps": merged,
+        "parameters": [
+            *(a.get("parameters") or []),
+            {
+                "name": param,
+                "default": values[0],
+                "allowed": list(values),
+                "description": f"Which variant to run: {', '.join(values)}.",
+            },
+        ],
+    }
+    out: list[dict] = []
+    for op in operations:
+        if op.get("name") == a_name:
+            out.append(folded)
+        elif op.get("name") == b_name:
+            continue
+        else:
+            out.append(op)
     return out

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -885,7 +885,9 @@ def generate_browser_skill(
             json.dumps(bundle, indent=2, ensure_ascii=False), encoding="utf-8"
         )
         manifest["provenance"] = _provenance.build(
-            bundle, bundle_file=bundle_file or _provenance.BUNDLE_FILE
+            bundle,
+            bundle_file=bundle_file or _provenance.BUNDLE_FILE,
+            operations=json.loads(operations_json).get("operations") or [],
         )
     (out_path / "manifest.json").write_text(
         json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -176,6 +176,7 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
 
     cands: list[dict] = []
     late_cands: list[dict] = []
+    prev_was_hover = False
     for c in click_events or []:
         # A hover that opened a menu is part of the gesture, not noise: the
         # click after it targets something that does not exist until the pointer
@@ -210,8 +211,21 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
         # Allow a small window on the far side. Wide enough to absorb the
         # inversion, far narrower than the gap to the human's next action, so a
         # click belonging to the NEXT page is still never claimed by this one.
+        # A hover is exempt, and so is the click it revealed.
+        #
+        # The window guards against claiming a LATER, unrelated click -- a "Log
+        # out" back on the same page. A hover is never that: it cannot cause a
+        # navigation, so it is not the thing being guarded against, and the
+        # click it reveals is not a separate action but the second half of one
+        # gesture. On ICICI the route change is stamped at seq 4 while the human
+        # hovers at 7 and clicks at 9; with a slack of 3 the window closed at 7,
+        # so the click that does the work was dropped outright and the menu-
+        # opening hover was all that survived.
+        is_hover = (c.get("event_type") or "click") == "hover"
+        in_gesture = is_hover or prev_was_hover
+        prev_was_hover = is_hover
         if nav_seq is not None and cseq is not None:
-            if cseq > nav_seq + _NAV_SEQ_SLACK:
+            if cseq > nav_seq + _NAV_SEQ_SLACK and not in_gesture:
                 continue
             late = cseq > nav_seq
         elif nav_dt and cdt:

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1922,6 +1922,26 @@ def _journey_part(op: dict) -> list[dict]:
     return steps[: max(0, len(steps) - len(segment))]
 
 
+def _after_last_terminal(steps: list[dict]) -> list[dict]:
+    """Drop everything up to and including a completed terminal action.
+
+    A finished action is a boundary. The human downloaded the MONTHLY statement,
+    then switched the period to Annual and downloaded again -- so the clicks
+    between the fork and the annual terminal include the monthly download that
+    ended the previous variant. Handed to the annual branch, it fired a monthly
+    download first, left the form busy ("the system is considering your first
+    request"), and the annual steps had nothing to act on.
+
+    What precedes a completed terminal belongs to the variant it completed, not
+    to the one that follows.
+    """
+    last = -1
+    for i, step in enumerate(steps):
+        if (step.get("expect") or {}).get("download") or step.get("command") == "list_downloads":
+            last = i
+    return steps[last + 1 :] if last >= 0 else steps
+
+
 def _branch_work(a: dict, b: dict) -> tuple[list[dict], list[dict]]:
     """Each operation's own work, including the journey only IT takes.
 
@@ -1932,8 +1952,8 @@ def _branch_work(a: dict, b: dict) -> tuple[list[dict], list[dict]]:
     a_journey, b_journey = _journey_part(a), _journey_part(b)
     shared = _common_prefix_len(a_journey, b_journey)
     return (
-        a_journey[shared:] + (a.get("segment_steps") or []),
-        b_journey[shared:] + (b.get("segment_steps") or []),
+        _after_last_terminal(a_journey[shared:]) + (a.get("segment_steps") or []),
+        _after_last_terminal(b_journey[shared:]) + (b.get("segment_steps") or []),
     )
 
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -27,7 +27,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import urlparse
 
-from noui_core.compile.locators import AMBIGUOUS, choose_locator
+from noui_core.compile.locators import AMBIGUOUS, UNKNOWN, choose_locator
 from noui_core.compile.login_assets import (
     _LOGIN_FLOW_SEGMENTS,
     _first_path_segment,
@@ -644,10 +644,41 @@ def _step_for_click(click: dict) -> dict | None:
     # verifies the state actually changed, which a click cannot promise.
     element = click.get("element") or {}
     role = str(element.get("role") or "").lower() if isinstance(element, dict) else ""
-    if role in ("radio", "checkbox") and locator and locator.get("is_css"):
+    # The ROLE_NAME candidate announces it too: "radio|Annual". ICICI's period
+    # control reports no element role and its unique candidate is that
+    # role_name, so both halves of the old test failed -- the step compiled to
+    # click_by_text "Annual", which clicks the LABEL. The click reported ok, the
+    # radio stayed on Monthly, and the replay downloaded a monthly statement
+    # while asking for the annual one.
+    if not role:
+        for cand in click.get("candidates") or []:
+            if isinstance(cand, dict) and str(cand.get("kind")) == "role_name":
+                head = str(cand.get("value") or "").split("|", 1)[0].strip().lower()
+                if head in ("radio", "checkbox"):
+                    role = head
+                    break
+    # set_checked needs a SELECTOR, and the chosen locator may be the role_name
+    # that identified the control rather than a css one. Fall back to the best
+    # css candidate: addressing the input directly is the whole point.
+    target = locator if (locator and locator.get("is_css")) else None
+    if role in ("radio", "checkbox") and target is None:
+        for cand in click.get("candidates") or []:
+            if not isinstance(cand, dict) or not _is_css_kind(str(cand.get("kind") or "")):
+                continue
+            # UNIQUE only. ICICI's Monthly and Annual radios share an id and a
+            # name, so that candidate matches two nodes -- set_checked would
+            # take the first and select MONTHLY, which is the exact bug this is
+            # meant to fix, made silent again. An ambiguous selector is worse
+            # here than no selector: falling through leaves the step as it was.
+            if cand.get("value") and cand.get("match_count") in (1, -1):
+                target = {"value": str(cand["value"]), "kind": cand.get("kind"),
+                          "match_count": cand.get("match_count"),
+                          "confidence": UNKNOWN, "is_css": True}
+                break
+    if role in ("radio", "checkbox") and target:
         step = {
             "command": "set_checked",
-            "params": {"selector": locator["value"], "checked": True},
+            "params": {"selector": target["value"], "checked": True},
         }
         if element.get("in_iframe"):
             for key in ("frame_url", "frame_name"):

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -869,6 +869,49 @@ def _expect_for_click(click: dict) -> dict | None:
     return expect or None
 
 
+def _is_shared_class_selector(selector: str) -> bool:
+    """Is this a selector that could name many controls at once?
+
+    An id addresses one node by definition, and a recorded css_path is a walk
+    down the tree. A bare tag.class is neither: `a.sub-menu-list-item-link` names
+    a STYLE, and a nav gives every submenu item in it the same one.
+    """
+    value = (selector or "").strip()
+    if not value or "#" in value or ">" in value or " " in value:
+        return False
+    return "." in value
+
+
+def _scope_under_the_hover(step: dict, hover_selector: str) -> None:
+    """Address the revealed control INSIDE the thing that revealed it.
+
+    ICICI's nav compiled to `a.sub-menu-list-item-link` -- a class every submenu
+    item in the nav carries, and one the recorder never checked for uniqueness:
+    the `match_count: 1` on that step belongs to a DIFFERENT candidate, a css_path
+    to an ancestor. So the click resolved whichever match came first in the
+    document, and when that one sat in a menu that was not open the step failed
+    "on the page but not visible". About half of all runs died there, on step 0,
+    and passed on an immediate retry.
+
+    A control revealed by a hover lives inside what revealed it, so the hover's
+    own selector is the scope that disambiguates -- no site knowledge, no
+    guessing which of the matches was meant.
+
+    The unscoped selector stays as the first fallback, since a menu rendered in
+    an overlay rather than inside its trigger would not match the scoped form.
+    Only for a selector that could name many controls: an id or a recorded path
+    is left exactly as it was.
+    """
+    params = step.get("params") or {}
+    selector = str(params.get("selector") or "")
+    if not _is_shared_class_selector(selector):
+        return
+    params["selector"] = f"{hover_selector} {selector}"
+    fallbacks = list(params.get("fallbacks") or [])
+    params["fallbacks"] = [{"selector": selector}, *fallbacks]
+    step["params"] = params
+
+
 def _fold_hover_into_click(steps: list[dict]) -> list[dict]:
     """A hover and the click it enables are ONE gesture, so emit one step.
 
@@ -895,6 +938,7 @@ def _fold_hover_into_click(steps: list[dict]) -> list[dict]:
         ):
             merged = {**nxt, "params": {**(nxt.get("params") or {}),
                                         "hover_first": step["params"]["selector"]}}
+            _scope_under_the_hover(merged, step["params"]["selector"])
             # The hover's own expectation described opening the menu; the click's
             # describes where the gesture lands. Keep the click's.
             out.append(merged)

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1352,12 +1352,18 @@ def render_browser_operations_json(
         if (
             segment is None
             and p.get("starts_from") is None
-            and entry_url
             and _page_key(p["url"]) != _page_key(entry_url)
         ):
             # The FIRST operation continues from a fresh session, which lands on
             # the entry page -- so getting from there to its own page is ITS
             # work, not a journey shared with anything before it.
+            #
+            # Not conditioned on KNOWING the entry page. `entry_url_for` returns
+            # "" when it cannot name a landing page, and requiring it meant the
+            # first operation silently kept its bare read on exactly the
+            # recordings where the compiler understood the least. It owns its nav
+            # chain either way; an operation that really is the landing page has
+            # no nav, so this still yields an empty segment for it.
             #
             # Without this, an operation whose nav chain has no parent was given
             # `starts_from: null` ("you are already here") while asserting a page

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -795,6 +795,32 @@ def _expect_for_click(click: dict) -> dict | None:
     return expect or None
 
 
+def _inherit_hover_settle(steps: list[dict]) -> None:
+    """A click after a hover waits for the menu the hover opened.
+
+    The recorder measures the settle on the HOVER -- 4322ms on ICICI's nav --
+    and the click that follows it carries none, so it fell back to the runtime's
+    3s floor. The reveal sits right around 3s, which made the step a coin flip:
+    it passed in one live run and failed "on the page but not visible" in the
+    next.
+
+    The hover's measurement IS how long its menu takes to appear, which is
+    exactly what the next click is waiting on. Inherited only when the click has
+    no settle of its own -- its own measurement, where it has one, describes its
+    own page and is the better number.
+    """
+    for before, after in zip(steps, steps[1:]):
+        if before.get("command") != "hover":
+            continue
+        settle = (before.get("expect") or {}).get("settle_ms")
+        if not isinstance(settle, int) or settle <= 0:
+            continue
+        expect = after.get("expect") or {}
+        if expect.get("settle_ms"):
+            continue
+        after["expect"] = {**expect, "settle_ms": settle}
+
+
 def _steps_for_page(p: dict) -> list[dict]:
     """Recipe to read a page WITHOUT a reload.
 
@@ -874,7 +900,9 @@ def _steps_for_page(p: dict) -> list[dict]:
         )
 
     steps.append({"command": "get_page_summary"})
-    return _collapse_repeats(steps)
+    out = _collapse_repeats(steps)
+    _inherit_hover_settle(out)
+    return out
 
 
 def ambiguous_steps(pages: list[dict]) -> list[dict]:
@@ -1597,6 +1625,7 @@ def _steps_for_terminal(op: dict) -> list[dict]:
         steps.append({"command": "list_downloads"})
     else:
         steps.append({"command": "get_page_summary"})
+    _inherit_hover_settle(steps)
     return steps
 
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -551,7 +551,12 @@ def _step_for_click(click: dict) -> dict | None:
     Falls back to the recorded text when there is no usable candidate, which is
     what every pre-schema-4 recording will hit.
     """
-    locator = click.get("locator")
+    # Fall back to resolving the candidates here. Click events arrive with a
+    # pre-resolved "locator", hover events do not -- they carry candidates and
+    # nothing else -- so the hover branch below read None and returned None for
+    # every hover ever recorded. The recorder captured ICICI's nav hover, the
+    # runtime had a hover command, and the step still never reached the skill.
+    locator = click.get("locator") or choose_locator(click.get("candidates"))
     text = (click.get("text") or "").strip()
 
     # A radio or checkbox is SET, not clicked.

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -463,7 +463,9 @@ def ambiguous_steps(pages: list[dict]) -> list[dict]:
     return out
 
 
-def render_browser_operations_json(pages: list[dict], *, profile_slug: str) -> str:
+def render_browser_operations_json(
+    pages: list[dict], *, profile_slug: str, terminal_ops: list[dict] | None = None
+) -> str:
     """operations.json for a browser skill — a click+read recipe per page.
 
     Shape mirrors the harness call_web_api operations.json (schema_version +
@@ -478,6 +480,19 @@ def render_browser_operations_json(pages: list[dict], *, profile_slug: str) -> s
                 "tool": "call_web_browser",
                 "profile_slug": profile_slug,
                 "steps": _steps_for_page(p),
+            }
+        )
+    # Goals that finish without landing on a new page — a download, a form
+    # submission. The page-centric model above cannot express them at all.
+    for op in terminal_ops or []:
+        operations.append(
+            {
+                "name": op["name"],
+                "description": _terminal_description(op),
+                "tool": "call_web_browser",
+                "profile_slug": profile_slug,
+                "kind": op["kind"],
+                "steps": _steps_for_terminal(op),
             }
         )
     return json.dumps(
@@ -495,6 +510,7 @@ def render_browser_skill_md(
     pages: list[dict],
     profile_slug: str,
     description_override: str = "",
+    terminal_ops: list[dict] | None = None,
 ) -> str:
     """SKILL.md for a browser-driven skill (harness frontmatter + body)."""
     description = description_override or (
@@ -531,6 +547,24 @@ def render_browser_skill_md(
     # Name the ambiguous steps outright. A compile that quietly ships a locator
     # known to match several elements is the exact failure this redesign exists
     # to remove; the human re-recording is the one who can fix it.
+    # Goals that produce something rather than land somewhere — a downloaded
+    # file, a submitted form. Named explicitly so the agent asks for them by name
+    # instead of trying to reconstruct the click path from the read pages.
+    if terminal_ops:
+        lines = "\n".join(
+            f"- **{op['name']}** — {_terminal_description(op)}" for op in terminal_ops
+        )
+        terminal_section = (
+            "## Operations that produce a result\n\n"
+            "These finish with an artifact or a submission rather than a page to "
+            "read. Run the steps exactly as `operations.json` gives them; for a "
+            "download the file itself is the result, reported by the closing "
+            "`list_downloads` step.\n\n"
+            f"{lines}\n\n"
+        )
+    else:
+        terminal_section = ""
+
     flagged = ambiguous_steps(pages)
     if flagged:
         lines = "\n".join(
@@ -620,7 +654,7 @@ use `command: "navigate"` on this app.
 
 {page_lines}
 
-The same recipes are machine-readable in `operations.json`.
+{terminal_section}The same recipes are machine-readable in `operations.json`.
 
 <!-- custom:start:notes -->
 <!-- Add skill-specific notes here; this region survives re-compilation. -->
@@ -665,6 +699,7 @@ def generate_browser_skill(
         )
 
     pages = derive_browser_pages(url_events, click_events or [], login_url=login_url)
+    terminal_ops = derive_terminal_operations(pages, click_events or [], login_url=login_url)
     if not pages:
         raise ValueError(
             "No readable data page was captured for this browser skill — the "
@@ -683,10 +718,13 @@ def generate_browser_skill(
         pages=pages,
         profile_slug=profile_slug,
         description_override=description_override,
+        terminal_ops=terminal_ops,
     )
     (out_path / "SKILL.md").write_text(skill_md, encoding="utf-8")
 
-    operations_json = render_browser_operations_json(pages, profile_slug=profile_slug)
+    operations_json = render_browser_operations_json(
+        pages, profile_slug=profile_slug, terminal_ops=terminal_ops
+    )
     (out_path / "operations.json").write_text(operations_json, encoding="utf-8")
 
     op_entries = [
@@ -698,6 +736,15 @@ def generate_browser_skill(
             "url": p["url"],
         }
         for p in pages
+    ] + [
+        {
+            "name": op["name"],
+            "description": _terminal_description(op),
+            "recipe": "operations.json",
+            "tool": "call_web_browser",
+            "url": op["url"],
+        }
+        for op in terminal_ops
     ]
 
     manifest: dict = {
@@ -736,3 +783,155 @@ def generate_browser_skill(
         json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
     )
     return manifest
+
+
+# --- Terminal operations ------------------------------------------------------
+#
+# An operation used to mean "a page the human visited": derive_browser_pages
+# walks url_events and compiles each distinct page as click-chain →
+# get_page_summary. That model can only express READING, so anything whose
+# result is not a new URL has no way to become an operation at all —
+# a statement download (an in-app click producing a blob:, no navigation), a
+# form submission, a filtered export. On ICICI the compiler produced two read
+# operations and the download had to be hand-written afterwards, which is not
+# reproducible and not verifiable.
+#
+# Tabby's recorder now reports what each interaction CAUSED, so the compiler can
+# work from what the human accomplished rather than from where they went.
+# Downloads are one kind of terminal outcome here, not a special case.
+
+#: Interactions that end a goal, and what to call the operation that reaches them.
+_TERMINAL_KINDS = ("download", "submit")
+
+
+def _terminal_kind(ev: dict) -> str | None:
+    """What goal, if any, this interaction completed.
+
+    Deliberately narrow. "Fired some XHRs" describes half the clicks on a bank
+    portal — filters, toggles, accordions — and emitting an operation for each
+    would bury the two or three a user would actually ask for. Only a finished
+    artifact and a submitted form count.
+    """
+    outcome = ev.get("outcome")
+    if isinstance(outcome, dict) and outcome.get("download"):
+        return "download"
+    if (ev.get("event_type") or "") == "submit":
+        return "submit"
+    return None
+
+
+def _op_name(kind: str, ev: dict, page_slug: str) -> str:
+    """A readable, stable operation name.
+
+    Prefers the control's own label ("Download statement" -> download_statement)
+    over the page slug, because the label is what the user will ask for.
+    """
+    label = (ev.get("text_content") or "").strip()
+    if not label:
+        loc = choose_locator(ev.get("candidates"))
+        if loc and not loc.get("is_css"):
+            value = loc["value"]
+            label = value.split("|", 1)[1] if loc["kind"] == "role_name" and "|" in value else value
+    stem = re.sub(r"[^a-z0-9]+", "_", label.lower()).strip("_") if label else ""
+    if not stem:
+        stem = page_slug or "action"
+    if not stem.startswith(kind):
+        stem = f"{kind}_{stem}"
+    return stem[:60].strip("_")
+
+
+def derive_terminal_operations(
+    pages: list[dict],
+    click_events: list[dict] | None,
+    *,
+    login_url: str,
+) -> list[dict]:
+    """Operations for goals that finish WITHOUT landing on a new page.
+
+    Each is the click chain that reaches the page the interaction happened on
+    (reusing the resolved page navigation, so the session is never reloaded),
+    then the interaction itself, then its recorded success condition.
+
+    Returns [] for any recording whose interactions carry no ``outcome`` — every
+    bundle captured before Tabby schema_version 5 — so older captures compile
+    exactly as they did.
+    """
+    click_events = order_events(click_events)
+    app_origin = _url_origin(login_url) if login_url else ""
+    by_key = {_page_key(p["url"]): p for p in pages}
+    out: list[dict] = []
+    seen: set[str] = set()
+
+    for ev in click_events or []:
+        kind = _terminal_kind(ev)
+        if kind is None:
+            continue
+        url = ev.get("url") or ""
+        if not url or (app_origin and _url_origin(url) != app_origin):
+            continue
+        if _is_login_flow_url(url):
+            continue
+
+        # Where did this happen, and how does the skill get there? An interaction
+        # on a page the compiler never resolved is unreachable, and a step that
+        # cannot be reached is worse than a missing one.
+        page = by_key.get(_page_key(url))
+        if page is None:
+            continue
+
+        step = _step_for_click(
+            {
+                "text": (ev.get("text_content") or "").strip(),
+                "locator": choose_locator(ev.get("candidates")),
+                "outcome": ev.get("outcome"),
+            }
+        )
+        if step is None:
+            continue
+        expect = _expect_for_click({"outcome": ev.get("outcome")})
+        if expect:
+            step["expect"] = expect
+
+        name = _op_name(kind, ev, _slug_from_path(url))
+        if name in seen:
+            continue
+        seen.add(name)
+
+        out.append(
+            {
+                "name": name,
+                "kind": kind,
+                "url": url,
+                # Reach the page exactly the way the read operation for it does.
+                "nav": list(page.get("nav") or []),
+                "terminal": step,
+            }
+        )
+    return out
+
+
+def _steps_for_terminal(op: dict) -> list[dict]:
+    """Recipe for a terminal operation: reach the page, then do the thing."""
+    steps: list[dict] = []
+    for click in op.get("nav") or []:
+        step = _step_for_click(click)
+        if step is None:
+            continue
+        expect = _expect_for_click(click)
+        if expect:
+            step["expect"] = expect
+        steps.append(step)
+    steps.append(op["terminal"])
+    if op.get("kind") == "download":
+        # The artifact IS the result, so the operation ends by naming it rather
+        # than by reading the page it left behind.
+        steps.append({"command": "list_downloads"})
+    else:
+        steps.append({"command": "get_page_summary"})
+    return steps
+
+
+def _terminal_description(op: dict) -> str:
+    if op.get("kind") == "download":
+        return f"Download the file produced from {op['url']}"
+    return f"Submit the form on {op['url']} and read the result"

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -773,6 +773,34 @@ def _step_for_click(click: dict) -> dict | None:
     locator = click.get("locator") or choose_locator(click.get("candidates"))
     text = (click.get("text") or "").strip()
 
+    # A dropdown the human changed is ONE command, not a click safari.
+    #
+    # The runtime has had select_option (by option value or visible label) all
+    # along, and the recorder now sees a <select> whose value was assigned by
+    # script -- which is how Finacle's styled overlay sets one. Without this the
+    # only compiled evidence was the human's clicks on that overlay: three steps
+    # per dropdown, keyed on classes encoding the widget's CURRENT state and on
+    # a :text-is carrying the entire option list. Replay stalled mid-panel every
+    # time, because step two needs the panel still open and step three needs to
+    # land on a floating option.
+    #
+    # Value first, label second, which is exactly what the runtime accepts. The
+    # selector must be css-expressible: there is no select-by-text.
+    if str(click.get("tag_name") or "").upper() == "SELECT":
+        chosen = str(click.get("value") or "").strip()
+        if chosen and locator and locator.get("is_css"):
+            select_step: dict[str, Any] = {
+                "command": "select_option",
+                "params": {"selector": locator["value"], "value": chosen},
+            }
+            element_ctx = click.get("element") or {}
+            if isinstance(element_ctx, dict) and element_ctx.get("in_iframe"):
+                for key in ("frame_url", "frame_name"):
+                    frame_val = str(element_ctx.get(key) or "").strip()
+                    if frame_val:
+                        select_step["params"][key] = frame_val
+            return select_step
+
     # A radio or checkbox is SET, not clicked.
     #
     # Portals style these as images or spans over a hidden input, so a click

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -439,6 +439,19 @@ def _step_for_click(click: dict) -> dict | None:
     if step is None:
         return None
 
+    # Which frame the human clicked in. Bank portals embed whole applications in
+    # iframes (ICICI serves statements from Finacle that way), and a step that
+    # names only the control drives the top-level page instead — the control is
+    # not there, the run improvises, and a navigation the human completed
+    # becomes one the skill cannot reproduce. The runtime matches on the name
+    # first, then the url ignoring its query string, where session tokens churn.
+    element = click.get("element") or {}
+    if isinstance(element, dict) and element.get("in_iframe"):
+        for key in ("frame_url", "frame_name"):
+            value = str(element.get(key) or "").strip()
+            if value:
+                step["params"][key] = value
+
     if locator:
         # Carried for the human reading the recipe and for a future repair pass:
         # an AMBIGUOUS step is the one to re-point first when a skill misbehaves.

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -675,6 +675,30 @@ def _step_for_click(click: dict) -> dict | None:
                           "match_count": cand.get("match_count"),
                           "confidence": UNKNOWN, "is_css": True}
                 break
+    # No unique selector? Address it the way the recorder identified it: role
+    # plus accessible name, which the worker now resolves for set_checked. That
+    # is the ONLY unique handle on a control whose id and name it shares with
+    # its sibling -- ICICI's Monthly / Annual pair.
+    if role in ("radio", "checkbox") and target is None:
+        for cand in click.get("candidates") or []:
+            if not isinstance(cand, dict) or str(cand.get("kind")) != "role_name":
+                continue
+            value = str(cand.get("value") or "")
+            if "|" not in value or cand.get("match_count") not in (1, -1):
+                continue
+            role_part, name_part = value.split("|", 1)
+            if role_part.strip().lower() not in ("radio", "checkbox"):
+                continue
+            step = {
+                "command": "set_checked",
+                "params": {"role": role_part.strip(), "name": name_part.strip(),
+                           "checked": True},
+            }
+            expect = _expect_for_click(click)
+            if expect:
+                step["expect"] = expect
+            return step
+
     if role in ("radio", "checkbox") and target:
         step = {
             "command": "set_checked",

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1823,6 +1823,27 @@ def fold_candidates(operations: list[dict]) -> list[dict]:
     return out
 
 
+def _merge_branches(a_steps: list[dict], b_steps: list[dict], param: str,
+                    values: list[str]) -> list[dict]:
+    """One list: shared prefix, each divergent middle tagged, shared ending.
+
+    Used for BOTH `steps` and `segment_steps`. Folding only the former left the
+    segment holding operation A's copy, so a segmented replay ran the monthly
+    branch whatever timeframe was asked for -- the skill offered a choice it
+    could not honour, which is worse than not folding at all.
+    """
+    pre = _common_prefix_len(a_steps, b_steps)
+    suf = _common_suffix_len(a_steps, b_steps, pre)
+    merged = list(a_steps[:pre])
+    for branch, value in zip(
+        (a_steps[pre : len(a_steps) - suf], b_steps[pre : len(b_steps) - suf]), values
+    ):
+        merged.extend({**step, "when": {param: value}} for step in branch)
+    if suf:
+        merged.extend(a_steps[len(a_steps) - suf :])
+    return merged
+
+
 def apply_fold(
     operations: list[dict], fold: dict, *, name: str, param: str, values: list[str]
 ) -> list[dict]:
@@ -1843,18 +1864,18 @@ def apply_fold(
     if a is None or b is None or len(values) != 2:
         return operations
 
-    steps_a = a.get("steps") or []
-    pre, suf = fold["prefix"], fold["suffix"]
-    merged = list(steps_a[:pre])
-    for branch, value in zip(fold["branches"], values):
-        for step in branch:
-            merged.append({**step, "when": {param: value}})
-    merged.extend(steps_a[len(steps_a) - suf :] if suf else [])
-
     folded = {
         **a,
         "name": name,
-        "steps": merged,
+        "steps": _merge_branches(
+            a.get("steps") or [], b.get("steps") or [], param, values
+        ),
+        # The segment gets the same treatment. It is what a segmented replay
+        # runs, and leaving it as operation A's copy meant every timeframe ran
+        # the monthly branch.
+        "segment_steps": _merge_branches(
+            a.get("segment_steps") or [], b.get("segment_steps") or [], param, values
+        ),
         "parameters": [
             *(a.get("parameters") or []),
             {

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1348,10 +1348,27 @@ def render_browser_operations_json(
         # and its own work is nothing. The refusal still catches what it was
         # written for, a genuinely unsegmented operation among segmented ones.
         op["starts_from"] = p.get("starts_from")
+        segment = p.get("segment")
+        if (
+            segment is None
+            and p.get("starts_from") is None
+            and entry_url
+            and _page_key(p["url"]) != _page_key(entry_url)
+        ):
+            # The FIRST operation continues from a fresh session, which lands on
+            # the entry page -- so getting from there to its own page is ITS
+            # work, not a journey shared with anything before it.
+            #
+            # Without this, an operation whose nav chain has no parent was given
+            # `starts_from: null` ("you are already here") while asserting a page
+            # the session does not land on. Observed on a harness run:
+            # read_credit_card asserted /credit-card with no navigation step of
+            # its own, the session was on /overview, and the operation blocked
+            # with "expected to be on /credit-card ... but the page is
+            # /overview". Every operation after it then failed its own guard.
+            segment = p.get("nav") or []
         op["segment_steps"] = (
-            _steps_for_page({**p, "nav": p.get("segment")})
-            if p.get("segment") is not None
-            else []
+            _steps_for_page({**p, "nav": segment}) if segment is not None else []
         )
         # How long the page AFTER this operation took to become usable, measured
         # from the human's own gap. Stamped on the operation that CAUSES the

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -2184,6 +2184,21 @@ def derive_terminal_operations(
                 continue
             source = {
                 "text": (c.get("text_content") or "").strip(),
+                # Without this a hover compiles as a CLICK. _step_for_click
+                # branches on event_type and this projection did not carry it, so
+                # every hover in a terminal's lead-in became click_element on
+                # whatever locator was chosen for it.
+                #
+                # On ICICI that meant clicking the radio group's container --
+                # `div.width100percent:has-text("Monthly")` -- immediately after
+                # set_checked had chosen Annual, reverting it. Another hover
+                # became a click_by_text carrying the whole form's prose. The
+                # human had only moved the pointer across them.
+                #
+                # Sixth field a projection here has been caught dropping, after
+                # candidates, is_opener, event_type, seq and reveal -- the same
+                # one, in fact, in the sibling builder.
+                "event_type": c.get("event_type"),
                 "locator": choose_locator(c.get("candidates")),
                 "candidates": c.get("candidates"),
                 "is_opener": event_seq(c) in term_opener_seqs,
@@ -2327,9 +2342,7 @@ def _steps_for_terminal(op: dict) -> list[dict]:
     # means the fragile half runs first -- and on ICICI the first of them clicked
     # "Monthly" immediately after Annual had been set.
     superseded = set(op.get("superseded_seqs") or [])
-    steps.extend(
-        [s for s in (op.get("lead") or []) if s.get("_seq") not in superseded]
-    )
+    steps.extend([s for s in (op.get("lead") or []) if s.get("_seq") not in superseded])
     steps.extend(fill_steps(op.get("parameters") or []))
     # The terminal asserts WHICH PAGE it fires on.
     #

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -2203,9 +2203,25 @@ def derive_terminal_operations(
                 lead["expect"] = lead_expect
             lead_steps.append(lead)
 
+        # A repeated name means a SECOND terminal on the same page, not a
+        # duplicate of the first.
+        #
+        # Discarding it threw away that terminal's whole operation, lead-in
+        # included. ICICI's statement form is submitted twice -- once by the GO
+        # button (#DUMMY1) to load the period's statements, once to download --
+        # and both submits name themselves after the same page, so the second
+        # collapsed into the first and #DUMMY1 reached no step at all. The
+        # journey then had no way to ask for the statements it was about to
+        # download.
+        #
+        # Number them instead. Two operations that genuinely do the same thing
+        # cost a redundant step; a dropped one costs the journey.
         name = _op_name(kind, ev, _slug_from_path(url))
         if name in seen:
-            continue
+            suffix = 2
+            while f"{name}_{suffix}" in seen:
+                suffix += 1
+            name = f"{name}_{suffix}"
         seen.add(name)
 
         out.append(

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -580,6 +580,32 @@ def _is_css_kind(kind: str) -> bool:
     return kind in ("css", "testid", "id", "name", "css_path")
 
 
+_LOGIN_CONTROL = re.compile(r"\|\s*(log ?in|sign ?in|login|signin|continue to login)\s*$", re.I)
+
+
+def _is_login_control(click: dict) -> bool:
+    """Does this click operate a sign-in control?
+
+    A workflow can contain a SECOND login, to another origin, inside the slice
+    the splitter already separated the first one from. ICICI's statement portal
+    has its own: the recording clicked "Log In" and the URL gained a jsessionid.
+    A replay whose session already satisfies it arrives past that point, the
+    button is absent, and the compiled step matches nothing -- unnecessary, not
+    broken.
+
+    Matched on the accessible NAME, not on a selector: #DEH_LOGIN says nothing,
+    while `role_name: button|Log In` is the control announcing what it is.
+    """
+    for cand in click.get("candidates") or []:
+        if not isinstance(cand, dict):
+            continue
+        if str(cand.get("kind") or "") == "role_name" and _LOGIN_CONTROL.search(
+            str(cand.get("value") or "")
+        ):
+            return True
+    return False
+
+
 def _step_for_click(click: dict) -> dict | None:
     """One compiled step for one recorded click.
 
@@ -664,6 +690,11 @@ def _step_for_click(click: dict) -> dict | None:
                     hover["params"][key] = value
         return hover
 
+    # Marked, not dropped: on a cold replay this login IS needed. Optional means
+    # "skip when its control is absent", which is the only reading that is true
+    # both times.
+    optional = _is_login_control(click)
+
     step: dict | None = None
     if locator and locator.get("is_css"):
         step = {"command": "click_element", "params": {"selector": locator["value"]}}
@@ -731,6 +762,12 @@ def _step_for_click(click: dict) -> dict | None:
         }
         if text and not locator.get("is_css"):
             step["locator"]["recorded_text"] = text
+    if step is not None and optional:
+        step["optional"] = True
+        step["optional_reason"] = (
+            "this signs in to the app this operation runs on, which a replay "
+            "may already have done"
+        )
     return step
 
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -504,6 +504,16 @@ def _resolve_nav_chains(pages: list[dict]) -> list[dict]:
             cur = by_key.get(parent_key)
         out = {k: v for k, v in page.items() if not k.startswith("_")}
         out["nav"] = chain if chain else None
+        # The SEGMENT: only the hop from the previous page, and the page it
+        # starts on. The full chain above is the whole journey repeated into
+        # every operation, which is why a replay of operation 2 demands being
+        # back at a landing page the recording left once and never returned to.
+        # Kept alongside rather than instead of `nav` so nothing downstream
+        # moves until it opts in.
+        own_hop = page.get("nav")
+        out["segment"] = list(own_hop) if own_hop else ([] if own_hop == [] else None)
+        parent = by_key.get(page.get("_from_key") or "")
+        out["starts_from"] = parent["url"] if parent else None
         if not ok:
             # Keep the page with the PARTIAL chain instead of discarding it.
             #
@@ -925,15 +935,27 @@ def render_browser_operations_json(
     """
     operations = []
     for p in pages:
-        operations.append(
-            {
-                "name": p["name"],
-                "description": f"Read the rendered contents of {p['url']}",
-                "tool": "call_web_browser",
-                "profile_slug": profile_slug,
-                "steps": _steps_for_page(p),
-            }
-        )
+        op = {
+            "name": p["name"],
+            "description": f"Read the rendered contents of {p['url']}",
+            "tool": "call_web_browser",
+            "profile_slug": profile_slug,
+            "steps": _steps_for_page(p),
+        }
+        # The segment: the page this operation starts on, and only the hop from
+        # it. `steps` above repeats the whole journey into every operation,
+        # which is why replaying operation 2 demands being back at a landing
+        # page the recording left once and never returned to -- and why the
+        # replay grew a reset that has to invent a way there.
+        #
+        # Emitted ALONGSIDE steps, not instead of them: switching the replay
+        # over is a separate change, and until it happens nothing here moves.
+        # Note `starts_from: null` means the landing page, where a fresh session
+        # already is.
+        if p.get("starts_from") is not None or p.get("segment") is not None:
+            op["starts_from"] = p.get("starts_from")
+            op["segment_steps"] = _steps_for_page({**p, "nav": p.get("segment")})
+        operations.append(op)
     # Goals that finish without landing on a new page — a download, a form
     # submission. The page-centric model above cannot express them at all.
     for op in terminal_ops or []:

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -857,6 +857,53 @@ def _inherit_hover_settle(steps: list[dict]) -> None:
         after["expect"] = {**expect, "settle_ms": settle}
 
 
+#: How much longer than the human we allow. Their gap is an upper bound already
+#: -- they could not click before the control existed -- but it was measured on
+#: one network on one day, so a little room costs nothing.
+_ARRIVAL_BUFFER = 1.5
+
+#: Nobody's page takes this long. Beyond it the recorded gap is someone reading
+#: their email, not a page loading, and a replay must not inherit that.
+_ARRIVAL_CAP_MS = 45_000
+
+
+def arrival_budget_ms(click_events: list[dict], arrive_seq: int | None) -> int | None:
+    """How long the human waited after the click that caused this arrival.
+
+    Measured, not guessed: the gap between the click at ``arrive_seq`` and their
+    next interaction. They could not have clicked the next control before it
+    existed, so this is an upper bound on the page becoming usable -- and on
+    ICICI's statement portal it was 17.2s, where a 3s constant gave up long
+    before the form appeared.
+
+    An upper bound is exactly what a deadline wants: the replay proceeds the
+    moment the control appears and only uses this to decide when to stop
+    waiting. Buffered a little because one recording is one sample, and capped
+    because some of that gap is a human reading.
+    """
+    if arrive_seq is None:
+        return None
+    ordered = sorted(
+        (c for c in click_events or [] if event_seq(c) is not None),
+        key=lambda c: event_seq(c),
+    )
+    cause = next((c for c in ordered if event_seq(c) == arrive_seq), None)
+    if cause is None:
+        return None
+    start = _parse_ts(cause.get("timestamp") or "")
+    if start is None:
+        return None
+    for c in ordered:
+        if event_seq(c) <= arrive_seq:
+            continue
+        at = _parse_ts(c.get("timestamp") or "")
+        if at is None:
+            continue
+        gap_ms = int((at - start).total_seconds() * 1000 * _ARRIVAL_BUFFER)
+        return max(0, min(gap_ms, _ARRIVAL_CAP_MS)) or None
+    return None
+
+
 def _steps_for_page(p: dict) -> list[dict]:
     """Recipe to read a page WITHOUT a reload.
 
@@ -1023,6 +1070,7 @@ def entry_url_for(url_events: list[dict], pages: list[dict]) -> str:
 
 def render_browser_operations_json(
     pages: list[dict],
+    click_events: list[dict] | None = None,
     *,
     profile_slug: str,
     terminal_ops: list[dict] | None = None,
@@ -1056,6 +1104,13 @@ def render_browser_operations_json(
         if p.get("starts_from") is not None or p.get("segment") is not None:
             op["starts_from"] = p.get("starts_from")
             op["segment_steps"] = _steps_for_page({**p, "nav": p.get("segment")})
+        # How long the page AFTER this operation took to become usable, measured
+        # from the human's own gap. Stamped on the operation that CAUSES the
+        # arrival, because that is the click the gap was measured from.
+        last = (p.get("nav") or [None])[-1]
+        budget = arrival_budget_ms(click_events or [], (last or {}).get("seq"))
+        if budget:
+            op["causes_arrival_budget_ms"] = budget
         operations.append(op)
     # Goals that finish without landing on a new page — a download, a form
     # submission. The page-centric model above cannot express them at all.
@@ -1339,6 +1394,7 @@ def generate_browser_skill(
         pages,
         profile_slug=profile_slug,
         terminal_ops=terminal_ops,
+        click_events=click_events,
         entry_url=entry_url_for(url_events, pages),
         entry_by_origin=entry_urls_by_origin(url_events),
     )

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -612,6 +612,19 @@ def _is_login_control(click: dict) -> bool:
     return False
 
 
+def _stamp_source(step: dict | None, click: dict) -> dict | None:
+    """Remember which recorded interaction a step was compiled from.
+
+    Only folding reads this, and only to place a boundary between two variants
+    recorded one after the other. It is provenance, never behaviour -- see
+    `_behaviour`, which keeps it from making two identical actions look
+    different.
+    """
+    if step is not None and click.get("seq") is not None:
+        step["_seq"] = click["seq"]
+    return step
+
+
 def _step_for_click(click: dict) -> dict | None:
     """One compiled step for one recorded click.
 
@@ -988,7 +1001,7 @@ def _steps_for_page(p: dict) -> list[dict]:
     steps: list[dict] = []
     carried: dict = {}
     for click in p.get("nav") or []:
-        step = _step_for_click(click)
+        step = _stamp_source(_step_for_click(click), click)
         if step is None:
             continue
         expect = _expect_for_click(click) or {}
@@ -1198,6 +1211,10 @@ def render_browser_operations_json(
                 # recorded order is a separate change.
                 "starts_from": _terminal_starts_from(op),
                 "segment_steps": _terminal_segment(op),
+                # Carried onto the emitted operation because folding happens in
+                # a later run, reading operations.json back from disk -- the
+                # recording is long gone by then.
+                "_terminal_seq": op.get("_terminal_seq"),
             }
         )
     doc = {"schema_version": "1", "style": "browser", "operations": operations}
@@ -1734,6 +1751,12 @@ def derive_terminal_operations(
                 "name": name,
                 "kind": kind,
                 "url": url,
+                # WHEN it finished. Two variants recorded one after the other
+                # share a journey, and the boundary between them is the moment
+                # the first one completed -- which for ICICI is a `submit` event
+                # that never becomes a step, so no comparison of the steps
+                # themselves can find it. Recorded order can.
+                "_terminal_seq": term_seq,
                 # Where its work happens -- what starts_from must name.
                 "work_url": work_url,
                 # Reach the page exactly the way the read operation for it does.
@@ -1782,7 +1805,7 @@ def _steps_for_terminal(op: dict) -> list[dict]:
     """Recipe for a terminal operation: reach the page, then do the thing."""
     steps: list[dict] = []
     for click in op.get("nav") or []:
-        step = _step_for_click(click)
+        step = _stamp_source(_step_for_click(click), click)
         if step is None:
             continue
         expect = _expect_for_click(click)
@@ -1834,11 +1857,23 @@ def _terminal_description(op: dict) -> str:
     return f"Submit the form on {op['url']} and read the result"
 
 
+def _behaviour(step: dict) -> dict:
+    """A step stripped of provenance -- what it DOES, not where it came from.
+
+    Underscore-prefixed keys record which interaction a step was compiled from.
+    Two operations that perform the same action perform the same action whether
+    or not it was recorded at the same moment: monthly and annual both end by
+    clicking Download, from different clicks, and comparing the raw dicts would
+    stop that being recognised as shared and duplicate it into both branches.
+    """
+    return {k: v for k, v in step.items() if not k.startswith("_")}
+
+
 def _common_prefix_len(a: list[dict], b: list[dict]) -> int:
     """How many leading steps two operations perform identically."""
     n = 0
     for x, y in zip(a, b):
-        if x != y:
+        if _behaviour(x) != _behaviour(y):
             break
         n += 1
     return n
@@ -1848,7 +1883,7 @@ def _common_suffix_len(a: list[dict], b: list[dict], skip: int) -> int:
     """How many trailing steps match, without eating into the shared prefix."""
     n = 0
     limit = min(len(a), len(b)) - skip
-    while n < limit and a[len(a) - 1 - n] == b[len(b) - 1 - n]:
+    while n < limit and _behaviour(a[len(a) - 1 - n]) == _behaviour(b[len(b) - 1 - n]):
         n += 1
     return n
 
@@ -1922,7 +1957,7 @@ def _journey_part(op: dict) -> list[dict]:
     return steps[: max(0, len(steps) - len(segment))]
 
 
-def _after_last_terminal(steps: list[dict]) -> list[dict]:
+def _after_last_terminal(steps: list[dict], boundary_seq: int | None = None) -> list[dict]:
     """Drop everything up to and including a completed terminal action.
 
     A finished action is a boundary. The human downloaded the MONTHLY statement,
@@ -1934,12 +1969,38 @@ def _after_last_terminal(steps: list[dict]) -> list[dict]:
 
     What precedes a completed terminal belongs to the variant it completed, not
     to the one that follows.
+
+    Two markers, because a terminal is not always visible in the steps. A step
+    that carries the download itself says so. ICICI's did not: the download was
+    reported against the `submit` the click triggered, and submits are not
+    replayable steps, so nothing in this list can show where the monthly
+    statement finished. `boundary_seq` is that moment in recorded order, and any
+    step at or before it was that variant's work.
     """
     last = -1
     for i, step in enumerate(steps):
-        if (step.get("expect") or {}).get("download") or step.get("command") == "list_downloads":
+        seq = step.get("_seq")
+        carries_download = bool((step.get("expect") or {}).get("download"))
+        confirms_download = step.get("command") == "list_downloads"
+        within_earlier_variant = (
+            boundary_seq is not None and seq is not None and seq <= boundary_seq
+        )
+        if carries_download or confirms_download or within_earlier_variant:
             last = i
     return steps[last + 1 :] if last >= 0 else steps
+
+
+def _preceding_terminal(mine: int | None, theirs: int | None) -> int | None:
+    """The other variant's terminal, if it completed BEFORE this one's.
+
+    Only a terminal already in the past can bound this branch. Applied the other
+    way round it would read the whole journey as belonging to a variant that had
+    not happened yet and drop every step the earlier branch needs -- which is
+    the same "everything passed, nothing ran" failure this rule exists to stop.
+    """
+    if mine is None or theirs is None or theirs >= mine:
+        return None
+    return theirs
 
 
 def _branch_work(a: dict, b: dict) -> tuple[list[dict], list[dict]]:
@@ -1951,9 +2012,12 @@ def _branch_work(a: dict, b: dict) -> tuple[list[dict], list[dict]]:
     """
     a_journey, b_journey = _journey_part(a), _journey_part(b)
     shared = _common_prefix_len(a_journey, b_journey)
+    a_term, b_term = a.get("_terminal_seq"), b.get("_terminal_seq")
     return (
-        _after_last_terminal(a_journey[shared:]) + (a.get("segment_steps") or []),
-        _after_last_terminal(b_journey[shared:]) + (b.get("segment_steps") or []),
+        _after_last_terminal(a_journey[shared:], _preceding_terminal(a_term, b_term))
+        + (a.get("segment_steps") or []),
+        _after_last_terminal(b_journey[shared:], _preceding_terminal(b_term, a_term))
+        + (b.get("segment_steps") or []),
     )
 
 
@@ -1998,12 +2062,30 @@ def apply_fold(
     if a is None or b is None or len(values) != 2:
         return operations
 
+    # The shared way to the fork, then each branch's own work -- the same
+    # decomposition the segment uses below, so the two cannot disagree. Merging
+    # the two full step lists directly instead left `steps` holding the monthly
+    # download at the head of the annual branch while `segment_steps` had
+    # correctly dropped it: one artifact describing the journey two ways, and
+    # the wrong one is the fallback for anything not running segments.
+    a_journey, b_journey = _journey_part(a), _journey_part(b)
+    shared = a_journey[: _common_prefix_len(a_journey, b_journey)]
+    work = _branch_work(a, b)
+    # Only a segmented operation can be split this way -- the journey is
+    # recovered by subtracting the segment, so without one there is nothing to
+    # subtract and the decomposition yields an empty skill. Those fold exactly
+    # as they always did.
+    segmented = a.get("segment_steps") is not None and b.get("segment_steps") is not None
+    merged_steps = (
+        shared + _merge_branches(*work, param, values)
+        if segmented
+        else _merge_branches(a.get("steps") or [], b.get("steps") or [], param, values)
+    )
+
     folded = {
         **a,
         "name": name,
-        "steps": _merge_branches(
-            a.get("steps") or [], b.get("steps") or [], param, values
-        ),
+        "steps": merged_steps,
         # The segment gets the same treatment, PLUS the part of each journey
         # that only its own branch takes.
         #
@@ -2019,9 +2101,7 @@ def apply_fold(
         # journey part is recoverable by length. Whatever the two journeys share
         # is the way to the fork; whatever they do not is the branch choosing
         # itself, and belongs with the branch.
-        "segment_steps": _merge_branches(
-            *_branch_work(a, b), param, values
-        ),
+        "segment_steps": _merge_branches(*work, param, values),
         "parameters": [
             *(a.get("parameters") or []),
             {

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -150,6 +150,17 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
     from_key = _page_key(from_url)
     nav_dt = _parse_ts((nav_ev or {}).get("timestamp") or "")
     nav_seq = event_seq(nav_ev)
+    # A click is an OPENER when the click that follows says it landed inside it.
+    # The recorder asserts that on the second click (opened_by_previous), because
+    # that is when it becomes true; here it is read back onto the first.
+    opener_seqs: set[int] = set()
+    ordered = [c for c in (click_events or []) if isinstance(c, dict)]
+    for prev, nxt in zip(ordered, ordered[1:], strict=False):
+        if nxt.get("opened_by_previous"):
+            pseq = event_seq(prev)
+            if pseq is not None:
+                opener_seqs.add(pseq)
+
     cands: list[dict] = []
     late_cands: list[dict] = []
     for c in click_events or []:
@@ -201,6 +212,7 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
         (late_cands if late else cands).append(
             {
                 "text": text,
+                "is_opener": event_seq(c) in opener_seqs,
                 # The OTHER ways this control was seen. choose_locator collapses
                 # them to one winner above; the runtime needs the rest to fall
                 # back on when that winner stops matching.
@@ -518,6 +530,21 @@ def _step_for_click(click: dict) -> dict | None:
         if expect:
             step["expect"] = expect
         return step
+
+    if click.get("is_opener") and (click.get("candidates") or []):
+        # This click OPENED the control the next one used -- a dropdown showing
+        # its current value, clicked to reveal the options. Its visible label is
+        # therefore the widget's VALUE ("FY2024-25"), not a control name, and it
+        # will read differently at replay: next year, or on another account. So
+        # address it by a stable selector even though a text candidate exists.
+        #
+        # Only for an opener. An ordinary control whose label happens to be a
+        # div -- ICICI's "Credit Cards" nav -- keeps its text, which is the whole
+        # point of recovering it.
+        for cand in click["candidates"]:
+            if isinstance(cand, dict) and _is_css_kind(str(cand.get("kind") or "")):
+                if cand.get("value") and cand.get("match_count") in (1, -1, None):
+                    return {"command": "click_element", "params": {"selector": str(cand["value"])}}
 
     if (click.get("event_type") or "") == "hover":
         # Hover is addressed like any other control, but it opens rather than

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -874,6 +874,32 @@ def _step_for_click(click: dict) -> dict | None:
                 value = str(element.get(key) or "").strip()
                 if value:
                     hover["params"][key] = value
+        # The opener needs alternatives as much as the control it reveals.
+        #
+        # This branch returned before the fallback loop below ever ran, so a
+        # hover step carried exactly one selector. On ICICI that selector is
+        # positional -- `#scroll-container > div > div:nth-of-type(5)` -- and
+        # when the nav reordered between sessions the menu never opened, so the
+        # click that followed could not match however durable ITS locators were.
+        #
+        # CSS-expressible only, since there is no hover-by-text.
+        hover_alts = []
+        for cand in click.get("candidates") or []:
+            if not isinstance(cand, dict) or not cand.get("value"):
+                continue
+            kind = str(cand.get("kind") or "")
+            if not _is_css_kind(kind):
+                continue
+            value = str(cand["value"])
+            if value == locator.get("value"):
+                continue
+            if cand.get("match_count") not in (1, -1, None):
+                continue
+            if _carries_account_number(value):
+                continue
+            hover_alts.append({"selector": value})
+        if hover_alts:
+            hover["params"]["fallbacks"] = hover_alts[:4]
         return hover
 
     # Marked, not dropped: on a cold replay this login IS needed. Optional means
@@ -1075,9 +1101,28 @@ def _fold_hover_into_click(steps: list[dict]) -> list[dict]:
             and nxt.get("command") in ("click_element", "click_by_text")
             and (step.get("params") or {}).get("selector")
         ):
+            # The hover keeps ITS OWN fallbacks, under a separate key.
+            #
+            # hover_first was emitted as a bare selector, and on ICICI that
+            # selector is positional -- `#scroll-container > div > div:nth-of-type(5)`
+            # named the Cards box in the session it was recorded in and something
+            # else in the next. With nothing behind it the menu never opened, so
+            # the click that followed could not match however durable ITS
+            # locators were: the whole gesture is only as addressable as its
+            # opener.
+            #
+            # Separate from `fallbacks` because the two describe different
+            # elements. The runtime used to spread the click's params into the
+            # opener lookup, so a missed hover fell through to a locator for the
+            # control it was supposed to reveal -- one that cannot exist until
+            # the hover succeeds.
+            hover_alts = list((step.get("params") or {}).get("fallbacks") or [])
+            merged_params = {**(nxt.get("params") or {}), "hover_first": step["params"]["selector"]}
+            if hover_alts:
+                merged_params["hover_fallbacks"] = hover_alts
             merged = {
                 **nxt,
-                "params": {**(nxt.get("params") or {}), "hover_first": step["params"]["selector"]},
+                "params": merged_params,
             }
             _scope_under_the_hover(merged, step["params"]["selector"])
             # The hover's own expectation described opening the menu; the click's

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -122,6 +122,28 @@ _NAV_SEQ_SLACK = 3
 _NAV_TIME_SLACK_S = 1.5
 
 
+def _opener_seqs(click_events: list[dict] | None) -> set[int]:
+    """Seqs of clicks that OPENED whatever the next click used.
+
+    The recorder asserts this on the SECOND click (``opened_by_previous``),
+    because that is when it becomes true; here it is read back onto the first.
+
+    Shared by every call site on purpose. It was computed inside the nav-chain
+    builder alone, so a dropdown opened in a terminal operation's LEAD-IN never
+    carried the flag -- the value was derived and then dropped one layer above
+    the code that uses it, which is how ICICI's year trigger kept compiling to
+    click_by_text on a label that is really the widget's current value.
+    """
+    out: set[int] = set()
+    ordered = [c for c in (click_events or []) if isinstance(c, dict)]
+    for prev, nxt in zip(ordered, ordered[1:], strict=False):
+        if nxt.get("opened_by_previous"):
+            pseq = event_seq(prev)
+            if pseq is not None:
+                out.add(pseq)
+    return out
+
+
 def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> list[dict]:
     """The recorded click CHAIN that drove an in-app navigation FROM from_url.
 
@@ -150,16 +172,7 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
     from_key = _page_key(from_url)
     nav_dt = _parse_ts((nav_ev or {}).get("timestamp") or "")
     nav_seq = event_seq(nav_ev)
-    # A click is an OPENER when the click that follows says it landed inside it.
-    # The recorder asserts that on the second click (opened_by_previous), because
-    # that is when it becomes true; here it is read back onto the first.
-    opener_seqs: set[int] = set()
-    ordered = [c for c in (click_events or []) if isinstance(c, dict)]
-    for prev, nxt in zip(ordered, ordered[1:], strict=False):
-        if nxt.get("opened_by_previous"):
-            pseq = event_seq(prev)
-            if pseq is not None:
-                opener_seqs.add(pseq)
+    opener_seqs = _opener_seqs(click_events)
 
     cands: list[dict] = []
     late_cands: list[dict] = []
@@ -1151,6 +1164,7 @@ def derive_terminal_operations(
     exactly as they did.
     """
     click_events = order_events(click_events)
+    term_opener_seqs = _opener_seqs(click_events)
     # Same multi-origin rule as the pages themselves: an interaction on the
     # app's second host (ICICI's statement portal) is still this app's.
     app_origins = {_url_origin(p["url"]) for p in pages}
@@ -1233,6 +1247,7 @@ def derive_terminal_operations(
                     "text": (c.get("text_content") or "").strip(),
                     "locator": choose_locator(c.get("candidates")),
                     "candidates": c.get("candidates"),
+                    "is_opener": event_seq(c) in term_opener_seqs,
                     "outcome": c.get("outcome"),
                 }
             )

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -940,7 +940,25 @@ def _fold_hover_into_click(steps: list[dict]) -> list[dict]:
                                         "hover_first": step["params"]["selector"]}}
             _scope_under_the_hover(merged, step["params"]["selector"])
             # The hover's own expectation described opening the menu; the click's
-            # describes where the gesture lands. Keep the click's.
+            # describes where the gesture lands. Keep the click's -- but NOT its
+            # timing.
+            #
+            # How long the menu takes to appear was measured on the HOVER, and
+            # folding the pair threw that away with the rest of its expectation:
+            # `_inherit_hover_settle` runs after this and has no hover step left
+            # to read, so it is a no-op for exactly the pairs it was written for.
+            # The merged step then carried no settle at all and fell back to the
+            # runtime's 3s floor, while ICICI's nav measured 2161ms to settle and
+            # renders its submenu right around there -- which is why this step was
+            # a coin flip that passed on an immediate retry.
+            #
+            # Only when the click has no measurement of its own: what the click
+            # observed is about where it landed, and is the better answer when
+            # it exists.
+            hover_settle = (step.get("expect") or {}).get("settle_ms")
+            if hover_settle and not (merged.get("expect") or {}).get("settle_ms"):
+                merged["expect"] = {**(merged.get("expect") or {}),
+                                    "settle_ms": hover_settle}
             out.append(merged)
             i += 2
             continue
@@ -1193,6 +1211,56 @@ def entry_url_for(url_events: list[dict], pages: list[dict]) -> str:
     return str((pages or [{}])[0].get("url") or "")
 
 
+def _truncate_reads_at_terminals(operations: list[dict]) -> None:
+    """A read must stop where the next goal begins.
+
+    Page operations collect every click the human made on that page, and the
+    human did TWO things on ICICI's statement page: downloaded the monthly
+    statement, then switched the form to Annual and downloaded that. So
+    `read_corp_finacle` spanned both -- and its steps included `set_checked
+    Annual` and the GO that submits it.
+
+    Replayed, that read performed the annual selection whatever timeframe was
+    asked for, navigating to /corp/Finacle before the MONTHLY download could
+    run. Monthly then either failed its guard or landed on the annual page and
+    fetched the wrong document, while every step reported ok.
+
+    The terminal is the boundary: anything a read does after another operation's
+    goal completed belongs to what comes next, not to the read. The annual
+    branch already carries those steps itself, so nothing is lost -- and annual,
+    which works, is untouched.
+    """
+    terminals = sorted(
+        t for t in (op.get("_terminal_seq") for op in operations) if isinstance(t, int)
+    )
+    if not terminals:
+        return
+    for op in operations:
+        if op.get("_terminal_seq") is not None:
+            continue
+        segment = op.get("segment_steps")
+        if not segment:
+            continue
+        seqs = [s["_seq"] for s in segment if isinstance(s.get("_seq"), int)]
+        if not seqs:
+            continue
+        inside = [t for t in terminals if min(seqs) < t < max(seqs)]
+        if not inside:
+            continue
+        cut = inside[0]
+        kept = [
+            s for s in segment
+            if not (isinstance(s.get("_seq"), int) and s["_seq"] > cut)
+        ]
+        dropped = len(segment) - len(kept)
+        if not dropped:
+            continue
+        op["segment_steps"] = kept
+        # steps is the journey followed by the segment, so the same tail goes.
+        if op.get("steps"):
+            op["steps"] = op["steps"][: len(op["steps"]) - dropped]
+
+
 def _recorded_position(op: dict) -> float:
     """When, in the recording, this operation happens.
 
@@ -1301,6 +1369,7 @@ def render_browser_operations_json(
     # Position comes from the recording: the earliest interaction an operation
     # touches, or the moment it completed. Operations with neither keep their
     # place, since a stable sort leaves equal keys alone.
+    _truncate_reads_at_terminals(operations)
     operations.sort(key=_recorded_position)
     doc = {"schema_version": "1", "style": "browser", "operations": operations}
     if entry_by_origin:

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -2039,6 +2039,14 @@ def derive_terminal_operations(
     out: list[dict] = []
     seen: set[str] = set()
 
+    # Every terminal's ordinal, so a toggle can be bound by the PREVIOUS terminal
+    # when it was set on a different page from the one it configures.
+    _terminal_seqs = sorted(
+        sq
+        for sq in (event_seq(c) for c in click_events or [] if _terminal_kind(c) is not None)
+        if sq is not None
+    )
+
     for ev in click_events or []:
         kind = _terminal_kind(ev)
         if kind is None:
@@ -2111,15 +2119,40 @@ def derive_terminal_operations(
         # later screen's clicks never leak in. Inputs are excluded: those become
         # parameters above, and replaying them as clicks would fight the values
         # the caller passes.
+        # A radio or checkbox the human SET is part of this gesture too.
+        #
+        # It arrives as a `change`, not a click, so the event-type guard below
+        # dropped it -- and it is not an input either, so `page_inputs` above did
+        # not claim it as a parameter. It belonged to nothing. ICICI's Annual
+        # radio (seq 21) went missing exactly that way: the compiled download
+        # never selected Annual, the form stayed on Monthly, and a monthly
+        # statement came back with every check passing.
+        #
+        # The page test has to relax for these as well. The human set the period
+        # on the AuthenticationController screen and submitted on the NEXT one,
+        # so the control that decides WHAT is downloaded lives on a different
+        # page from the terminal that downloads it. Bounded by the previous
+        # terminal instead: whatever was set in that window was setting up THIS
+        # submit, whichever screen it was on.
+        prev_term_seq = max((sq for sq in _terminal_seqs if sq < (term_seq or 0)), default=None)
+
+        def _is_toggle(c: dict) -> bool:
+            return (c.get("event_type") or "") == "change" and str(
+                c.get("input_type") or ""
+            ).lower() in ("radio", "checkbox")
+
         lead_steps: list[dict] = []
         for c in click_events or []:
+            toggle = _is_toggle(c)
             # A hover that opened a menu is part of the gesture, not noise.
-            if (c.get("event_type") or "click") not in ("click", "hover"):
+            if not toggle and (c.get("event_type") or "click") not in ("click", "hover"):
                 continue
-            if _page_key(c.get("url") or "") != _page_key(work_url):
+            if not toggle and _page_key(c.get("url") or "") != _page_key(work_url):
                 continue
             c_seq = event_seq(c)
             if term_seq is None or c_seq is None or c_seq >= term_seq:
+                continue
+            if toggle and prev_term_seq is not None and c_seq <= prev_term_seq:
                 continue
             source = {
                 "text": (c.get("text_content") or "").strip(),

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -406,6 +406,11 @@ def _resolve_nav_chains(pages: list[dict]) -> list[dict]:
     return resolved
 
 
+def _is_css_kind(kind: str) -> bool:
+    """Kinds whose value is a CSS selector rather than human-visible text."""
+    return kind in ("css", "testid", "id", "name", "css_path")
+
+
 def _step_for_click(click: dict) -> dict | None:
     """One compiled step for one recorded click.
 
@@ -475,6 +480,35 @@ def _step_for_click(click: dict) -> dict | None:
             value = str(element.get(key) or "").strip()
             if value:
                 step["params"][key] = value
+
+    # The OTHER ways the recorder saw this control, for the runtime to try when
+    # the chosen one matches nothing.
+    #
+    # The recorder ranks several candidates -- id, aria-label, role+name, visible
+    # text, css path -- and choose_locator committed to one and discarded the
+    # rest. On a portal whose nav is icon divs the winner is a positional css
+    # path, and when the page shifts by one node the step is simply dead, while
+    # the text candidate that would have worked was recorded and thrown away.
+    # An ICICI replay failed every nav step this way, and a hand-written skill
+    # using click_by_text("Cards") on the same portal worked.
+    #
+    # Ordered as the recorder ranked them, unique matches only: a fallback that
+    # matches several nodes would trade a dead step for a wrong click.
+    alts = []
+    for cand in click.get("candidates") or []:
+        if not isinstance(cand, dict) or not cand.get("value"):
+            continue
+        if locator and cand.get("value") == locator.get("value"):
+            continue
+        if cand.get("match_count") not in (1, -1, None):
+            continue
+        value = str(cand["value"])
+        kind = str(cand.get("kind") or "")
+        if kind == "role_name" and "|" in value:
+            value = value.split("|", 1)[1]
+        alts.append({"selector": value} if _is_css_kind(kind) else {"text": value})
+    if alts:
+        step["params"]["fallbacks"] = alts[:4]
 
     if locator:
         # Carried for the human reading the recipe and for a future repair pass:

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -424,7 +424,28 @@ def _nav_clicks_for(from_url: str, nav_ev: dict, click_events: list[dict]) -> li
     # ["Banking","Cards","Credit Card"], so the first click targeted an element
     # still hidden behind the un-opened hamburger. Three-deep accordions behind a
     # menu toggle are normal on HSBCnet/ICICI.
-    return [out[0]] + out[-(_NAV_MAX_CLICKS - 1) :]
+    #
+    # But never at the cost of work done ON the destination page. The cap exists
+    # to bound a long MENU walk, where the middle really is redundant once the
+    # first and last are known. It was applied to the whole chain, so it also
+    # threw away clicks that changed the page's own state: an ICICI capture
+    # recorded hover, "Past", hover, "download previous statement" on
+    # /credit-card, and `[out[0]] + out[-2:]` returned hover, hover,
+    # "download previous statement" -- dropping the tab switch. The replay then
+    # sat on the CURRENT tab looking for a link that only exists under PAST, and
+    # reported "nothing on the page matches" about a control that was genuinely
+    # not there. Nothing in the bundle or the report said a step had been
+    # discarded.
+    #
+    # So the cap only trims the LEAD-IN: entries recorded on an earlier page than
+    # the one this gesture ends on. Everything on the destination page is the
+    # operation's own work and is kept whole.
+    last_key = _page_key(str(out[-1].get("url") or ""))
+    on_destination = [c for c in out if _page_key(str(c.get("url") or "")) == last_key]
+    lead_in = [c for c in out if c not in on_destination]
+    if not lead_in:
+        return out
+    return [lead_in[0]] + lead_in[-(_NAV_MAX_CLICKS - 1) :] + on_destination
 
 
 def app_origins_from(

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -795,6 +795,42 @@ def _expect_for_click(click: dict) -> dict | None:
     return expect or None
 
 
+def _fold_hover_into_click(steps: list[dict]) -> list[dict]:
+    """A hover and the click it enables are ONE gesture, so emit one step.
+
+    As two steps they are two round trips to the worker, and a menu that only
+    exists while the pointer rests on its trigger cannot survive the gap.
+    Measured on ICICI: hover returned ok and the submenu was not visible on any
+    later call -- 1s, 2s, 3s, 4s. The click was racing the menu closing, which
+    looked like slowness and got "fixed" twice by waiting longer.
+
+    Only a css-addressable hover immediately followed by a click_element: there
+    is no hover-by-text, and a hover followed by anything else is not this
+    pattern.
+    """
+    out: list[dict] = []
+    i = 0
+    while i < len(steps):
+        step = steps[i]
+        nxt = steps[i + 1] if i + 1 < len(steps) else None
+        if (
+            step.get("command") == "hover"
+            and nxt is not None
+            and nxt.get("command") == "click_element"
+            and (step.get("params") or {}).get("selector")
+        ):
+            merged = {**nxt, "params": {**(nxt.get("params") or {}),
+                                        "hover_first": step["params"]["selector"]}}
+            # The hover's own expectation described opening the menu; the click's
+            # describes where the gesture lands. Keep the click's.
+            out.append(merged)
+            i += 2
+            continue
+        out.append(step)
+        i += 1
+    return out
+
+
 def _inherit_hover_settle(steps: list[dict]) -> None:
     """A click after a hover waits for the menu the hover opened.
 
@@ -900,7 +936,7 @@ def _steps_for_page(p: dict) -> list[dict]:
         )
 
     steps.append({"command": "get_page_summary"})
-    out = _collapse_repeats(steps)
+    out = _fold_hover_into_click(_collapse_repeats(steps))
     _inherit_hover_settle(out)
     return out
 
@@ -1625,6 +1661,7 @@ def _steps_for_terminal(op: dict) -> list[dict]:
         steps.append({"command": "list_downloads"})
     else:
         steps.append({"command": "get_page_summary"})
+    steps = _fold_hover_into_click(steps)
     _inherit_hover_settle(steps)
     return steps
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1149,6 +1149,34 @@ def entry_url_for(url_events: list[dict], pages: list[dict]) -> str:
     return str((pages or [{}])[0].get("url") or "")
 
 
+def _recorded_position(op: dict) -> float:
+    """When, in the recording, this operation happens.
+
+    The earliest interaction any of its steps came from, or the moment its
+    terminal completed -- whichever is earlier, since a terminal operation's
+    lead-in steps carry no position of their own while its terminal does.
+
+    Infinity for an operation the recording cannot place, so a stable sort keeps
+    it where it was rather than moving it somewhere arbitrary.
+    """
+    # Its OWN work, not the journey that reaches it. `steps` carries the whole
+    # chain from the landing page, which every operation shares -- so the
+    # earliest step there is the same first click for all of them and orders
+    # nothing.
+    own = op.get("segment_steps")
+    if own is None:
+        own = op.get("steps") or []
+    seqs = [
+        step["_seq"]
+        for step in own
+        if isinstance(step, dict) and isinstance(step.get("_seq"), int)
+    ]
+    terminal = op.get("_terminal_seq")
+    if isinstance(terminal, int):
+        seqs.append(terminal)
+    return float(min(seqs)) if seqs else float("inf")
+
+
 def render_browser_operations_json(
     pages: list[dict],
     click_events: list[dict] | None = None,
@@ -1217,6 +1245,19 @@ def render_browser_operations_json(
                 "_terminal_seq": op.get("_terminal_seq"),
             }
         )
+    # In the order the human did them.
+    #
+    # These operations are ONE journey cut into pieces, and each continues from
+    # the page its predecessor left behind -- so the list order IS the replay
+    # order. Emitting every page operation and then every terminal one puts them
+    # out of sequence: ICICI's portal sign-in (recorded at 18) landed AFTER the
+    # statement-page read (20-24), which had already navigated past the page the
+    # sign-in runs on, so it could only ever fail its own starts_from guard.
+    #
+    # Position comes from the recording: the earliest interaction an operation
+    # touches, or the moment it completed. Operations with neither keep their
+    # place, since a stable sort leaves equal keys alone.
+    operations.sort(key=_recorded_position)
     doc = {"schema_version": "1", "style": "browser", "operations": operations}
     if entry_by_origin:
         # One per host. A reset must not change hosts -- see entry_urls_by_origin.

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -497,6 +497,43 @@ def _resolve_nav_chains(pages: list[dict]) -> list[dict]:
     return resolved
 
 
+#: Selectors that name the document rather than a control.
+_DOCUMENT_SELECTORS = frozenset({"body", "html", ":root", "body *", "html body"})
+
+
+def _same_control(a: dict, b: dict) -> bool:
+    """Do two steps drive the same control?"""
+    pa, pb = (a.get("params") or {}), (b.get("params") or {})
+    for key in ("selector", "text", "label"):
+        if pa.get(key) and pa.get(key) == pb.get(key):
+            return True
+    return False
+
+
+def _collapse_repeats(steps: list[dict]) -> list[dict]:
+    """One gesture, one step.
+
+    A click on a submit control fires the form's submit too -- ICICI recorded a
+    click and a submit on #DOWNLOAD_ESTATEMENT_PDF four milliseconds apart. The
+    download was attributed to the submit, making it the terminal step, while the
+    click became a lead-in: one press of one button compiled as two clicks, and a
+    replay would ask the portal for the file twice.
+
+    Only ADJACENT repeats collapse. The same control clicked again later in a
+    workflow is a real second action -- a paging control, a retry -- and must
+    survive.
+    """
+    out: list[dict] = []
+    for step in steps:
+        if out and out[-1].get("command") == step.get("command") and _same_control(out[-1], step):
+            # Keep whichever carries more for the runtime (expectations, frame).
+            if len(step) > len(out[-1]):
+                out[-1] = step
+            continue
+        out.append(step)
+    return out
+
+
 def _is_css_kind(kind: str) -> bool:
     """Kinds whose value is a CSS selector rather than human-visible text."""
     return kind in ("css", "testid", "id", "name", "css_path")
@@ -543,6 +580,13 @@ def _step_for_click(click: dict) -> dict | None:
         if expect:
             step["expect"] = expect
         return step
+
+    # A locator that resolves to the document addresses no control. It appears
+    # when the click landed on padding and the walk found nothing better, and at
+    # replay it clicks the page: harmless at best, dismissing something at worst.
+    _loc = click.get("locator") or {}
+    if str(_loc.get("value") or "").strip().lower() in _DOCUMENT_SELECTORS:
+        return None
 
     if click.get("is_opener") and (click.get("candidates") or []):
         # This click OPENED the control the next one used -- a dropdown showing
@@ -709,7 +753,7 @@ def _steps_for_page(p: dict) -> list[dict]:
         )
 
     steps.append({"command": "get_page_summary"})
-    return steps
+    return _collapse_repeats(steps)
 
 
 def ambiguous_steps(pages: list[dict]) -> list[dict]:
@@ -1297,6 +1341,7 @@ def _steps_for_terminal(op: dict) -> list[dict]:
     steps.extend(op.get("lead") or [])
     steps.extend(fill_steps(op.get("parameters") or []))
     steps.append(op["terminal"])
+    steps = _collapse_repeats(steps)
     if op.get("kind") == "download":
         # The artifact IS the result, so the operation ends by naming it rather
         # than by reading the page it left behind.

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -868,6 +868,13 @@ def _inherit_hover_settle(steps: list[dict]) -> None:
 #: one network on one day, so a little room costs nothing.
 _ARRIVAL_BUFFER = 1.5
 
+#: A human clicking straight through says nothing about how fast the page was --
+#: they may have known exactly where to aim, or the control may have been there
+#: already. Measured 4ms between two clicks on ICICI, which as a budget meant the
+#: next arrival waited 6ms and the operation after it failed its starts_from.
+#: Below this the measurement carries no information, so the floor stands in.
+_ARRIVAL_FLOOR_MS = 5_000
+
 #: Nobody's page takes this long. Beyond it the recorded gap is someone reading
 #: their email, not a page loading, and a replay must not inherit that.
 _ARRIVAL_CAP_MS = 45_000
@@ -906,7 +913,7 @@ def arrival_budget_ms(click_events: list[dict], arrive_seq: int | None) -> int |
         if at is None:
             continue
         gap_ms = int((at - start).total_seconds() * 1000 * _ARRIVAL_BUFFER)
-        return max(0, min(gap_ms, _ARRIVAL_CAP_MS)) or None
+        return min(max(gap_ms, _ARRIVAL_FLOOR_MS), _ARRIVAL_CAP_MS)
     return None
 
 

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -504,10 +504,7 @@ _DOCUMENT_SELECTORS = frozenset({"body", "html", ":root", "body *", "html body"}
 def _same_control(a: dict, b: dict) -> bool:
     """Do two steps drive the same control?"""
     pa, pb = (a.get("params") or {}), (b.get("params") or {})
-    for key in ("selector", "text", "label"):
-        if pa.get(key) and pa.get(key) == pb.get(key):
-            return True
-    return False
+    return any(pa.get(k) and pa.get(k) == pb.get(k) for k in ("selector", "text", "label"))
 
 
 def _collapse_repeats(steps: list[dict]) -> list[dict]:

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -25,6 +25,7 @@ import json
 import re
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from noui_core.compile.locators import AMBIGUOUS, UNKNOWN, choose_locator
@@ -694,9 +695,13 @@ def _step_for_click(click: dict) -> dict | None:
             # meant to fix, made silent again. An ambiguous selector is worse
             # here than no selector: falling through leaves the step as it was.
             if cand.get("value") and cand.get("match_count") in (1, -1):
-                target = {"value": str(cand["value"]), "kind": cand.get("kind"),
-                          "match_count": cand.get("match_count"),
-                          "confidence": UNKNOWN, "is_css": True}
+                target = {
+                    "value": str(cand["value"]),
+                    "kind": cand.get("kind"),
+                    "match_count": cand.get("match_count"),
+                    "confidence": UNKNOWN,
+                    "is_css": True,
+                }
                 break
     # No unique selector? Address it the way the recorder identified it: role
     # plus accessible name, which the worker now resolves for set_checked. That
@@ -712,18 +717,17 @@ def _step_for_click(click: dict) -> dict | None:
             role_part, name_part = value.split("|", 1)
             if role_part.strip().lower() not in ("radio", "checkbox"):
                 continue
-            step = {
+            checked_step: dict[str, Any] = {
                 "command": "set_checked",
-                "params": {"role": role_part.strip(), "name": name_part.strip(),
-                           "checked": True},
+                "params": {"role": role_part.strip(), "name": name_part.strip(), "checked": True},
             }
             expect = _expect_for_click(click)
             if expect:
-                step["expect"] = expect
-            return step
+                checked_step["expect"] = expect
+            return checked_step
 
     if role in ("radio", "checkbox") and target:
-        step = {
+        checked_step = {
             "command": "set_checked",
             "params": {"selector": target["value"], "checked": True},
         }
@@ -731,11 +735,11 @@ def _step_for_click(click: dict) -> dict | None:
             for key in ("frame_url", "frame_name"):
                 value = str(element.get(key) or "").strip()
                 if value:
-                    step["params"][key] = value
+                    checked_step["params"][key] = value
         expect = _expect_for_click(click)
         if expect:
-            step["expect"] = expect
-        return step
+            checked_step["expect"] = expect
+        return checked_step
 
     # A locator that resolves to the document addresses no control. It appears
     # when the click landed on padding and the walk found nothing better, and at
@@ -849,8 +853,7 @@ def _step_for_click(click: dict) -> dict | None:
     if step is not None and optional:
         step["optional"] = True
         step["optional_reason"] = (
-            "this signs in to the app this operation runs on, which a replay "
-            "may already have done"
+            "this signs in to the app this operation runs on, which a replay may already have done"
         )
     return step
 
@@ -946,8 +949,10 @@ def _fold_hover_into_click(steps: list[dict]) -> list[dict]:
             and nxt.get("command") == "click_element"
             and (step.get("params") or {}).get("selector")
         ):
-            merged = {**nxt, "params": {**(nxt.get("params") or {}),
-                                        "hover_first": step["params"]["selector"]}}
+            merged = {
+                **nxt,
+                "params": {**(nxt.get("params") or {}), "hover_first": step["params"]["selector"]},
+            }
             _scope_under_the_hover(merged, step["params"]["selector"])
             # The hover's own expectation described opening the menu; the click's
             # describes where the gesture lands. Keep the click's -- but NOT its
@@ -967,8 +972,7 @@ def _fold_hover_into_click(steps: list[dict]) -> list[dict]:
             # it exists.
             hover_settle = (step.get("expect") or {}).get("settle_ms")
             if hover_settle and not (merged.get("expect") or {}).get("settle_ms"):
-                merged["expect"] = {**(merged.get("expect") or {}),
-                                    "settle_ms": hover_settle}
+                merged["expect"] = {**(merged.get("expect") or {}), "settle_ms": hover_settle}
             out.append(merged)
             i += 2
             continue
@@ -1038,7 +1042,7 @@ def arrival_budget_ms(click_events: list[dict], arrive_seq: int | None) -> int |
         return None
     ordered = sorted(
         (c for c in click_events or [] if event_seq(c) is not None),
-        key=lambda c: event_seq(c),
+        key=lambda c: event_seq(c) or 0,
     )
     cause = next((c for c in ordered if event_seq(c) == arrive_seq), None)
     if cause is None:
@@ -1047,7 +1051,7 @@ def arrival_budget_ms(click_events: list[dict], arrive_seq: int | None) -> int |
     if start is None:
         return None
     for c in ordered:
-        if event_seq(c) <= arrive_seq:
+        if (event_seq(c) or 0) <= arrive_seq:
             continue
         at = _parse_ts(c.get("timestamp") or "")
         if at is None:
@@ -1258,10 +1262,7 @@ def _truncate_reads_at_terminals(operations: list[dict]) -> None:
         if not inside:
             continue
         cut = inside[0]
-        kept = [
-            s for s in segment
-            if not (isinstance(s.get("_seq"), int) and s["_seq"] > cut)
-        ]
+        kept = [s for s in segment if not (isinstance(s.get("_seq"), int) and s["_seq"] > cut)]
         dropped = len(segment) - len(kept)
         if not dropped:
             continue
@@ -1289,9 +1290,7 @@ def _recorded_position(op: dict) -> float:
     if own is None:
         own = op.get("steps") or []
     seqs = [
-        step["_seq"]
-        for step in own
-        if isinstance(step, dict) and isinstance(step.get("_seq"), int)
+        step["_seq"] for step in own if isinstance(step, dict) and isinstance(step.get("_seq"), int)
     ]
     terminal = op.get("_terminal_seq")
     if isinstance(terminal, int):
@@ -1373,9 +1372,7 @@ def render_browser_operations_json(
             # with "expected to be on /credit-card ... but the page is
             # /overview". Every operation after it then failed its own guard.
             segment = p.get("nav") or []
-        op["segment_steps"] = (
-            _steps_for_page({**p, "nav": segment}) if segment is not None else []
-        )
+        op["segment_steps"] = _steps_for_page({**p, "nav": segment}) if segment is not None else []
         # How long the page AFTER this operation took to become usable, measured
         # from the human's own gap. Stamped on the operation that CAUSES the
         # arrival, because that is the click the gap was measured from.
@@ -1422,7 +1419,7 @@ def render_browser_operations_json(
     # place, since a stable sort leaves equal keys alone.
     _truncate_reads_at_terminals(operations)
     operations.sort(key=_recorded_position)
-    doc = {"schema_version": "1", "style": "browser", "operations": operations}
+    doc: dict[str, Any] = {"schema_version": "1", "style": "browser", "operations": operations}
     if entry_by_origin:
         # One per host. A reset must not change hosts -- see entry_urls_by_origin.
         doc["entry_urls"] = entry_by_origin
@@ -2129,9 +2126,7 @@ def fold_candidates(operations: list[dict]) -> list[dict]:
     out: list[dict] = []
     # `operations` is a count in some result shapes, not a list of steps -- and
     # a report that raises would fail an import that otherwise succeeded.
-    ops = [
-        o for o in operations or [] if isinstance(o, dict) and isinstance(o.get("steps"), list)
-    ]
+    ops = [o for o in operations or [] if isinstance(o, dict) and isinstance(o.get("steps"), list)]
     for i, a in enumerate(ops):
         for b in ops[i + 1 :]:
             if (a.get("kind") or "read") != (b.get("kind") or "read"):
@@ -2232,8 +2227,9 @@ def _branch_work(a: dict, b: dict) -> tuple[list[dict], list[dict]]:
     )
 
 
-def _merge_branches(a_steps: list[dict], b_steps: list[dict], param: str,
-                    values: list[str]) -> list[dict]:
+def _merge_branches(
+    a_steps: list[dict], b_steps: list[dict], param: str, values: list[str]
+) -> list[dict]:
     """One list: shared prefix, each divergent middle tagged, shared ending.
 
     Used for BOTH `steps` and `segment_steps`. Folding only the former left the

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -1858,6 +1858,30 @@ def fold_candidates(operations: list[dict]) -> list[dict]:
     return out
 
 
+def _journey_part(op: dict) -> list[dict]:
+    """The steps that reach this operation, before its own work begins."""
+    steps = op.get("steps") or []
+    segment = op.get("segment_steps")
+    if segment is None:
+        return []
+    return steps[: max(0, len(steps) - len(segment))]
+
+
+def _branch_work(a: dict, b: dict) -> tuple[list[dict], list[dict]]:
+    """Each operation's own work, including the journey only IT takes.
+
+    The shared head of the two journeys is the way to the fork and stays out of
+    both branches -- the operation before them already walks it. The tail that
+    differs is the branch selecting itself.
+    """
+    a_journey, b_journey = _journey_part(a), _journey_part(b)
+    shared = _common_prefix_len(a_journey, b_journey)
+    return (
+        a_journey[shared:] + (a.get("segment_steps") or []),
+        b_journey[shared:] + (b.get("segment_steps") or []),
+    )
+
+
 def _merge_branches(a_steps: list[dict], b_steps: list[dict], param: str,
                     values: list[str]) -> list[dict]:
     """One list: shared prefix, each divergent middle tagged, shared ending.
@@ -1905,11 +1929,23 @@ def apply_fold(
         "steps": _merge_branches(
             a.get("steps") or [], b.get("steps") or [], param, values
         ),
-        # The segment gets the same treatment. It is what a segmented replay
-        # runs, and leaving it as operation A's copy meant every timeframe ran
-        # the monthly branch.
+        # The segment gets the same treatment, PLUS the part of each journey
+        # that only its own branch takes.
+        #
+        # A step can both navigate and belong to one branch. ICICI's annual
+        # statement is selected by clicking a radio and pressing GO -- and that
+        # submit navigates to /corp/Finacle, so both steps were classified as
+        # journey and stripped from the segment. Nothing else performed them:
+        # the monthly branch diverges before, and no operation sits between. So
+        # timeframe=annual ran the monthly steps on the monthly page and
+        # returned a MONTHLY statement.
+        #
+        # Each operation's steps are its journey followed by its segment, so the
+        # journey part is recoverable by length. Whatever the two journeys share
+        # is the way to the fork; whatever they do not is the branch choosing
+        # itself, and belongs with the branch.
         "segment_steps": _merge_branches(
-            a.get("segment_steps") or [], b.get("segment_steps") or [], param, values
+            *_branch_work(a, b), param, values
         ),
         "parameters": [
             *(a.get("parameters") or []),

--- a/skills/noui/noui_core/compile/locators.py
+++ b/skills/noui/noui_core/compile/locators.py
@@ -1,0 +1,114 @@
+"""Choosing how a compiled step should address an element.
+
+Tabby's recorder (schema_version >= 4) stops guessing. Instead of one selector
+picked in-page by a fixed ladder, each recorded interaction carries several
+CANDIDATES — test-id, id, name, aria-label, role+accessible-name, label, text,
+css path — every one of them with `match_count`, the number of nodes it actually
+matched at the instant it was recorded.
+
+That count is the whole point. The old recorder could emit `a.mb-0` for a link on
+ICICI's dashboard with no idea it matched forty elements; the skill compiled
+cleanly and misclicked in production. Here, a candidate that matched more than
+one node is known to be untrustworthy BEFORE the skill ships.
+
+This module is deliberately pure and knows nothing about steps or skills: given
+candidates, return the best way to address the element and how much to trust it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Durability order, most durable first. Not preference-by-taste: this is roughly
+# "how likely is this to survive a redesign".
+#   testid      — put there for automation; changes only deliberately
+#   id/name     — stable when authored, though frameworks do generate them
+#   aria_label  — accessibility text; survives visual restyling
+#   role_name   — semantic identity; survives DOM restructuring
+#   label       — the form label a human reads
+#   text        — visible copy; survives restructuring, dies on rewording
+#   css_path    — structural; the first thing a redesign breaks
+_KIND_RANK: dict[str, int] = {
+    "testid": 0,
+    "id": 1,
+    "name": 2,
+    "aria_label": 3,
+    "role_name": 4,
+    "label": 5,
+    "text": 6,
+    "css_path": 7,
+}
+
+# Kinds whose `value` is a CSS selector, so a step can address them with
+# `click_element`. The rest carry human-readable text that the runtime resolves
+# semantically (click_by_text / type_into_label).
+_CSS_KINDS = frozenset({"testid", "id", "name", "aria_label", "css_path"})
+
+#: Returned confidence levels, worst to best.
+UNIQUE = "unique"
+UNKNOWN = "unknown"
+AMBIGUOUS = "ambiguous"
+
+
+def _rank(kind: Any) -> int:
+    return _KIND_RANK.get(str(kind), len(_KIND_RANK))
+
+
+def choose_locator(candidates: Any) -> dict | None:
+    """The most durable trustworthy way to address the element, or None.
+
+    Returns ``{"kind", "value", "match_count", "confidence", "is_css"}``.
+
+    Selection order:
+
+    1. Candidates that matched EXACTLY ONE node, best kind first. These are the
+       only ones known to identify this element.
+    2. Failing that, candidates whose count could not be taken (``-1`` — the
+       page could not evaluate the selector). Unknown is not the same as wrong,
+       and it beats a locator we know to be ambiguous.
+    3. Failing that, the best-ranked AMBIGUOUS candidate, so the caller can still
+       emit something and flag it rather than dropping the step entirely.
+
+    ``match_count == 0`` is never selected. It means the candidate did not match
+    even the element it was recorded from — which happens legitimately for
+    elements inside a shadow root or a cross-document iframe, where the top
+    document's query cannot see them. Emitting one guarantees a runtime failure.
+
+    None means there is nothing usable at all: no candidates, or every one of
+    them matched zero nodes.
+    """
+    usable: list[dict] = []
+    for c in candidates or []:
+        if not isinstance(c, dict):
+            continue
+        value = c.get("value")
+        kind = c.get("kind")
+        if not value or not isinstance(value, str) or not kind:
+            continue
+        count = c.get("match_count")
+        if not isinstance(count, int) or isinstance(count, bool):
+            continue
+        if count == 0:
+            continue
+        usable.append({"kind": str(kind), "value": value, "match_count": count})
+
+    if not usable:
+        return None
+
+    def _pick(pool: list[dict], confidence: str) -> dict | None:
+        if not pool:
+            return None
+        best = min(pool, key=lambda c: _rank(c["kind"]))
+        return {
+            "kind": best["kind"],
+            "value": best["value"],
+            "match_count": best["match_count"],
+            "confidence": confidence,
+            "is_css": best["kind"] in _CSS_KINDS,
+        }
+
+    return (
+        _pick([c for c in usable if c["match_count"] == 1], UNIQUE)
+        or _pick([c for c in usable if c["match_count"] < 0], UNKNOWN)
+        or _pick([c for c in usable if c["match_count"] > 1], AMBIGUOUS)
+    )

--- a/skills/noui/noui_core/compile/locators.py
+++ b/skills/noui/noui_core/compile/locators.py
@@ -27,6 +27,16 @@ from typing import Any
 #   role_name   — semantic identity; survives DOM restructuring
 #   label       — the form label a human reads
 #   text        — visible copy; survives restructuring, dies on rewording
+#   container_label / row_scoped
+#               — a :has-text() selector naming the element by what its
+#                 container SAYS ("the nav box that says Cards", "the row that
+#                 says 31 Jan 2025"). Words rather than position, so it survives
+#                 reordering, which is the failure an ordinal path cannot
+#                 survive: `#subContainer4 > ul > li:nth-of-type(1) > a` matched
+#                 the Cards submenu in the session it was recorded in and matched
+#                 NOTHING in the next one, while an earlier capture had the same
+#                 shape resolving to Fixed Deposits. Below plain text because it
+#                 depends on a class as well as the words.
 #   css_path    — structural; the first thing a redesign breaks
 _KIND_RANK: dict[str, int] = {
     "testid": 0,
@@ -36,13 +46,20 @@ _KIND_RANK: dict[str, int] = {
     "role_name": 4,
     "label": 5,
     "text": 6,
-    "css_path": 7,
+    "container_label": 7,
+    "row_scoped": 8,
+    "css_path": 9,
 }
 
 # Kinds whose `value` is a CSS selector, so a step can address them with
 # `click_element`. The rest carry human-readable text that the runtime resolves
 # semantically (click_by_text / type_into_label).
-_CSS_KINDS = frozenset({"testid", "id", "name", "aria_label", "css_path"})
+# container_label/row_scoped are Playwright's :has-text() dialect rather than
+# plain CSS, but they ARE selectors -- addressed with click_element, never
+# emitted as text a human could read.
+_CSS_KINDS = frozenset(
+    {"testid", "id", "name", "aria_label", "css_path", "container_label", "row_scoped"}
+)
 
 #: Returned confidence levels, worst to best.
 UNIQUE = "unique"

--- a/skills/noui/noui_core/compile/login_assets.py
+++ b/skills/noui/noui_core/compile/login_assets.py
@@ -297,6 +297,50 @@ def _first_path_segment(url: str) -> str:
     return path.split("/")[0].lower() if path else ""
 
 
+def _before_first_click(
+    transitions: list[tuple[str, str]],
+    url_events: list[dict],
+    click_events: list[dict] | None,
+) -> list[tuple[str, str]]:
+    """The URL transitions belonging to the LOGIN, not to what the human did next.
+
+    A login lands you somewhere by REDIRECT; everything after that is the human
+    clicking. So the login segment ends at the first click, and that boundary
+    holds however the app is built.
+
+    The rule it replaces stopped at the first ORIGIN CHANGE, which was written
+    for a multi-host portal (ICICI corporate on a different host than retail).
+    On a SINGLE-origin app there is never an origin change, so it walked to the
+    end of a combined recording and took wherever the human finished: ICICI
+    retail compiled `https://retailnetbanking.icici.bank.in/credit-card**` as
+    its post-login check, a page reached four clicks into the workflow, when the
+    login actually lands on /overview.
+
+    Falls back to every transition when the ordering cannot be established (no
+    seq, or a click before any navigation), because a login with no landing
+    page at all is worse than one derived the old way.
+    """
+    clicks = [c for c in (click_events or []) if isinstance(c, dict)]
+    if not clicks or len(transitions) != len(url_events):
+        return transitions
+
+    def seq_of(ev: dict) -> int | None:
+        v = ev.get("seq")
+        return v if isinstance(v, int) else None
+
+    click_seqs = [s for s in (seq_of(c) for c in clicks) if s is not None]
+    url_seqs = [seq_of(u) for u in url_events]
+    if not click_seqs or any(s is None for s in url_seqs):
+        return transitions
+
+    first_click = min(click_seqs)
+    kept = [
+        t for t, s in zip(transitions, url_seqs, strict=False) if s is not None and s < first_click
+    ]
+    # A click before any navigation (a cookie banner, say) would leave nothing.
+    return kept or transitions
+
+
 def _derive_post_login_pattern(login_url: str, landing_url: str) -> str:
     """A glob the LOGGED-IN url matches but the login page does not, or ``""``.
 
@@ -988,7 +1032,7 @@ def generate(
     # Find the last stable URL after the login sequence
     stable_urls = [
         to_url
-        for from_url, to_url in url_transitions
+        for from_url, to_url in _before_first_click(url_transitions, url_events, click_events)
         if not _is_redirect_hop(from_url, to_url) and to_url != first_url
     ]
     if stable_urls:

--- a/skills/noui/noui_core/compile/login_assets.py
+++ b/skills/noui/noui_core/compile/login_assets.py
@@ -1030,11 +1030,32 @@ def generate(
 
     # Determine post-login success condition
     # Find the last stable URL after the login sequence
-    stable_urls = [
-        to_url
-        for from_url, to_url in _before_first_click(url_transitions, url_events, click_events)
-        if not _is_redirect_hop(from_url, to_url) and to_url != first_url
-    ]
+    def _landings(transitions: list[tuple[str, str]]) -> list[str]:
+        return [
+            to_url
+            for from_url, to_url in transitions
+            if not _is_redirect_hop(from_url, to_url) and to_url != first_url
+        ]
+
+    stable_urls = _landings(_before_first_click(url_transitions, url_events, click_events))
+    if not stable_urls and manual_takeover:
+        # "The login segment ends at the first click" assumes the login lands you
+        # by REDIRECT. A manual takeover is the opposite: the human IS the login,
+        # so every click belongs to it and the landing necessarily comes after
+        # them. Narrowing then keeps only the login page, which the filter above
+        # drops as first_url -- leaving no landing page at all.
+        #
+        # ICICI recorded login-page -> (human signs in) -> /overview and compiled
+        # a takeover with no wait_for_url, so every session asked a human to
+        # confirm a login they had already completed. The auto-resolve mechanism
+        # was working; it had no pattern to resolve against.
+        #
+        # Only for a takeover, and only when the narrow rule found nothing: the
+        # automated path keeps its bound, and this branch replaces "no pattern"
+        # rather than a good one. Its wait_for_url carries on_failure: skip, so a
+        # pattern that turns out not to match costs one timeout, not a stuck
+        # session.
+        stable_urls = _landings(url_transitions)
     if stable_urls:
         # The landing page is the end of the FIRST same-origin run of stable URLs,
         # not the last URL of the recording.

--- a/skills/noui/noui_core/compile/login_assets.py
+++ b/skills/noui/noui_core/compile/login_assets.py
@@ -337,6 +337,29 @@ def _before_first_click(
     kept = [
         t for t, s in zip(transitions, url_seqs, strict=False) if s is not None and s < first_click
     ]
+    # A login lands you by REDIRECT, and for SSO / auto-submit that redirect
+    # precedes the first click, so `s < first_click` captures it. But the classic
+    # form login lands via the "Log In" click ITSELF: its redirect fires just
+    # after that recorded click, and `s < first_click` then drops the one
+    # transition that matters -- e.g. url_events=[seq0 ''->/login, seq3
+    # /login->/overview], click=[seq2 "Log In"] keeps only ''->/login, and the
+    # compiler emits no_post_login_url for the most ordinary login shape there is.
+    # So when nothing before the first click has actually left the login page --
+    # the login has not landed yet -- extend the segment to the redirect the first
+    # click caused, stopping at the SECOND click: the earliest interaction that
+    # can belong to the workflow rather than to the login.
+    login_page = transitions[0][1] if transitions else ""
+    landed_before = any(
+        t[1] and t[1] != login_page and not _is_login_flow_segment_url(t[1]) for t in kept
+    )
+    if not landed_before:
+        ordered = sorted(click_seqs)
+        second_click = ordered[1] if len(ordered) > 1 else None
+        kept = [
+            t
+            for t, s in zip(transitions, url_seqs, strict=False)
+            if s is not None and (second_click is None or s < second_click)
+        ]
     # A click before any navigation (a cookie banner, say) would leave nothing.
     return kept or transitions
 

--- a/skills/noui/noui_core/compile/login_assets.py
+++ b/skills/noui/noui_core/compile/login_assets.py
@@ -1397,6 +1397,21 @@ def generate(
                 enable_downloads if enable_downloads is not None else keepalive_style == "activity"
             ),
             "file_chooser": False,
+            # Refuse `navigate` on browser-driven apps.
+            #
+            # A full-page navigation is a RELOAD, and refresh-sensitive portals
+            # destroy the session on one: ICICI lands on /session-expire and the
+            # member is asked to sign in again mid-task. The compiled skill never
+            # emits navigate — it reaches every page by replaying the recorded
+            # click chain — so nothing legitimate is lost. What this stops is an
+            # agent that gets stuck and reaches for it anyway, which is exactly
+            # how a freshly built ICICI skill killed a live session 20 seconds
+            # after the member signed in.
+            #
+            # Set HERE rather than by hand on each profile, because every
+            # recording mints a NEW profile: setting it manually protects the app
+            # you just fixed and none of the ones you build next.
+            "block_navigate": keepalive_style == "activity",
         },
         "notification_config": {"channels": ["slack:#local-dev"]},
         "desired_session_count": 0,

--- a/skills/noui/noui_core/compile/parameters.py
+++ b/skills/noui/noui_core/compile/parameters.py
@@ -26,10 +26,17 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from noui_core.capture.split import CREDENTIAL_FIELD_ROLES
 from noui_core.compile.locators import choose_locator
 
-#: Field roles that must never become parameters, whatever their value.
-_CREDENTIAL_ROLES = frozenset({"password", "otp"})
+#: Field roles that must never become parameters, whatever their value. Reuses
+#: the SINGLE canonical set (capture/split.py) rather than a local subset: a
+#: narrower copy here ({"password", "otp"}) silently let an ``unknown_sensitive``
+#: field -- sensitive but not confidently password/otp, e.g. a re-entered
+#: transaction PIN -- through unless it happened to be redacted upstream, and
+#: compile it to a plaintext parameter default. Aligning fails closed on every
+#: role Tabby treats as a credential (also ``username``).
+_CREDENTIAL_ROLES = CREDENTIAL_FIELD_ROLES
 
 #: The recorder writes this in place of a credential value.
 _REDACTED = "[REDACTED]"

--- a/skills/noui/noui_core/compile/parameters.py
+++ b/skills/noui/noui_core/compile/parameters.py
@@ -1,0 +1,165 @@
+"""Turning recorded input values into operation parameters.
+
+A recording captures ONE run: "1 Jan – 31 Jan", "account ...4471". Compiled
+literally, the skill can only ever fetch that. On ICICI the agent was asked for
+"last year", found nothing in the operation to vary, and spent twenty steps
+hunting the page for a period selector it had no way to know existed.
+
+The recorded values are the parameters — they just have to be recognised as
+such. Each becomes an argument with the recorded value as its DEFAULT, so the
+operation still does exactly what was recorded when nothing is passed, and does
+something useful when something is.
+
+Two rules this module will not bend:
+
+  - Credentials are never parameters. Password and OTP values are redacted
+    in-pod before they leave the browser, and a skill that accepted them as
+    arguments would be asking callers to hold what Tabby exists to avoid holding.
+  - A control we cannot drive is reported, not faked. A native <select> cannot
+    be set with the browser command set available to a skill, so it is surfaced
+    as a parameter the agent must handle rather than compiled into a step that
+    would silently do nothing.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from noui_core.compile.locators import choose_locator
+
+#: Field roles that must never become parameters, whatever their value.
+_CREDENTIAL_ROLES = frozenset({"password", "otp"})
+
+#: The recorder writes this in place of a credential value.
+_REDACTED = "[REDACTED]"
+
+_DATE_PATTERNS = (
+    re.compile(r"^\d{4}-\d{2}-\d{2}$"),  # 2026-01-31
+    re.compile(r"^\d{2}[/-]\d{2}[/-]\d{4}$"),  # 31/01/2026, 31-01-2026
+    re.compile(r"^\d{2}\s+\w{3,9}\s+\d{4}$"),  # 31 January 2026
+)
+_YEAR = re.compile(r"^(19|20)\d{2}$")
+_AMOUNT = re.compile(r"^\d+(\.\d{1,2})?$")
+
+
+def _param_type(value: str, field_name: str, input_type: str) -> str:
+    """What KIND of value this is, so the caller knows what to pass.
+
+    Read off the value first and the field name second: a field called
+    ``txnDate`` holding ``2026-01-31`` is a date whatever its input type says,
+    and a bank's date fields are routinely ``type="text"`` with a picker bolted
+    on.
+    """
+    v = (value or "").strip()
+    name = (field_name or "").lower()
+    if input_type in ("date", "month"):
+        return "date"
+    if any(p.match(v) for p in _DATE_PATTERNS):
+        return "date"
+    if _YEAR.match(v) and ("year" in name or "yr" in name):
+        return "year"
+    if _AMOUNT.match(v) and any(k in name for k in ("amount", "amt", "value", "sum")):
+        return "amount"
+    return "string"
+
+
+def _param_name(field_name: str, label: str, index: int) -> str:
+    """A readable argument name — the field's own name, else its label."""
+    raw = (field_name or label or "").strip()
+    slug = re.sub(r"(?<!^)(?=[A-Z])", "_", raw)  # fromDate -> from_Date
+    slug = re.sub(r"[^a-z0-9]+", "_", slug.lower()).strip("_")
+    return slug or f"value_{index + 1}"
+
+
+def _label_of(ev: dict) -> str:
+    """The human-readable label for the field, when the recording carries one."""
+    element = ev.get("element")
+    if isinstance(element, dict) and element.get("accessible_name"):
+        return str(element["accessible_name"])
+    for c in ev.get("candidates") or []:
+        if isinstance(c, dict) and c.get("kind") == "label" and c.get("value"):
+            return str(c["value"])
+    return str(ev.get("placeholder") or ev.get("aria_label") or "")
+
+
+def derive_parameters(events: list[dict] | None) -> list[dict]:
+    """Parameters implied by the values a human typed or chose.
+
+    ``events`` are the input/change interactions belonging to one operation, in
+    interaction order. The LAST value for a field wins: a human who types, edits
+    and retypes leaves several events for one field, and what matters is what it
+    held when they acted on it.
+
+    Each parameter is ``{name, type, default, control, selector|label,
+    settable}``. ``settable`` is False for a control no browser command can
+    drive; the caller surfaces those rather than compiling a step that would
+    quietly do nothing.
+    """
+    by_field: dict[str, dict] = {}
+
+    for index, ev in enumerate(events or []):
+        if (ev.get("event_type") or "") not in ("input", "change"):
+            continue
+        role = ev.get("field_role") or ""
+        value = ev.get("value")
+        if role in _CREDENTIAL_ROLES or ev.get("is_redacted") or value == _REDACTED:
+            continue
+        if not isinstance(value, str) or not value.strip():
+            continue
+        # Checkbox/radio states are not values a caller supplies; they are part
+        # of the recorded path and belong in the steps, not the signature.
+        if value in ("checked", "unchecked"):
+            continue
+
+        tag = (ev.get("tag_name") or "").lower()
+        input_type = (ev.get("input_type") or "").lower()
+        label = _label_of(ev)
+        name = _param_name(str(ev.get("field_name") or ""), label, index)
+
+        locator = choose_locator(ev.get("candidates"))
+        param: dict[str, Any] = {
+            "name": name,
+            "type": _param_type(value, str(ev.get("field_name") or ""), input_type),
+            "default": value,
+            "control": "select" if tag == "select" else "text",
+            # A native <select> cannot be set by any command a skill has
+            # (there is no select_option), so it is reported, never faked.
+            "settable": tag != "select",
+        }
+        if label:
+            param["label"] = label
+        if locator and locator.get("is_css"):
+            param["selector"] = locator["value"]
+        elif label:
+            param["by_label"] = label
+
+        by_field[name] = param  # last write wins
+
+    return list(by_field.values())
+
+
+def fill_steps(parameters: list[dict]) -> list[dict]:
+    """Steps that put each parameter's value into its field.
+
+    Templated on the parameter name, so the operation runs as recorded when
+    nothing is passed and takes an override when something is. Parameters whose
+    control cannot be driven produce no step — see ``settable``.
+    """
+    steps: list[dict] = []
+    for p in parameters:
+        if not p.get("settable"):
+            continue
+        placeholder = "{{" + p["name"] + "}}"
+        if p.get("selector"):
+            steps.append(
+                {"command": "type_text", "params": {"selector": p["selector"], "text": placeholder}}
+            )
+        elif p.get("by_label"):
+            steps.append(
+                {
+                    "command": "type_into_label",
+                    "params": {"label": p["by_label"], "text": placeholder},
+                }
+            )
+    return steps

--- a/skills/noui/noui_core/compile/parameters.py
+++ b/skills/noui/noui_core/compile/parameters.py
@@ -34,6 +34,19 @@ _CREDENTIAL_ROLES = frozenset({"password", "otp"})
 #: The recorder writes this in place of a credential value.
 _REDACTED = "[REDACTED]"
 
+#: A <select>'s recorded value, normalised to letters/digits, that means "nothing
+#: was chosen" -- the inert placeholder option a decoy dropdown sits on. Kept
+#: deliberately tight: only values that are self-evidently non-selections, so a
+#: real option (a year, an account, "All accounts") is never dropped.
+_PLACEHOLDER_SELECT_VALUES = frozenset(
+    {"value", "select", "choose", "none", "pleaseselect", "selectanoption", "selectone"}
+)
+
+
+def _is_placeholder_select_value(value: str) -> bool:
+    return re.sub(r"[^a-z0-9]", "", (value or "").lower()) in _PLACEHOLDER_SELECT_VALUES
+
+
 _DATE_PATTERNS = (
     re.compile(r"^\d{4}-\d{2}-\d{2}$"),  # 2026-01-31
     re.compile(r"^\d{2}[/-]\d{2}[/-]\d{4}$"),  # 31/01/2026, 31-01-2026
@@ -114,6 +127,14 @@ def derive_parameters(events: list[dict] | None) -> list[dict]:
 
         tag = (ev.get("tag_name") or "").lower()
         input_type = (ev.get("input_type") or "").lower()
+        # A <select> still sitting on its placeholder option was never a choice
+        # the human made. ICICI's #FieldDropdown is exactly this: its recorded
+        # value is the literal "Value", the inert first option. Turning that into
+        # a parameter + select_option drives a meaningless control and asks the
+        # caller to supply a value that means "nothing is selected". A real
+        # selection (a period, an account) carries a real value and is kept.
+        if tag == "select" and _is_placeholder_select_value(value):
+            continue
         label = _label_of(ev)
         name = _param_name(str(ev.get("field_name") or ""), label, index)
 

--- a/skills/noui/noui_core/compile/parameters.py
+++ b/skills/noui/noui_core/compile/parameters.py
@@ -123,9 +123,17 @@ def derive_parameters(events: list[dict] | None) -> list[dict]:
             "type": _param_type(value, str(ev.get("field_name") or ""), input_type),
             "default": value,
             "control": "select" if tag == "select" else "text",
-            # A native <select> cannot be set by any command a skill has
-            # (there is no select_option), so it is reported, never faked.
-            "settable": tag != "select",
+            # A native <select> IS settable: the runtime has had select_option
+            # (by option value or by visible label) all along -- see
+            # execute-browser-handler's `case 'select_option'`. Marking these
+            # read-only meant every dropdown a skill needed was surfaced as
+            # something to report rather than something to drive, and the only
+            # way left to change one was to click through whatever widget the
+            # page draws on top of it. On ICICI that is three brittle steps per
+            # dropdown, keyed on the overlay's current-state classes and on a
+            # :text-is holding the whole option list, and it stalled every
+            # replay mid-panel.
+            "settable": True,
         }
         if label:
             param["label"] = label
@@ -151,7 +159,17 @@ def fill_steps(parameters: list[dict]) -> list[dict]:
         if not p.get("settable"):
             continue
         placeholder = "{{" + p["name"] + "}}"
-        if p.get("selector"):
+        if p.get("control") == "select" and p.get("selector"):
+            # A dropdown is chosen, not typed into. select_option takes the
+            # option's value or its visible label, so the recorded default and a
+            # caller's override both work unchanged.
+            steps.append(
+                {
+                    "command": "select_option",
+                    "params": {"selector": p["selector"], "value": placeholder},
+                }
+            )
+        elif p.get("selector"):
             steps.append(
                 {"command": "type_text", "params": {"selector": p["selector"], "text": placeholder}}
             )

--- a/skills/noui/noui_core/compile/provenance.py
+++ b/skills/noui/noui_core/compile/provenance.py
@@ -137,6 +137,49 @@ def build(
 #: `_step_locators`/`_TYPED_VALUE_COMMANDS` exactly.
 _TYPED_VALUE_COMMANDS = frozenset({"type_into_label", "type_text", "fill", "select_option"})
 
+#: Commands that act ON a specific control (a click, a keypress, a checkbox or
+#: dropdown, a text entry). For these a locator is the whole evidence the step is
+#: backed by the recording, so one that carries none -- a coordinate click
+#: (click_at), a key-press on the focused element (press_key) -- contributes
+#: nothing to step_locators and would sail through unobserved_locators as
+#: trivially backed. The shipped compiler never emits a keyless control action
+#: (it addresses every control by selector/label/text), so this only guards
+#: hand-written operations. Reads / navigation / scroll are absent by design:
+#: they legitimately target no control.
+_CONTROL_ACTION_COMMANDS = frozenset(
+    {
+        "click_element",
+        "click_by_text",
+        "click_at",
+        "type_text",
+        "type_into_label",
+        "fill",
+        "press_key",
+        "set_checked",
+        "select_option",
+        "hover",
+    }
+)
+
+
+def _locator_of_step(step: dict[str, Any]) -> str | None:
+    """The one locator a step targets, or None if it carries none."""
+    if not isinstance(step, dict):
+        return None
+    raw = step.get("params")
+    params: dict[str, Any] = raw if isinstance(raw, dict) else step
+    command = str(step.get("command") or "")
+    keys = (
+        ("label", "selector")
+        if command in _TYPED_VALUE_COMMANDS
+        else ("selector", "text", "label", "value")
+    )
+    for key in keys:
+        v = params.get(key)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return None
+
 
 def step_locators(operations: list[dict[str, Any]]) -> list[str]:
     """The locator each step targets, for steps that target one.
@@ -148,21 +191,32 @@ def step_locators(operations: list[dict[str, Any]]) -> list[str]:
     out: list[str] = []
     for op in operations or []:
         for step in op.get("steps") or []:
+            loc = _locator_of_step(step)
+            if loc:
+                out.append(loc)
+    return out
+
+
+def unbacked_control_steps(operations: list[dict[str, Any]]) -> list[str]:
+    """Control-acting steps that carry NO locator to check against the recording.
+
+    ``unobserved_locators`` compares the locators steps drive against what the
+    recording saw, but a control action with no locator (a coordinate click, a
+    key-press) contributes nothing to that list -- so an operation built entirely
+    from such steps would "verify" against any bundle at all, defeating a check
+    whose whole job is catching fabricated or hand-written operations. Returns a
+    human-readable marker per offending step. Empty for every skill the compiler
+    produces; non-empty only for hand-authored keyless control actions.
+    """
+    out: list[str] = []
+    for op in operations or []:
+        name = str(op.get("name") or op.get("operation") or "operation")
+        for step in op.get("steps") or []:
             if not isinstance(step, dict):
                 continue
-            raw = step.get("params")
-            params: dict[str, Any] = raw if isinstance(raw, dict) else step
             command = str(step.get("command") or "")
-            keys = (
-                ("label", "selector")
-                if command in _TYPED_VALUE_COMMANDS
-                else ("selector", "text", "label", "value")
-            )
-            for key in keys:
-                v = params.get(key)
-                if isinstance(v, str) and v.strip():
-                    out.append(v.strip())
-                    break
+            if command in _CONTROL_ACTION_COMMANDS and not _locator_of_step(step):
+                out.append(f"{name}: {command} targets a control by nothing the recording saw")
     return out
 
 

--- a/skills/noui/noui_core/compile/provenance.py
+++ b/skills/noui/noui_core/compile/provenance.py
@@ -178,6 +178,17 @@ def _locator_of_step(step: dict[str, Any]) -> str | None:
         v = params.get(key)
         if isinstance(v, str) and v.strip():
             return v.strip()
+    # A control addressed by ROLE + accessible NAME -- a radio/checkbox with no
+    # unique CSS selector, which the compiler deliberately emits as
+    # set_checked {role: "radio", name: "Annual"} (the recorder's `role_name`
+    # candidate). observed_selectors keeps both "role|name" and the bare name, so
+    # the name is exactly what ties this step back to the recording. Without it a
+    # legitimately-recorded role-addressed control reads as anchorless and the
+    # provenance guard rejects a skill it should bless.
+    role = params.get("role")
+    name = params.get("name")
+    if isinstance(role, str) and role.strip() and isinstance(name, str) and name.strip():
+        return name.strip()
     return None
 
 

--- a/skills/noui/noui_core/compile/provenance.py
+++ b/skills/noui/noui_core/compile/provenance.py
@@ -74,7 +74,40 @@ def observed_selectors(bundle: dict[str, Any]) -> set[str]:
     return {s for s in seen if s}
 
 
-def build(bundle: dict[str, Any], *, bundle_file: str) -> dict[str, Any]:
+def steps_digest(operations: list[dict[str, Any]]) -> str:
+    """A digest of what the operations DO, ignoring what they are called.
+
+    Checking that every locator appears somewhere in the recording proved too
+    weak: a build read the bundle's locator vocabulary and reassembled steps out
+    of it, which passed while being no longer the compiled workflow. Locators
+    are a set; a workflow is a sequence. Pinning the sequence closes that.
+
+    Names and descriptions are excluded deliberately. Renaming an operation or
+    rewording its description changes nothing about what runs, and a gate that
+    fires on a wording fix is one people learn to route around -- which is
+    exactly how the reconstruction started.
+    """
+    material = [
+        {
+            "kind": op.get("kind") or "read",
+            "steps": op.get("steps") or [],
+            "parameters": [
+                {"name": p.get("name"), "default": p.get("default")}
+                for p in op.get("parameters") or []
+            ],
+        }
+        for op in operations or []
+    ]
+    blob = json.dumps(material, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def build(
+    bundle: dict[str, Any],
+    *,
+    bundle_file: str,
+    operations: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     """The provenance block stamped into a browser skill's manifest.
 
     bundle_file is relative to the workbench root (``bundles/<name>-<sid>.json``)
@@ -91,6 +124,8 @@ def build(bundle: dict[str, Any], *, bundle_file: str) -> dict[str, Any]:
         "recorded_urls": len(bundle.get("url_events") or []),
         "observed_selectors": len(observed_selectors(bundle)),
         "schema_version": bundle.get("schema_version"),
+        # What the compiler emitted, so a later edit to the steps is visible.
+        "steps_sha256": steps_digest(operations) if operations is not None else "",
     }
 
 

--- a/skills/noui/noui_core/compile/provenance.py
+++ b/skills/noui/noui_core/compile/provenance.py
@@ -1,0 +1,94 @@
+"""Bind a compiled browser skill to the recording it was compiled from.
+
+WHY THIS EXISTS. A browser skill's operations are only worth anything because a
+human once did the task and the recorder watched: the selectors are ones that
+resolved, the page order is one that happened, and "this click downloads a file"
+is an observation rather than a hope. A skill written from memory of how a site
+probably looks has the same shape and none of that, and it is not reviewable --
+nobody can tell a real ICICI selector from a plausible one by reading it.
+
+That is not hypothetical. An agent asked for an "ICICI browser skill" wrote
+SKILL.md and operations.json itself, never recorded anything, and uploaded it to
+an org catalog.
+
+WHAT CAN AND CANNOT BE PROVEN. Nothing inside the skill directory proves
+provenance -- every file there is written by whoever authored the skill, so a
+fabricated skill can carry a fabricated stamp. Proof needs an INDEPENDENT
+artifact, and the only one available is the recording bundle: a large, awkward
+object produced by actually driving a browser. So this module stamps a pointer
+to that bundle plus a digest of it, and the installer verifies the bundle exists
+and still hashes the same. Faking that means synthesising a whole self-
+consistent recording -- far more work than recording, which is the point.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+PROVENANCE_VERSION = "1"
+
+#: Written beside the skill: the exact recording the operations were compiled
+#: from. Not uploaded to the catalog — it is evidence for the installer, which
+#: verifies the digest below still matches it.
+BUNDLE_FILE = "recording_bundle.json"
+
+
+def bundle_digest(bundle: dict[str, Any]) -> str:
+    """A digest of the recording, reproducible from the bundle file alone.
+
+    Canonical JSON rather than raw file bytes: the compiler holds a parsed dict
+    and the verifier holds a file, and those need to agree. Sorted keys and tight
+    separators make the two paths land on the same string.
+    """
+    blob = json.dumps(bundle, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def observed_selectors(bundle: dict[str, Any]) -> set[str]:
+    """Every locator value the recorder actually saw, in any form.
+
+    Union of the candidates it ranked, the locator it chose and the visible text
+    it read. Deliberately generous: this is used to catch selectors that were
+    INVENTED, so a false accusation is far worse than missing one fabrication.
+    """
+    seen: set[str] = set()
+    for click in bundle.get("click_events") or []:
+        if not isinstance(click, dict):
+            continue
+        for cand in click.get("candidates") or []:
+            if isinstance(cand, dict) and cand.get("value"):
+                seen.add(str(cand["value"]))
+                # role_name candidates are "role|name"; the step keeps the name.
+                if "|" in str(cand["value"]):
+                    seen.add(str(cand["value"]).split("|", 1)[1])
+        loc = click.get("locator")
+        if isinstance(loc, dict) and loc.get("value"):
+            seen.add(str(loc["value"]))
+            if "|" in str(loc["value"]):
+                seen.add(str(loc["value"]).split("|", 1)[1])
+        for key in ("selector", "text", "css_path"):
+            if click.get(key):
+                seen.add(str(click[key]).strip())
+    return {s for s in seen if s}
+
+
+def build(bundle: dict[str, Any], *, bundle_file: str) -> dict[str, Any]:
+    """The provenance block stamped into a browser skill's manifest.
+
+    bundle_file is relative to the workbench root (``bundles/<name>-<sid>.json``)
+    so the installer can find it without knowing absolute paths in a sandbox it
+    did not create.
+    """
+    return {
+        "provenance_version": PROVENANCE_VERSION,
+        "source": "recording",
+        "recording_session_id": str(bundle.get("session_id") or ""),
+        "bundle_file": bundle_file,
+        "bundle_sha256": bundle_digest(bundle),
+        "recorded_events": len(bundle.get("click_events") or []),
+        "recorded_urls": len(bundle.get("url_events") or []),
+        "observed_selectors": len(observed_selectors(bundle)),
+        "schema_version": bundle.get("schema_version"),
+    }

--- a/skills/noui/noui_core/compile/provenance.py
+++ b/skills/noui/noui_core/compile/provenance.py
@@ -129,6 +129,15 @@ def build(
     }
 
 
+#: Commands whose `text`/`value` param is the VALUE being typed/chosen, not the
+#: control being addressed. For these the locator is the label or the selector;
+#: taking `text` first meant a label-addressed parameterised fill had its own
+#: `{{placeholder}}` validated as a locator -- never in the recording, so the
+#: gate refused every such skill with "invented selector". Mirror adoptai-workflows
+#: `_step_locators`/`_TYPED_VALUE_COMMANDS` exactly.
+_TYPED_VALUE_COMMANDS = frozenset({"type_into_label", "type_text", "fill", "select_option"})
+
+
 def step_locators(operations: list[dict[str, Any]]) -> list[str]:
     """The locator each step targets, for steps that target one.
 
@@ -143,7 +152,13 @@ def step_locators(operations: list[dict[str, Any]]) -> list[str]:
                 continue
             raw = step.get("params")
             params: dict[str, Any] = raw if isinstance(raw, dict) else step
-            for key in ("selector", "text", "label", "value"):
+            command = str(step.get("command") or "")
+            keys = (
+                ("label", "selector")
+                if command in _TYPED_VALUE_COMMANDS
+                else ("selector", "text", "label", "value")
+            )
+            for key in keys:
                 v = params.get(key)
                 if isinstance(v, str) and v.strip():
                     out.append(v.strip())

--- a/skills/noui/noui_core/compile/provenance.py
+++ b/skills/noui/noui_core/compile/provenance.py
@@ -159,4 +159,30 @@ def unobserved_locators(operations: list[dict[str, Any]], bundle: dict[str, Any]
     steps that were written rather than observed.
     """
     seen = observed_selectors(bundle)
-    return [loc for loc in step_locators(operations) if loc not in seen]
+    return [
+        loc
+        for loc in step_locators(operations)
+        if loc not in seen and not _is_observed_scoped_inside_observed(loc, seen)
+    ]
+
+
+def _is_observed_scoped_inside_observed(locator: str, seen: set[str]) -> bool:
+    """Is this one observed control narrowed by another observed one?
+
+    The compiler scopes a hover-revealed control inside the thing that revealed
+    it -- "<hover> <control>" -- because a class like `a.sub-menu-list-item-link`
+    names a style every submenu item shares, and unscoped it resolves whichever
+    match comes first in the document.
+
+    That composition invents nothing: both halves were observed, and the result
+    can only ever match FEWER nodes than the half on its right. Deliberately not
+    a general "all the words are observed" rule -- the whole string either splits
+    into exactly two observed selectors or it does not.
+    """
+    if " " not in locator:
+        return False
+    for part in seen:
+        prefix = f"{part} "
+        if locator.startswith(prefix) and locator[len(prefix) :] in seen:
+            return True
+    return False

--- a/skills/noui/noui_core/compile/provenance.py
+++ b/skills/noui/noui_core/compile/provenance.py
@@ -92,3 +92,36 @@ def build(bundle: dict[str, Any], *, bundle_file: str) -> dict[str, Any]:
         "observed_selectors": len(observed_selectors(bundle)),
         "schema_version": bundle.get("schema_version"),
     }
+
+
+def step_locators(operations: list[dict[str, Any]]) -> list[str]:
+    """The locator each step targets, for steps that target one.
+
+    Mirrors the installer's reader (adoptai-workflows `_step_locators`). If the
+    two drift, migration blesses a skill the installer then refuses -- annoying,
+    but the failure is closed, which is the right direction for a mismatch.
+    """
+    out: list[str] = []
+    for op in operations or []:
+        for step in op.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            raw = step.get("params")
+            params: dict[str, Any] = raw if isinstance(raw, dict) else step
+            for key in ("selector", "text", "label", "value"):
+                v = params.get(key)
+                if isinstance(v, str) and v.strip():
+                    out.append(v.strip())
+                    break
+    return out
+
+
+def unobserved_locators(operations: list[dict[str, Any]], bundle: dict[str, Any]) -> list[str]:
+    """Locators the operations drive that this recording never saw.
+
+    Empty means the recording backs the operations. Non-empty is the signal that
+    a skill was not compiled from this recording -- either the wrong bundle, or
+    steps that were written rather than observed.
+    """
+    seen = observed_selectors(bundle)
+    return [loc for loc in step_locators(operations) if loc not in seen]

--- a/skills/noui/noui_core/compile/unreplayable.py
+++ b/skills/noui/noui_core/compile/unreplayable.py
@@ -119,9 +119,7 @@ def detect_unreplayable(har: dict | None, *, app_origin: str = "") -> dict:
         else:
             # A metadata-reduced HAR (Tabby workflow bundles) carries the body's
             # shape instead of its bytes. Same test, same verdict.
-            is_envelope = _is_envelope_shape(
-                post.get("keys") or [], bool(post.get("long_values"))
-            )
+            is_envelope = _is_envelope_shape(post.get("keys") or [], bool(post.get("long_values")))
         if is_envelope:
             envelope_posts += 1
 

--- a/skills/noui/noui_core/compile/unreplayable.py
+++ b/skills/noui/noui_core/compile/unreplayable.py
@@ -47,6 +47,27 @@ def _origin(url: str) -> str:
         return ""
 
 
+def _is_envelope_shape(keys: list, long_values: bool) -> bool:
+    """Envelope test from a body's SHAPE rather than its bytes.
+
+    Tabby reduces `workflow` HARs to metadata — no bodies, no headers, no query
+    strings — because a browser skill never replays a request and a bank
+    portal's payloads (balances, PANs, live tokens) have no business sitting in
+    a recording bundle. It keeps the top-level field NAMES and a flag for whether
+    any value was a long string, which is precisely what the text-based test
+    below reduces to: names ⊆ envelope set, and at least one ciphertext-looking
+    value.
+
+    Without this, reducing the HAR would silently disable browser-vs-replay
+    auto-detection: every workflow recording would look replayable, and apps like
+    ICICI would compile back into the 40-operations-that-all-403 skill.
+    """
+    if not keys or not long_values:
+        return False
+    names = {str(k).lower() for k in keys}
+    return bool(names) and names <= _ENVELOPE_KEYS
+
+
 def _is_encryption_envelope(text: str) -> bool:
     """True when ``text`` is a JSON object carrying only ciphertext/wrapped-key
     fields — the shape a page produces when it encrypts the real payload in JS."""
@@ -91,8 +112,17 @@ def detect_unreplayable(har: dict | None, *, app_origin: str = "") -> dict:
         if app_origin and _origin(url) != app_origin:
             continue
         app_posts += 1
-        text = (req.get("postData") or {}).get("text") or ""
-        if _is_encryption_envelope(text):
+        post = req.get("postData") or {}
+        text = post.get("text") or ""
+        if text:
+            is_envelope = _is_encryption_envelope(text)
+        else:
+            # A metadata-reduced HAR (Tabby workflow bundles) carries the body's
+            # shape instead of its bytes. Same test, same verdict.
+            is_envelope = _is_envelope_shape(
+                post.get("keys") or [], bool(post.get("long_values"))
+            )
+        if is_envelope:
             envelope_posts += 1
 
     ratio = (envelope_posts / app_posts) if app_posts else 0.0

--- a/skills/noui/noui_core/compile/workflow.py
+++ b/skills/noui/noui_core/compile/workflow.py
@@ -275,6 +275,10 @@ def compile_workflow_bundle(
                 output_dir=str(root / "skills" / slug),
                 session_id=session_id,
                 start_url=start_url,
+                # Without this nothing stamps provenance, and every skill
+                # compiled through this path is refused at install as "not
+                # compiled from a recording" -- which is exactly what happened.
+                bundle=bundle,
             )
         else:
             result["skill"] = compile_workflow_to_skill(

--- a/skills/noui/noui_core/tabby_client.py
+++ b/skills/noui/noui_core/tabby_client.py
@@ -41,6 +41,14 @@ _RETRY_STATUSES = frozenset({502, 503, 504})
 _TRANSPORT_ERRORS = (OSError, http.client.HTTPException)
 
 
+class TabbyUnreachableError(RuntimeError):
+    """No answer came back from Tabby at all — the endpoint was down, the socket
+    timed out, or DNS failed. A subclass of RuntimeError so every existing
+    ``except RuntimeError`` handler still catches it and prints the clean message;
+    the distinct type lets a caller tell "the control plane is unreachable" apart
+    from "the control plane said no", which are different next steps."""
+
+
 def _unreachable_error(
     method: str, path: str, detail: str, attempts: int, elapsed: float
 ) -> RuntimeError:
@@ -57,7 +65,7 @@ def _unreachable_error(
     mode = settings.tabby_auth_mode or "agent_token"
     who = "control-plane broker" if settings.broker_mode() else "Tabby API"
     tried = f" Retried {attempts} time(s) over {elapsed:.0f}s." if attempts > 1 else " Not retried."
-    return RuntimeError(
+    return TabbyUnreachableError(
         f"Cannot reach the {who} at {base} ({mode} mode) for {method} {path}: {detail}."
         f"{tried} This is an upstream/network failure, not an auth problem — a rejected "
         f"bearer answers with HTTP 401/403. Check that the {who} is up, then re-run."

--- a/skills/noui/noui_core/tabby_client.py
+++ b/skills/noui/noui_core/tabby_client.py
@@ -284,6 +284,7 @@ def create_recording_session(
     profile_id: str = "",
     source_session_id: str = "",
     residential_proxy: bool = False,
+    browser_driven: bool = False,
 ) -> dict:
     """
     POST /recording/sessions (agent bearer) — provision a recording-shell
@@ -292,6 +293,16 @@ def create_recording_session(
     ``source_session_id`` seeds the recording browser with the cookies captured
     by a prior login recording (session reuse), so the human starts already
     authenticated without stored credentials.
+
+    ``browser_driven`` declares that this recording will be compiled into a
+    BROWSER-DRIVEN skill, so Tabby reduces the HAR to metadata (no bodies,
+    headers or query strings) — a browser skill never replays a request, and a
+    bank portal's payloads have no business sitting in a bundle. Independent of
+    ``recording_mode``, which is the authoring phase rather than the skill kind:
+    a workflow recording of an ordinary REST app still compiles by HAR replay and
+    needs the full HAR. Omitted when False so the full HAR is kept — set it only
+    when the kind is already known (the operator asked for a browser skill, or
+    replay is known to fail on this app).
 
     ``residential_proxy`` routes the recording session's egress through Tabby's
     residential proxy (a US residential IP) instead of the datacenter egress —
@@ -308,6 +319,8 @@ def create_recording_session(
         body["source_session_id"] = source_session_id
     if residential_proxy:
         body["residential_proxy"] = True
+    if browser_driven:
+        body["browser_driven"] = True
     # Provisioning blocks server-side until the worker session row exists (worker
     # scheduling can take >15s under load), so allow a generous client timeout.
     # Deliberately NOT retried: each call creates a shell app (and can claim or

--- a/skills/noui/noui_core/verify/__init__.py
+++ b/skills/noui/noui_core/verify/__init__.py
@@ -1,0 +1,1 @@
+"""Verifying a compiled draft against the live app before anything is installed."""

--- a/skills/noui/noui_core/verify/gate.py
+++ b/skills/noui/noui_core/verify/gate.py
@@ -25,6 +25,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from noui_core.compile import amendments as amendments_mod
 from noui_core.verify.replay import operations_fingerprint
 
 #: Where an approved replay is recorded, beside the skill it approves.
@@ -111,3 +112,27 @@ def check_installable(skill_dir: str | Path) -> None:
             "the plan that was replayed. Replay again and get a fresh approval; the "
             "previous one was for a different set of steps."
         )
+
+    # Every amendment must be approved by name, to match the harness install gate
+    # (adoptai-workflows `_unapproved_amendments`). A step discovered at replay is
+    # not a step a human was watched performing, so approving the skill as a whole
+    # must not wave it through. No amendments.json (the common case, and the whole
+    # record→replay path that carries none) is a strict no-op.
+    amendments = amendments_mod.load(_read_amendments(path))
+    if amendments:
+        approved = set(approval.get("approved_amendments") or [])
+        unapproved = [a for a in amendments if amendments_mod.amendment_id(a) not in approved]
+        if unapproved:
+            raise NotApprovedError(
+                f"{len(unapproved)} step(s) were discovered at replay and not approved by "
+                "the member. Each amendment is approved individually — "
+                "verify_approve --approve-amendment ID — because nobody was watched "
+                "performing them."
+            )
+
+
+def _read_amendments(skill_dir: Path) -> str:
+    try:
+        return (skill_dir / amendments_mod.AMENDMENTS_FILE).read_text(encoding="utf-8")
+    except OSError:
+        return ""

--- a/skills/noui/noui_core/verify/gate.py
+++ b/skills/noui/noui_core/verify/gate.py
@@ -1,0 +1,113 @@
+"""The gate: a browser skill installs only after a human approved its replay.
+
+Without this, replay is a report — something produced, looked at, and routinely
+skipped when it is inconvenient. The point is that it is a GATE: the installer
+refuses a browser skill that has no approved replay for the exact plan being
+installed.
+
+Two properties make that hold.
+
+**Approval is tied to the plan.** The report carries a fingerprint of the
+operations that were replayed. Amend a step, recompile, and the fingerprint moves
+— the old approval no longer matches and the installer refuses again. That is
+what makes "the human's confirmation takes precedence" enforceable rather than a
+convention. Descriptions are excluded from the fingerprint, so renaming an
+operation or fixing a typo does not cost a replay; behaviour changes do.
+
+**Only browser skills are gated.** A HAR-replay skill is verified by its existing
+test loop, and replaying one means firing recorded requests, which is a different
+risk profile. Gating those here would block a path that already has an answer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from noui_core.verify.replay import operations_fingerprint
+
+#: Where an approved replay is recorded, beside the skill it approves.
+APPROVAL_FILE = "replay_approval.json"
+
+
+class NotApprovedError(RuntimeError):
+    """The skill has no approved replay for the plan being installed."""
+
+
+def _operations_of(skill_dir: Path) -> list[dict]:
+    try:
+        data = json.loads((skill_dir / "operations.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    ops = data.get("operations")
+    return ops if isinstance(ops, list) else []
+
+
+def is_browser_skill(skill_dir: Path) -> bool:
+    """Does this directory hold a browser-driven skill?
+
+    Read from the manifest's runtime style, falling back to the operations' tool
+    — a skill whose operations call `call_web_browser` is browser-driven whatever
+    the manifest happens to say.
+    """
+    try:
+        manifest = json.loads((skill_dir / "manifest.json").read_text(encoding="utf-8"))
+        if (manifest.get("runtime") or {}).get("operation_style") == "browser":
+            return True
+    except (OSError, ValueError):
+        pass
+    return any((op.get("tool") or "") == "call_web_browser" for op in _operations_of(skill_dir))
+
+
+def write_approval(skill_dir: str | Path, report: dict) -> Path:
+    """Record a human's approval beside the skill.
+
+    Refuses a report that is not actually approved, so the file can never be a
+    rubber stamp written by the same code that produced the report.
+    """
+    if not report.get("installable"):
+        raise ValueError(
+            "refusing to record an approval for a report that was never approved — "
+            "call replay.approve() with the human's decision first"
+        )
+    path = Path(skill_dir) / APPROVAL_FILE
+    path.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def read_approval(skill_dir: str | Path) -> dict | None:
+    try:
+        return json.loads((Path(skill_dir) / APPROVAL_FILE).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def check_installable(skill_dir: str | Path) -> None:
+    """Raise unless this skill may be installed.
+
+    A non-browser skill passes straight through. A browser skill must carry an
+    approval whose fingerprint matches the operations on disk right now.
+    """
+    path = Path(skill_dir)
+    if not is_browser_skill(path):
+        return
+
+    approval: dict[str, Any] | None = read_approval(path)
+    if not approval:
+        raise NotApprovedError(
+            "this browser skill has not been replayed and approved. Replay the draft "
+            "against a live session, show the result to the human, and record their "
+            "approval before installing — a browser skill that has never been run is "
+            "exactly the kind that looks correct in review and fails in production."
+        )
+    if not approval.get("installable"):
+        raise NotApprovedError("the recorded replay was not approved by a human")
+
+    current = operations_fingerprint(_operations_of(path))
+    if approval.get("fingerprint") != current:
+        raise NotApprovedError(
+            "the skill has changed since it was approved — its steps no longer match "
+            "the plan that was replayed. Replay again and get a fresh approval; the "
+            "previous one was for a different set of steps."
+        )

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -31,6 +31,8 @@ prevent.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from typing import Any
 
@@ -238,6 +240,35 @@ def goal_reached(operation: dict, steps: list[dict]) -> bool:
     return True
 
 
+def operations_fingerprint(operations: list[dict]) -> str:
+    """A stable digest of what the draft actually DOES.
+
+    An approval is only meaningful for the plan that was replayed. Amend a step
+    and recompile and this changes, so the stale approval no longer matches and
+    the installer refuses — which is what makes "user confirmation takes
+    precedence" enforceable rather than a convention.
+
+    Keyed on the operations' names, kinds and steps. Descriptions are excluded
+    deliberately: renaming an operation or rewording its description changes
+    nothing about its behaviour, and forcing a fresh replay for a typo fix would
+    make the gate something to work around.
+    """
+    material = [
+        {
+            "name": op.get("name"),
+            "kind": op.get("kind") or "read",
+            "steps": op.get("steps") or [],
+            "parameters": [
+                {"name": p.get("name"), "default": p.get("default")}
+                for p in op.get("parameters") or []
+            ],
+        }
+        for op in operations or []
+    ]
+    blob = json.dumps(material, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:32]
+
+
 def build_report(operations: list[dict], results: list[list[dict]]) -> dict:
     """The whole replay, in the shape the confirmation card renders.
 
@@ -266,6 +297,8 @@ def build_report(operations: list[dict], results: list[list[dict]]) -> dict:
         "operations": ops_out,
         "all_goals_reached": bool(ops_out) and all(o["goal_reached"] for o in ops_out),
         "needs_approval": any(o["needs_approval_count"] for o in ops_out),
+        # Ties the approval to the exact plan that was replayed.
+        "fingerprint": operations_fingerprint(operations),
         # The gate itself. Nothing downstream should install on anything else.
         "installable": False,
     }

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -167,6 +167,28 @@ def plan_operations(operations: list[dict], *, browser_only: bool = True) -> lis
     return [op for op in operations or [] if (op.get("tool") or "") == "call_web_browser"]
 
 
+_ABSENT = ("nothing on the page matches", "unknown command", "not visible")
+
+
+def _satisfied_already(step: dict, detail: str) -> bool:
+    """Is this an optional step whose control is simply not there?
+
+    ICICI's statement portal has its own sign-in, INSIDE the workflow. The
+    recording had to do it -- click Log In, and the URL gains a jsessionid. A
+    replay whose session already satisfies it arrives past that point, so the
+    button is absent and the compiled step matched nothing. The step is
+    unnecessary, not broken.
+
+    Only for a step the compiler marked optional, and only when the control is
+    ABSENT. A login button that is present and fails to click is a real failure
+    and must stay one.
+    """
+    if not step.get("optional"):
+        return False
+    low = str(detail or "").lower()
+    return any(marker in low for marker in _ABSENT)
+
+
 def replay_step(
     execute: Any,
     step: dict,
@@ -207,13 +229,30 @@ def replay_step(
         # instead of recording the plan as broken.
         raise
     except Exception as exc:  # noqa: BLE001 — a blocked step is data, not a crash
+        if _satisfied_already(step, str(exc)):
+            result["status"] = SKIPPED
+            result["detail"] = (
+                f"{step.get('optional_reason') or 'optional step'}: its control is not "
+                "on the page, which means this was already satisfied before the "
+                "replay arrived."
+            )
+            return result
         result["status"] = BLOCKED
         result["detail"] = str(exc)
         return result
 
     if isinstance(response, dict) and response.get("success") is False:
+        detail = str(response.get("error") or "the command reported failure")
+        if _satisfied_already(step, detail):
+            result["status"] = SKIPPED
+            result["detail"] = (
+                f"{step.get('optional_reason') or 'optional step'}: its control is not "
+                "on the page, which means this was already satisfied before the "
+                "replay arrived."
+            )
+            return result
         result["status"] = BLOCKED
-        result["detail"] = str(response.get("error") or "the command reported failure")
+        result["detail"] = detail
         return result
 
     result["status"] = OK

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -189,6 +189,70 @@ def _satisfied_already(step: dict, detail: str) -> bool:
     return any(marker in low for marker in _ABSENT)
 
 
+_INVISIBLE = "on the page but not visible"
+
+
+def _unactionable(detail: str) -> bool:
+    """Could this control not be acted on, whether it is hidden or simply gone?
+
+    ICICI's GO button showed up both ways on consecutive runs -- once present
+    but hidden, once absent entirely -- because how far the portal has re-rendered
+    when the step fires varies. Both mean the same thing: the step cannot be
+    performed here. Whether that is a FAILURE is decided by `arrived_past`, which
+    looks at what comes next.
+    """
+    low = (detail or "").lower()
+    return any(marker in low for marker in _ABSENT) or _INVISIBLE in low
+
+
+def _selector_of(step: Any) -> str:
+    if not isinstance(step, dict):
+        return ""
+    return str((step.get("params") or {}).get("selector") or "")
+
+
+def arrived_past(step: dict, following: Any, execute: Any) -> bool:
+    """Has the page already moved beyond this step, leaving its control behind?
+
+    ICICI's annual statement is chosen with a radio. The human then pressed GO,
+    because their selection did not submit the form. The replay's `set_checked`
+    DOES submit it, so the page is already on the annual view and that GO button
+    is hidden -- present, unclickable, and permanently so: it stayed hidden
+    through a full 30s wait. The step is unnecessary, not broken.
+
+    "Invisible" alone cannot mean "skip". The very first step of this same
+    replay -- the credit-card link inside a hover menu -- is invisible until its
+    menu opens, and blocking there is exactly right. What separates the two is
+    what comes NEXT: the menu item's successor is not reachable yet either,
+    while the GO button's successor is already on screen. A control we cannot
+    see, followed by one we can, means the page went past this step.
+
+    Looks ahead to the next step that addresses a CONTROL, not merely the next
+    step. A read operation ends with `get_page_summary`, which names nothing, so
+    anchoring on the immediate successor found no evidence and blocked -- on the
+    very case this rule was written for.
+
+    Requires that successor to name a CSS selector, because that is the only
+    thing that can be probed without acting on the page. Anything else is
+    treated as a real failure, which is the safe direction.
+    """
+    selector = ""
+    for candidate in (following if isinstance(following, list) else [following]):
+        selector = _selector_of(candidate)
+        if selector:
+            break
+    if not selector:
+        return False
+    try:
+        result = execute(
+            "wait_for_selector",
+            {"selector": selector, "state": "visible", "timeout_ms": 4000},
+        )
+    except Exception:  # noqa: BLE001 — cannot prove it, so do not skip
+        return False
+    return bool(result.get("success", True)) if isinstance(result, dict) else False
+
+
 def replay_step(
     execute: Any,
     step: dict,
@@ -196,6 +260,7 @@ def replay_step(
     recorded: set[str],
     approvals: set[str] | None = None,
     known_downloads: set[str] | None = None,
+    following: Any = None,
 ) -> dict:
     """Run one step and report what happened, without ever raising.
 
@@ -250,6 +315,14 @@ def replay_step(
                 f"{step.get('optional_reason') or 'optional step'}: its control is not "
                 "on the page, which means this was already satisfied before the "
                 "replay arrived."
+            )
+            return result
+        if _unactionable(detail) and arrived_past(step, following, execute):
+            result["status"] = SKIPPED
+            result["detail"] = (
+                "its control is on the page but not visible, and the control this "
+                "operation needs NEXT already is — so the page has moved past this "
+                "step and performing it is neither possible nor needed."
             )
             return result
         result["status"] = BLOCKED

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -241,7 +241,7 @@ def arrived_past(step: dict, following: Any, execute: Any) -> bool:
     treated as a real failure, which is the safe direction.
     """
     selector = ""
-    for candidate in (following if isinstance(following, list) else [following]):
+    for candidate in following if isinstance(following, list) else [following]:
         selector = _selector_of(candidate)
         if selector:
             break
@@ -584,9 +584,7 @@ def build_report(
     already: set[str] = set(already_downloaded or ())
     for op, steps in zip(operations, results, strict=False):
         reached = goal_reached(op, steps, already_downloaded=already)
-        already.update(
-            str(r["id"]) for r in downloads_listed(steps) if r.get("id") is not None
-        )
+        already.update(str(r["id"]) for r in downloads_listed(steps) if r.get("id") is not None)
         ops_out.append(
             {
                 "name": op.get("name"),

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -548,7 +548,12 @@ def operations_fingerprint(operations: list[dict]) -> str:
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:32]
 
 
-def build_report(operations: list[dict], results: list[list[dict]]) -> dict:
+def build_report(
+    operations: list[dict],
+    results: list[list[dict]],
+    *,
+    already_downloaded: Any = None,
+) -> dict:
     """The whole replay, in the shape the confirmation card renders.
 
     ``results`` is one list of step-results PER operation, positionally matched
@@ -559,10 +564,15 @@ def build_report(operations: list[dict], results: list[list[dict]]) -> dict:
     needs to decide on is whether each GOAL was reached.
     """
     ops_out = []
-    # What the operations BEFORE this one already produced. Downloads are
-    # reported cumulatively for the whole session, so without this an operation
-    # inherits its predecessor's file as proof of its own success.
-    already: set[str] = set()
+    # What was already on disk before this operation ran -- both what earlier
+    # operations produced AND what was there before the replay started.
+    #
+    # Seeded only from earlier operations, a file left by a PREVIOUS replay
+    # counted as this one's evidence: a run that downloaded nothing reported the
+    # goal reached, on the strength of a statement fetched minutes earlier. The
+    # session accumulates downloads for its whole life, so the baseline has to
+    # be taken when the run starts.
+    already: set[str] = set(already_downloaded or ())
     for op, steps in zip(operations, results, strict=False):
         reached = goal_reached(op, steps, already_downloaded=already)
         already.update(

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -264,6 +264,16 @@ def arrived_past(step: dict, following: Any, execute: Any) -> bool:
     return bool(result.get("success", True)) if isinstance(result, dict) else False
 
 
+def _target_identity(step: dict) -> str:
+    """What a step acts on, for recognising a control we have already failed."""
+    params = step.get("params") or {}
+    for key in ("selector", "text", "role"):
+        value = params.get(key)
+        if isinstance(value, str) and value:
+            return f"{key}={value}"
+    return ""
+
+
 def replay_step(
     execute: Any,
     step: dict,
@@ -272,6 +282,7 @@ def replay_step(
     approvals: set[str] | None = None,
     known_downloads: set[str] | None = None,
     following: Any = None,
+    unactionable_targets: set[str] | None = None,
 ) -> dict:
     """Run one step and report what happened, without ever raising.
 
@@ -292,6 +303,28 @@ def replay_step(
         "expect": step.get("expect"),
         "locator": step.get("locator"),
     }
+
+    # A control already proven unactionable on this page is not worth waiting for
+    # again.
+    #
+    # ICICI's statement operations repeat a selector -- #DUMMY1 twice, then
+    # #DOWNLOAD_ESTATEMENT_PDF twice -- and when the control is present but
+    # hidden, each attempt spends the attach wait AND the click timeout before
+    # reporting the same thing it reported a moment ago. That was roughly three
+    # minutes of a replay sitting on the statement page, none of it doing
+    # anything.
+    #
+    # Reported as blocked, not skipped: the step DID fail, and the run should say
+    # so. It simply says it immediately, on the evidence it already has.
+    repeat_target = _target_identity(step)
+    if unactionable_targets is not None and repeat_target and repeat_target in unactionable_targets:
+        result["status"] = BLOCKED
+        result["error"] = (
+            f"{repeat_target} was already found on the page but not actionable earlier in "
+            "this run, so this repeat was not attempted -- waiting again would cost the "
+            "same timeout to learn the same thing."
+        )
+        return result
 
     risk = classify_risk(step, recorded_controls=recorded)
     if risk and identity not in approvals:
@@ -320,6 +353,10 @@ def replay_step(
 
     if isinstance(response, dict) and response.get("success") is False:
         detail = str(response.get("error") or "the command reported failure")
+        if unactionable_targets is not None and _unactionable(detail):
+            identity = _target_identity(step)
+            if identity:
+                unactionable_targets.add(identity)
         if _satisfied_already(step, detail):
             result["status"] = SKIPPED
             result["detail"] = (

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -126,6 +126,10 @@ def _text_of(step: dict) -> str:
         params.get("text") or "",
         params.get("label") or "",
         params.get("selector") or "",
+        # A role-addressed control carries its words in `name`, not `text`/`label`
+        # (set_checked {role: "radio", name: "Transfer"}); read it too so a risky
+        # role-named control still trips ground 1.
+        params.get("name") or "",
         (step.get("locator") or {}).get("recorded_text") or "",
     ]
     return " ".join(str(p) for p in parts).lower()
@@ -189,6 +193,15 @@ def _control_identity(step: dict) -> str:
         value = params.get(key)
         if isinstance(value, str) and value.strip():
             return f"{key}:{value.strip().lower()}"
+    # A control addressed by ROLE + accessible NAME (set_checked {role, name}) --
+    # a radio/checkbox with no unique CSS selector -- is still a named control the
+    # recording saw. Give it an identity so it lands in recorded_controls and is
+    # not mistaken (ground 2 / the fail-closed check) for an anchorless step the
+    # recording could not vouch for.
+    role = params.get("role")
+    name = params.get("name")
+    if isinstance(role, str) and role.strip() and isinstance(name, str) and name.strip():
+        return f"role:{role.strip().lower()}|{name.strip().lower()}"
     return ""
 
 

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -277,9 +277,10 @@ def expectation_unmet(expect: Any, execute: Any) -> str:
     """Why the recorded postcondition does not hold, or "" if it does.
 
     Deliberately forgiving about HOW a page is reached and strict about WHERE it
-    ends up: a URL matches if the recorded one is a prefix of it (ignoring the
-    query, where session tokens churn between the recording and the replay), so
-    a portal that appends its own parameters still passes.
+    ends up: a URL matches if the recorded one is a prefix of it, ignoring the
+    query AND any path parameter -- both are where session tokens churn between
+    the recording and the replay -- so a portal that appends its own still
+    passes.
     """
     if not isinstance(expect, dict) or not expect:
         return ""
@@ -292,7 +293,14 @@ def expectation_unmet(expect: Any, execute: Any) -> str:
         except Exception:  # noqa: BLE001 — an unreadable url is not a failed expectation
             here = ""
         if here:
-            bare = lambda u: u.split("?")[0].split("#")[0].rstrip("/")  # noqa: E731
+            # Path parameters go too, not just the query. ICICI carries its
+            # portal session as `;jsessionid=...` in the PATH, so a recorded URL
+            # and a live one name the same page with different tokens -- and
+            # neither is a prefix of the other. Left in, the download's own
+            # page assertion would fail every replay for the wrong reason.
+            bare = lambda u: (  # noqa: E731
+                u.split("?")[0].split("#")[0].split(";")[0].rstrip("/")
+            )
             if not bare(here).startswith(bare(want_url)) and not bare(want_url).startswith(
                 bare(here)
             ):

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -218,7 +218,57 @@ def replay_step(
 
     result["status"] = OK
     result["data"] = response.get("data") if isinstance(response, dict) else None
+
+    # Check the postcondition the recorder observed.
+    #
+    # Until now `expect` was carried into the result and never evaluated, so a
+    # replay could execute every step, end up on a completely different page,
+    # and report success -- "no step was blocked" was the whole test. That is
+    # how a run clicked its way onto /discover and still called itself passing.
+    # The compiler already states what the recording observed after each click;
+    # this is the enforcer that was missing.
+    unmet = expectation_unmet(step.get("expect"), execute)
+    if unmet:
+        result["status"] = BLOCKED
+        result["detail"] = unmet
     return result
+
+
+def expectation_unmet(expect: Any, execute: Any) -> str:
+    """Why the recorded postcondition does not hold, or "" if it does.
+
+    Deliberately forgiving about HOW a page is reached and strict about WHERE it
+    ends up: a URL matches if the recorded one is a prefix of it (ignoring the
+    query, where session tokens churn between the recording and the replay), so
+    a portal that appends its own parameters still passes.
+    """
+    if not isinstance(expect, dict) or not expect:
+        return ""
+
+    want_url = str(expect.get("url") or "")
+    if want_url:
+        try:
+            info = execute("get_page_info", {}) or {}
+            here = str((info.get("data") or info).get("url") or "")
+        except Exception:  # noqa: BLE001 — an unreadable url is not a failed expectation
+            here = ""
+        if here:
+            bare = lambda u: u.split("?")[0].split("#")[0].rstrip("/")  # noqa: E731
+            if not bare(here).startswith(bare(want_url)) and not bare(want_url).startswith(
+                bare(here)
+            ):
+                return f"expected to be on {want_url} after this step, but the page is {here}"
+
+    if expect.get("download"):
+        try:
+            listed = execute("list_downloads", {}) or {}
+            files = ((listed.get("data") or listed) or {}).get("downloads") or []
+        except Exception:  # noqa: BLE001
+            files = []
+        if not files:
+            return "this step downloaded a file when it was recorded; no file arrived"
+
+    return ""
 
 
 def goal_reached(operation: dict, steps: list[dict]) -> bool:

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -1,0 +1,268 @@
+"""Replaying a DRAFT skill before anything is installed.
+
+A recording is a claim about how an app works. Compiling it produces a plan that
+looks right on paper — and every failure this project has hit looked right on
+paper. `a.mb-0` reads like a selector. A missing download operation looks like a
+skill with three operations. A hidden radio looks clickable. The only question
+that matters is whether a step resolves against the live page, and the only way
+to answer it is to try.
+
+So: compile a draft, replay it against the real app in the session the human just
+authenticated, show them what happened, and install NOTHING until they approve.
+
+Three rules shape the design.
+
+**Nothing is installed until a human approves.** The draft is compiled in place,
+replayed, and either approved or amended. No App Template is registered, no
+profile bound, no catalog entry written before that.
+
+**Risky steps stop and ask.** The replay agent is allowed to improvise around a
+blocked step, and an improvising agent on a bank portal can reach Pay, Transfer
+or Block Card while hunting for a statement. Anything that moves money, is
+irreversible, or touches a control the human never touched is refused here and
+handed back for explicit approval — even when it looks like the way forward.
+
+**Replay starts where a real run starts.** Not where the recording happened to
+end. An installed skill gets a session provisioned from its profile, loads the
+app with stored cookies, and lands on the post-login page; replay does the same.
+A plan that only works from mid-flow is the exact false pass this gate exists to
+prevent.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+#: Step outcomes, as rendered to the human.
+OK = "ok"
+BLOCKED = "blocked"
+RECOVERED = "recovered"
+NEEDS_APPROVAL = "needs_approval"
+SKIPPED = "skipped"
+
+#: Commands that only read. Safe to replay without asking, always.
+_READ_ONLY_COMMANDS = frozenset(
+    {"get_page_summary", "get_page_info", "screenshot", "wait_for_selector", "list_downloads"}
+)
+
+#: Words that mean this control does something to the account, not just shows it.
+#: Deliberately broad: a false stop costs one question, a false proceed can move
+#: money.
+_RISKY_TEXT = (
+    "pay",
+    "transfer",
+    "remit",
+    "send money",
+    "fund",
+    "block",
+    "close",
+    "cancel",
+    "delete",
+    "remove",
+    "deactivate",
+    "confirm",
+    "authorise",
+    "authorize",
+    "submit",
+    "update",
+    "change",
+    "reset",
+    "modify",
+)
+
+
+def _text_of(step: dict) -> str:
+    params = step.get("params") or {}
+    parts = [
+        params.get("text") or "",
+        params.get("label") or "",
+        params.get("selector") or "",
+        (step.get("locator") or {}).get("recorded_text") or "",
+    ]
+    return " ".join(str(p) for p in parts).lower()
+
+
+def classify_risk(step: dict, *, recorded_controls: set[str]) -> str | None:
+    """Why this step must not be replayed unattended, or None if it is safe.
+
+    Three grounds, in the order they catch things:
+
+    1. It moves money or is irreversible — pay, transfer, block, delete, submit.
+    2. It touches a control the human never touched. This is the one that
+       actually catches the unexpected: the plan only departs from the recording
+       when the agent is improvising, and that is exactly when nobody has
+       verified what the control does.
+    3. It is a form submission. `submit` operations are compiled from a real
+       submit the human made, but replaying one on a bank portal repeats
+       whatever it did.
+
+    Read-only commands are never risky, whatever their text says — reading a page
+    that happens to contain the word "Transfer" is not a transfer.
+    """
+    command = step.get("command") or ""
+    if command in _READ_ONLY_COMMANDS:
+        return None
+
+    text = _text_of(step)
+    for word in _RISKY_TEXT:
+        if re.search(rf"\b{re.escape(word)}", text):
+            return f"looks like it {word}s something rather than reading it"
+
+    identity = _control_identity(step)
+    if identity and identity not in recorded_controls:
+        return "the human never touched this control during the recording"
+
+    return None
+
+
+def _control_identity(step: dict) -> str:
+    """A stable key for "the same control", for comparing against the recording."""
+    params = step.get("params") or {}
+    for key in ("selector", "label", "text"):
+        value = params.get(key)
+        if isinstance(value, str) and value.strip():
+            return f"{key}:{value.strip().lower()}"
+    return ""
+
+
+def recorded_controls(operations: list[dict]) -> set[str]:
+    """Every control the compiled draft addresses — i.e. what the human did.
+
+    The draft is compiled from the recording, so its steps ARE the human's
+    actions. A step outside this set can only have come from the agent
+    improvising.
+    """
+    out: set[str] = set()
+    for op in operations or []:
+        for step in op.get("steps") or []:
+            identity = _control_identity(step)
+            if identity:
+                out.add(identity)
+    return out
+
+
+def plan_operations(operations: list[dict], *, browser_only: bool = True) -> list[dict]:
+    """The operations replay should run.
+
+    Browser skills only, by decision: a HAR-replay skill is validated by its
+    existing test loop, and replaying one means firing recorded requests, which
+    is a different risk profile entirely.
+    """
+    if not browser_only:
+        return list(operations or [])
+    return [op for op in operations or [] if (op.get("tool") or "") == "call_web_browser"]
+
+
+def replay_step(
+    execute: Any,
+    step: dict,
+    *,
+    recorded: set[str],
+    approvals: set[str] | None = None,
+) -> dict:
+    """Run one step and report what happened, without ever raising.
+
+    ``execute(command, params)`` performs the command and returns the worker's
+    response; anything it raises becomes a BLOCKED result rather than ending the
+    replay. A blocked step is information — it is the thing the human needs to
+    see — so it must never abort the run and lose everything after it.
+
+    ``approvals`` holds control identities the human has already approved this
+    run, so an approved risky step executes on the next pass instead of asking
+    again.
+    """
+    approvals = approvals or set()
+    identity = _control_identity(step)
+    result: dict[str, Any] = {
+        "command": step.get("command"),
+        "params": step.get("params") or {},
+        "expect": step.get("expect"),
+        "locator": step.get("locator"),
+    }
+
+    risk = classify_risk(step, recorded_controls=recorded)
+    if risk and identity not in approvals:
+        result["status"] = NEEDS_APPROVAL
+        result["detail"] = risk
+        return result
+
+    try:
+        response = execute(step.get("command"), step.get("params") or {})
+    except Exception as exc:  # noqa: BLE001 — a blocked step is data, not a crash
+        result["status"] = BLOCKED
+        result["detail"] = str(exc)
+        return result
+
+    if isinstance(response, dict) and response.get("success") is False:
+        result["status"] = BLOCKED
+        result["detail"] = str(response.get("error") or "the command reported failure")
+        return result
+
+    result["status"] = OK
+    result["data"] = response.get("data") if isinstance(response, dict) else None
+    return result
+
+
+def goal_reached(operation: dict, steps: list[dict]) -> bool:
+    """Did this operation actually achieve what it exists for?
+
+    Not "did every step pass" — an operation whose steps all ran but which never
+    produced its file has not reached its goal, and that distinction is the whole
+    reason `kind` is recorded. For a download the evidence is a file; for
+    everything else it is that no step was left blocked.
+    """
+    if any(s.get("status") in (BLOCKED, NEEDS_APPROVAL) for s in steps):
+        return False
+    if (operation.get("kind") or "") == "download":
+        for s in steps:
+            if s.get("command") == "list_downloads":
+                data = s.get("data") or {}
+                return bool((data or {}).get("downloads"))
+        return False
+    return True
+
+
+def build_report(operations: list[dict], results: list[list[dict]]) -> dict:
+    """The whole replay, in the shape the confirmation card renders.
+
+    ``results`` is one list of step-results PER operation, positionally matched
+    to ``operations``.
+
+    Reports per operation AND overall, because "11 of 12 steps passed" is the
+    kind of summary that hides exactly the failure that matters. What the human
+    needs to decide on is whether each GOAL was reached.
+    """
+    ops_out = []
+    for op, steps in zip(operations, results, strict=False):
+        reached = goal_reached(op, steps)
+        ops_out.append(
+            {
+                "name": op.get("name"),
+                "kind": op.get("kind") or "read",
+                "description": op.get("description"),
+                "goal_reached": reached,
+                "steps": steps,
+                "blocked_count": sum(1 for s in steps if s.get("status") == BLOCKED),
+                "needs_approval_count": sum(1 for s in steps if s.get("status") == NEEDS_APPROVAL),
+            }
+        )
+    return {
+        "operations": ops_out,
+        "all_goals_reached": bool(ops_out) and all(o["goal_reached"] for o in ops_out),
+        "needs_approval": any(o["needs_approval_count"] for o in ops_out),
+        # The gate itself. Nothing downstream should install on anything else.
+        "installable": False,
+    }
+
+
+def approve(report: dict) -> dict:
+    """Mark a replayed draft as approved by the human.
+
+    Separate from build_report on purpose: `installable` is never something the
+    replay concludes on its own, however well it went. It is set only here, by an
+    explicit human decision, so no code path can install a skill nobody looked at.
+    """
+    approved = dict(report)
+    approved["installable"] = True
+    return approved

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -389,6 +389,13 @@ def substitute_parameters(operation: dict, values: dict[str, str] | None = None)
         params = {
             k: (fill(v) if isinstance(v, str) else v) for k, v in (step.get("params") or {}).items()
         }
+        # Carry the recorded settle to the worker. It decides how long a control
+        # that exists but is not yet visible may take -- a hover-revealed menu
+        # measured at 4.3s was failing against a flat 3s grace. The measurement
+        # is in the recording; the worker cannot see the expect block.
+        settle = (step.get("expect") or {}).get("settle_ms")
+        if isinstance(settle, int) and settle > 0:
+            params.setdefault("settle_ms", settle)
         out.append({**step, "params": params})
     return out
 

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import time
 from typing import Any
 
 
@@ -189,6 +190,9 @@ def _satisfied_already(step: dict, detail: str) -> bool:
     return any(marker in low for marker in _ABSENT)
 
 
+_RETRY_PAUSE_S = 2.5
+"""How long to let a transiently-missing control appear before trying again."""
+
 _INVISIBLE = "on the page but not visible"
 
 
@@ -244,9 +248,16 @@ def arrived_past(step: dict, following: Any, execute: Any) -> bool:
     if not selector:
         return False
     try:
+        # As patient as the step that follows.
+        #
+        # A 4s probe judged the page while the portal was still re-rendering:
+        # ICICI's GO button was reported BLOCKED, and the very next step -- the
+        # one whose control the probe had just failed to find -- succeeded
+        # seconds later. Evidence gathered less patiently than the thing it is
+        # evidence about is worse than none.
         result = execute(
             "wait_for_selector",
-            {"selector": selector, "state": "visible", "timeout_ms": 4000},
+            {"selector": selector, "state": "visible", "timeout_ms": 12000},
         )
     except Exception:  # noqa: BLE001 — cannot prove it, so do not skip
         return False
@@ -317,6 +328,38 @@ def replay_step(
                 "replay arrived."
             )
             return result
+        # One retry, because a control can be transiently unreachable.
+        #
+        # The first step of the ICICI replay opens a hover menu, and its item is
+        # not rendered the instant the pointer lands. That made the run a coin
+        # flip: it failed at step 0 about half the time and passed on an
+        # immediate retry with nothing changed. Waiting for the page to stop
+        # navigating did NOT fix it -- the page was not navigating; the menu was
+        # simply not up yet -- so the retry is the fix rather than a symptom of
+        # a missing one.
+        #
+        # Before deciding the page has moved past this step, since a control
+        # that appears on the second attempt has not been moved past at all.
+        if _unactionable(detail):
+            time.sleep(_RETRY_PAUSE_S)
+            try:
+                retry = execute(step.get("command"), step.get("params") or {})
+            except SessionNotReadyError:
+                raise
+            except Exception:  # noqa: BLE001 — keep the FIRST failure's detail
+                retry = None
+            if isinstance(retry, dict) and retry.get("success") is not False:
+                result["status"] = OK
+                result["data"] = retry.get("data")
+                result["detail"] = "succeeded on a second attempt"
+                unmet = expectation_unmet(
+                    step.get("expect"), execute, known_downloads=known_downloads
+                )
+                if unmet:
+                    result["status"] = BLOCKED
+                    result["detail"] = unmet
+                return result
+
         if _unactionable(detail) and arrived_past(step, following, execute):
             result["status"] = SKIPPED
             result["detail"] = (
@@ -453,14 +496,27 @@ def goal_reached(
     replay exists to catch, passing the replay. ``already_downloaded`` carries
     what the operations before it had already produced.
     """
-    if any(s.get("status") in (BLOCKED, NEEDS_APPROVAL) for s in steps):
+    # An unanswered approval is a hard stop whatever else happened: the human
+    # has not agreed to the thing being asked about.
+    if any(s.get("status") == NEEDS_APPROVAL for s in steps):
         return False
+
     if (operation.get("kind") or "") == "download":
+        # The file is the evidence, and it is stronger than the step list.
+        #
+        # The annual replay produced the right statement -- "Statement Period
+        # 01/04/2025 TO 31/03/2026" -- through `#PDF_Download`, while a later
+        # click on a control the page had already moved past was recorded as
+        # blocked. Reporting that run as goal-not-reached describes the plan, not
+        # the outcome, and the outcome is what this field is for. The blocked
+        # steps stay in the report, and `installable` still waits for a human.
         listed = downloads_listed(steps)
         if not listed:
             return False
         return any(_is_new_download(r, already_downloaded) for r in listed)
-    return True
+
+    # Everything else has only its steps to go on.
+    return not any(s.get("status") == BLOCKED for s in steps)
 
 
 def operations_fingerprint(operations: list[dict]) -> str:

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -384,8 +384,41 @@ def substitute_parameters(operation: dict, values: dict[str, str] | None = None)
 
     out: list[dict] = []
     for step in operation.get("steps") or []:
+        if not step_applies(step, values):
+            continue
         params = {
             k: (fill(v) if isinstance(v, str) else v) for k, v in (step.get("params") or {}).items()
         }
         out.append({**step, "params": params})
     return out
+
+
+def step_applies(step: dict, values: dict) -> bool:
+    """Does this step run for these parameter values?
+
+    Two operations recorded from one page often differ by WHICH STEPS RUN rather
+    than by a value: ICICI's monthly and annual statements share four steps to
+    reach the page, then diverge -- annual clicks a radio and picks a financial
+    year, monthly does not. Substitution cannot express that, so the compiler had
+    to emit both as separate operations, each replaying the whole journey from
+    the landing page.
+
+    ``when`` is how a step says which variant it belongs to::
+
+        {"command": "click_by_text", "params": {...}, "when": {"timeframe": "annual"}}
+
+    A step with no ``when`` always runs -- every operation compiled before this
+    existed keeps behaving exactly as it did. All named keys must match, so a
+    step can belong to a combination of choices, and an unknown parameter never
+    silently matches: a ``when`` naming something the operation does not declare
+    means the step is skipped rather than run by accident.
+    """
+    cond = step.get("when")
+    if not isinstance(cond, dict) or not cond:
+        return True
+    for name, wanted in cond.items():
+        if name not in values:
+            return False
+        if str(values.get(name)) != str(wanted):
+            return False
+    return True

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -60,6 +60,25 @@ _READ_ONLY_COMMANDS = frozenset(
     {"get_page_summary", "get_page_info", "screenshot", "wait_for_selector", "list_downloads"}
 )
 
+#: Commands that act on the PAGE or the BROWSER rather than on a specific control
+#: -- navigation, scrolling, HAR capture, collecting a finished download. They
+#: carry no selector/label/text by nature, so an empty control identity is
+#: expected for them and is NOT a risk signal. Everything else that is neither
+#: read-only nor listed here acts on a control, and an action whose control
+#: cannot be identified (a coordinate click, a key-press on the focused element)
+#: is treated as risky below -- see classify_risk ground 2.
+_NON_CONTROL_COMMANDS = frozenset(
+    {
+        "navigate",
+        "scroll_page",
+        "wait_for_url",
+        "har_start",
+        "har_stop",
+        "har_status",
+        "get_download",
+    }
+)
+
 #: Words that mean this control does something to the account, not just shows it.
 #: Deliberately broad: a false stop costs one question, a false proceed can move
 #: money.
@@ -68,7 +87,10 @@ _RISKY_TEXT = (
     "transfer",
     "remit",
     "send money",
+    "wire",
     "fund",
+    "withdraw",
+    "deposit",
     "block",
     "close",
     "cancel",
@@ -83,6 +105,18 @@ _RISKY_TEXT = (
     "change",
     "reset",
     "modify",
+    # Money-moving and account-structural actions a bank/broker portal carries
+    # that the list above missed: adding a payee/beneficiary, taking a loan,
+    # buying/selling/redeeming an investment. Same rule as the rest -- a false
+    # stop costs one question, a false proceed can move money.
+    "payee",
+    "beneficiary",
+    "loan",
+    "purchase",
+    "buy",
+    "sell",
+    "invest",
+    "redeem",
 )
 
 
@@ -100,19 +134,23 @@ def _text_of(step: dict) -> str:
 def classify_risk(step: dict, *, recorded_controls: set[str]) -> str | None:
     """Why this step must not be replayed unattended, or None if it is safe.
 
-    Three grounds, in the order they catch things:
+    Grounds, in the order they catch things:
 
     1. It moves money or is irreversible — pay, transfer, block, delete, submit.
     2. It touches a control the human never touched. This is the one that
        actually catches the unexpected: the plan only departs from the recording
        when the agent is improvising, and that is exactly when nobody has
        verified what the control does.
-    3. It is a form submission. `submit` operations are compiled from a real
-       submit the human made, but replaying one on a bank portal repeats
-       whatever it did.
+    3. It acts on a control that cannot be identified at all — a coordinate click
+       or a key-press on the focused element carries no selector/label/text, so
+       grounds 1 and 2 both find nothing and would wave it through. That is the
+       fail-open version of ground 2, closed here: an action the recording cannot
+       vouch for is refused, not run.
 
     Read-only commands are never risky, whatever their text says — reading a page
-    that happens to contain the word "Transfer" is not a transfer.
+    that happens to contain the word "Transfer" is not a transfer. Page/browser
+    commands (navigate, scroll) target no control, so an empty identity is
+    expected for them and does not trip ground 3.
     """
     command = step.get("command") or ""
     if command in _READ_ONLY_COMMANDS:
@@ -126,6 +164,20 @@ def classify_risk(step: dict, *, recorded_controls: set[str]) -> str | None:
     identity = _control_identity(step)
     if identity and identity not in recorded_controls:
         return "the human never touched this control during the recording"
+
+    # Ground 2 needs an identity to compare. A control-acting step that carries
+    # none -- a coordinate click (click_at), a key-press on the focused element
+    # (press_key) -- has no identity here AND no text for ground 1, so both gates
+    # above silently pass it, and it replays unattended: exactly the improvisation
+    # the module's docstring warns of ("reach Pay/Transfer/Block Card while
+    # hunting for a statement"). Read-only commands already returned above, and
+    # page/browser commands (navigate, scroll) legitimately target no control, so
+    # anything left here with no identity is an action on a control the recording
+    # cannot vouch for. Fail closed -- a needless question costs one click.
+    if not identity and command not in _NON_CONTROL_COMMANDS:
+        return (
+            "acts on a control the recording cannot identify (e.g. a coordinate click or key-press)"
+        )
 
     return None
 

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -195,6 +195,7 @@ def replay_step(
     *,
     recorded: set[str],
     approvals: set[str] | None = None,
+    known_downloads: set[str] | None = None,
 ) -> dict:
     """Run one step and report what happened, without ever raising.
 
@@ -266,14 +267,39 @@ def replay_step(
     # how a run clicked its way onto /discover and still called itself passing.
     # The compiler already states what the recording observed after each click;
     # this is the enforcer that was missing.
-    unmet = expectation_unmet(step.get("expect"), execute)
+    unmet = expectation_unmet(step.get("expect"), execute, known_downloads=known_downloads)
     if unmet:
         result["status"] = BLOCKED
         result["detail"] = unmet
     return result
 
 
-def expectation_unmet(expect: Any, execute: Any) -> str:
+def _is_new_download(record: Any, known: Any) -> bool:
+    """A file that arrived HERE, and actually finished arriving.
+
+    `list_downloads` reports every download the browser context has taken, for
+    the life of the session -- so once any operation downloads anything, every
+    later download check passes on that same file. The annual statement replay
+    "succeeded" on the monthly PDF fetched two operations earlier.
+
+    A record also counts as a download while it is still in flight and after it
+    has failed. Neither is evidence that the step did what it was recorded
+    doing.
+    """
+    if not isinstance(record, dict):
+        return False
+    # Only an explicit verdict counts against it. A record with no state at all
+    # is not evidence of failure, and refusing those would fail every download
+    # against a worker that does not report one.
+    if record.get("state") in ("in_progress", "failed"):
+        return False
+    rid = record.get("id")
+    # Untrackable, so it cannot be shown to be old. Real records always carry an
+    # id; treating its absence as "already seen" would reject every download.
+    return rid is None or str(rid) not in known
+
+
+def expectation_unmet(expect: Any, execute: Any, *, known_downloads: set[str] | None = None) -> str:
     """Why the recorded postcondition does not hold, or "" if it does.
 
     Deliberately forgiving about HOW a page is reached and strict about WHERE it
@@ -312,28 +338,55 @@ def expectation_unmet(expect: Any, execute: Any) -> str:
             files = ((listed.get("data") or listed) or {}).get("downloads") or []
         except Exception:  # noqa: BLE001
             files = []
-        if not files:
+        known = known_downloads if known_downloads is not None else set()
+        fresh = [f for f in files if _is_new_download(f, known)]
+        # Everything on disk is accounted for from here on, whether or not it
+        # satisfied THIS step.
+        if known_downloads is not None:
+            known_downloads.update(str(f.get("id")) for f in files if f.get("id") is not None)
+        if not fresh:
+            if files:
+                return (
+                    "this step downloaded a file when it was recorded; no NEW completed "
+                    f"file arrived (the {len(files)} already here came from earlier steps)"
+                )
             return "this step downloaded a file when it was recorded; no file arrived"
 
     return ""
 
 
-def goal_reached(operation: dict, steps: list[dict]) -> bool:
+def downloads_listed(steps: list[dict]) -> list[dict]:
+    """Every download record this operation's own `list_downloads` reported."""
+    for s in steps:
+        if s.get("command") == "list_downloads":
+            listed = (s.get("data") or {}).get("downloads")
+            return [r for r in (listed or []) if isinstance(r, dict)]
+    return []
+
+
+def goal_reached(
+    operation: dict, steps: list[dict], *, already_downloaded: Any = frozenset()
+) -> bool:
     """Did this operation actually achieve what it exists for?
 
     Not "did every step pass" — an operation whose steps all ran but which never
     produced its file has not reached its goal, and that distinction is the whole
     reason `kind` is recorded. For a download the evidence is a file; for
     everything else it is that no step was left blocked.
+
+    The file has to be THIS operation's. `list_downloads` reports the whole
+    session's downloads, so the annual statement operation was reporting success
+    on the monthly PDF a previous operation had fetched — the exact failure the
+    replay exists to catch, passing the replay. ``already_downloaded`` carries
+    what the operations before it had already produced.
     """
     if any(s.get("status") in (BLOCKED, NEEDS_APPROVAL) for s in steps):
         return False
     if (operation.get("kind") or "") == "download":
-        for s in steps:
-            if s.get("command") == "list_downloads":
-                data = s.get("data") or {}
-                return bool((data or {}).get("downloads"))
-        return False
+        listed = downloads_listed(steps)
+        if not listed:
+            return False
+        return any(_is_new_download(r, already_downloaded) for r in listed)
     return True
 
 
@@ -377,8 +430,15 @@ def build_report(operations: list[dict], results: list[list[dict]]) -> dict:
     needs to decide on is whether each GOAL was reached.
     """
     ops_out = []
+    # What the operations BEFORE this one already produced. Downloads are
+    # reported cumulatively for the whole session, so without this an operation
+    # inherits its predecessor's file as proof of its own success.
+    already: set[str] = set()
     for op, steps in zip(operations, results, strict=False):
-        reached = goal_reached(op, steps)
+        reached = goal_reached(op, steps, already_downloaded=already)
+        already.update(
+            str(r["id"]) for r in downloads_listed(steps) if r.get("id") is not None
+        )
         ops_out.append(
             {
                 "name": op.get("name"),

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -284,6 +284,39 @@ def replay_step(
     following: Any = None,
     unactionable_targets: set[str] | None = None,
 ) -> dict:
+    """Run one step, timing it, and stamp elapsed_ms on the result.
+
+    Wraps the real work so every one of its exits is measured, whichever branch
+    returns -- a fast-fail, an approval gate, a success, a block. `elapsed_ms` is
+    what makes "the replay felt slow" answerable: without it, where a run spends
+    its time is guesswork, and a step that fails after a full attach-plus-click
+    timeout looks identical in the report to one that failed instantly.
+    """
+    started = time.monotonic()
+    result = _replay_step_inner(
+        execute,
+        step,
+        recorded=recorded,
+        approvals=approvals,
+        known_downloads=known_downloads,
+        following=following,
+        unactionable_targets=unactionable_targets,
+    )
+    if isinstance(result, dict):
+        result["elapsed_ms"] = round((time.monotonic() - started) * 1000)
+    return result
+
+
+def _replay_step_inner(
+    execute: Any,
+    step: dict,
+    *,
+    recorded: set[str],
+    approvals: set[str] | None = None,
+    known_downloads: set[str] | None = None,
+    following: Any = None,
+    unactionable_targets: set[str] | None = None,
+) -> dict:
     """Run one step and report what happened, without ever raising.
 
     ``execute(command, params)`` performs the command and returns the worker's

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -34,6 +34,17 @@ from __future__ import annotations
 import re
 from typing import Any
 
+
+class SessionNotReadyError(RuntimeError):
+    """Tabby has no healthy session for this profile — the human must sign in.
+
+    Deliberately its own type so it can pass THROUGH replay_step rather than
+    becoming a blocked step. "The session is not signed in" is not a defect in
+    the plan, and recording it as one would blame the skill for the operator not
+    having signed in yet. The caller shows the sign-in card and replays again.
+    """
+
+
 #: Step outcomes, as rendered to the human.
 OK = "ok"
 BLOCKED = "blocked"
@@ -189,6 +200,10 @@ def replay_step(
 
     try:
         response = execute(step.get("command"), step.get("params") or {})
+    except SessionNotReadyError:
+        # Not a step failure. Let it out so the caller can ask for a sign-in
+        # instead of recording the plan as broken.
+        raise
     except Exception as exc:  # noqa: BLE001 — a blocked step is data, not a crash
         result["status"] = BLOCKED
         result["detail"] = str(exc)
@@ -266,3 +281,28 @@ def approve(report: dict) -> dict:
     approved = dict(report)
     approved["installable"] = True
     return approved
+
+
+def substitute_parameters(operation: dict, values: dict[str, str] | None = None) -> list[dict]:
+    """The operation's steps with ``{{placeholders}}`` filled in.
+
+    Replay runs the recorded defaults unless told otherwise, because that is the
+    run we have evidence for. Typing a literal "{{from_date}}" into a bank's date
+    field would fail for a reason that has nothing to do with the plan.
+    """
+    values = dict(values or {})
+    for param in operation.get("parameters") or []:
+        values.setdefault(param["name"], param.get("default", ""))
+
+    def fill(text: str) -> str:
+        for name, value in values.items():
+            text = text.replace("{{" + name + "}}", str(value))
+        return text
+
+    out: list[dict] = []
+    for step in operation.get("steps") or []:
+        params = {
+            k: (fill(v) if isinstance(v, str) else v) for k, v in (step.get("params") or {}).items()
+        }
+        out.append({**step, "params": params})
+    return out

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -496,6 +496,15 @@ def goal_reached(
     replay exists to catch, passing the replay. ``already_downloaded`` carries
     what the operations before it had already produced.
     """
+    # An operation that ran NOTHING reached no goal.
+    #
+    # Seen live: a replay that executed zero steps reported goal_reached true
+    # and all_goals_reached true, because "no step was blocked" is trivially
+    # satisfied by an empty list. That is the most misleading answer this field
+    # can give -- a report nobody would question.
+    if not steps:
+        return False
+
     # An unanswered approval is a hard stop whatever else happened: the human
     # has not agreed to the thing being asked about.
     if any(s.get("status") == NEEDS_APPROVAL for s in steps):

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -72,6 +72,57 @@ def session_is_ready(profile_slug: str, token: str) -> bool:
     return True
 
 
+def _same_page(a: str, b: str) -> bool:
+    """Same page, ignoring a trailing slash."""
+    return a.rstrip("/") == b.rstrip("/")
+
+
+def _entry_path(entry_url: str) -> str:
+    """The path part of the entry, which is what a same-app link carries."""
+    path = re.sub(r"^[a-z]+://[^/]+", "", entry_url, flags=re.I)
+    return (path.split("?")[0] or "/").rstrip("/")
+
+
+def _home_control(controls: dict, entry_url: str) -> dict | None:
+    """The app's own way back to the landing page, by where it POINTS.
+
+    Not by what it says: the control is often a logo with no text at all, and
+    matching words would need a list per language and per bank. A link whose
+    href is the entry path is the same link a person clicks, on any app.
+    """
+    want = _entry_path(entry_url)
+    if not want or want == "":
+        return None
+    for group in ("links", "buttons"):
+        for c in controls.get(group) or []:
+            if not isinstance(c, dict):
+                continue
+            href = str(c.get("href") or "")
+            sel = str(c.get("selector") or "")
+            target = href or sel
+            if want and (target.split("?")[0].rstrip("/").endswith(want)):
+                if sel:
+                    return {"command": "click_element", "params": {"selector": sel}}
+                text = str(c.get("text") or "").strip()
+                if text:
+                    return {"command": "click_by_text", "params": {"text": text}}
+    return None
+
+
+def _cannot_reset(entry_url: str, here: str, why: str) -> dict:
+    return {
+        "command": "return_to_entry",
+        "params": {"url": entry_url},
+        "status": "blocked",
+        "error": (
+            f"could not return to the start of the journey ({entry_url}): {why}. "
+            f"The browser is on {here or 'an unknown page'}, which is not where these "
+            "steps were recorded, so replaying them from here proves nothing. Sign in "
+            "again for a session that starts at the landing page."
+        ),
+    }
+
+
 def _return_to_entry(execute: Any, entry_url: str) -> dict | None:
     """Put the browser back at the start of the journey before replaying it.
 
@@ -96,27 +147,59 @@ def _return_to_entry(execute: Any, entry_url: str) -> dict | None:
         here = str((info.get("data") or info).get("url") or "")
     except SessionNotReadyError:
         raise
-    except Exception:  # noqa: BLE001 — an unreadable url just means "navigate anyway"
+    except Exception:  # noqa: BLE001 — an unreadable url just means "reset anyway"
         here = ""
 
-    if here and here.rstrip("/") == entry_url.rstrip("/"):
-        return None  # already at the start; navigating would only cost a load
+    if here and _same_page(here, entry_url):
+        return None  # already at the start; moving would only cost a load
 
+    # navigate FIRST, because on an app that allows it this is one call and
+    # lands exactly where we mean. It is not always allowed: a portal that
+    # carries its session in the URL loses it on a full page load, and the
+    # worker refuses the command outright -- which is how the first live run of
+    # this reset failed, using the one command the app forbids.
     try:
         execute("navigate", {"url": entry_url})
+        return None
     except SessionNotReadyError:
         raise
-    except Exception as exc:  # noqa: BLE001 — reported, not raised
-        return {
-            "command": "navigate",
-            "params": {"url": entry_url},
-            "status": "blocked",
-            "error": (
-                f"could not return to the start of the journey ({entry_url}): {exc}. "
-                f"The browser is on {here or 'an unknown page'}, which is not where "
-                "these steps were recorded, so replaying them from here proves nothing."
-            ),
-        }
+    except Exception as exc:  # noqa: BLE001 — may be the refusal, may be real
+        if "navigate is disabled" not in str(exc):
+            return _cannot_reset(entry_url, here, str(exc))
+
+    # Move the way a person does: the app's own link back to the landing page.
+    # Matched on where the link POINTS, not what it says, so this works on a
+    # logo with no text and in any language.
+    try:
+        summary = execute("get_page_summary", {})
+        controls = (summary.get("data") or summary) or {}
+    except SessionNotReadyError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        return _cannot_reset(entry_url, here, f"could not read the page: {exc}")
+
+    home = _home_control(controls, entry_url)
+    if home is None:
+        return _cannot_reset(
+            entry_url,
+            here,
+            "this app does not allow navigate, and no link back to the start was "
+            "found on the page",
+        )
+
+    try:
+        execute(home["command"], home["params"])
+        info = execute("get_page_info", {})
+        landed = str((info.get("data") or info).get("url") or "")
+    except SessionNotReadyError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        return _cannot_reset(entry_url, here, f"clicking the way back failed: {exc}")
+
+    if not _same_page(landed, entry_url):
+        return _cannot_reset(
+            entry_url, landed, "clicking the way back did not land on the start"
+        )
     return None
 
 

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -72,6 +72,54 @@ def session_is_ready(profile_slug: str, token: str) -> bool:
     return True
 
 
+def _return_to_entry(execute: Any, entry_url: str) -> dict | None:
+    """Put the browser back at the start of the journey before replaying it.
+
+    A replay does not get a fresh browser -- the session is deliberately kept
+    warm so the amend-and-replay loop costs no sign-ins (see the module
+    docstring). The cost of that is a browser sitting wherever the LAST run
+    abandoned it, and these operations are one recorded journey cut into pieces:
+    every one of them assumes the page its predecessor left behind, and the first
+    assumes the landing page.
+
+    Observed: a replay died mid-journey on ICICI, an amendment fixed the step it
+    died on, and the re-run began on `/credit-card/add-card` -- where the
+    already-passing early steps no longer matched anything, so the amendment
+    looked no better than what it replaced. Re-running has to mean re-running,
+    not resuming.
+
+    Returns a step-shaped dict when the reset itself failed, so the caller can
+    report it as what stopped the replay rather than blaming the first step.
+    """
+    try:
+        info = execute("get_page_info", {})
+        here = str((info.get("data") or info).get("url") or "")
+    except SessionNotReadyError:
+        raise
+    except Exception:  # noqa: BLE001 — an unreadable url just means "navigate anyway"
+        here = ""
+
+    if here and here.rstrip("/") == entry_url.rstrip("/"):
+        return None  # already at the start; navigating would only cost a load
+
+    try:
+        execute("navigate", {"url": entry_url})
+    except SessionNotReadyError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — reported, not raised
+        return {
+            "command": "navigate",
+            "params": {"url": entry_url},
+            "status": "blocked",
+            "error": (
+                f"could not return to the start of the journey ({entry_url}): {exc}. "
+                f"The browser is on {here or 'an unknown page'}, which is not where "
+                "these steps were recorded, so replaying them from here proves nothing."
+            ),
+        }
+    return None
+
+
 def run_replay(
     operations: list[dict],
     *,
@@ -80,6 +128,7 @@ def run_replay(
     approvals: set[str] | None = None,
     parameter_values: dict[str, str] | None = None,
     timeout_ms: int = 30000,
+    entry_url: str | None = None,
 ) -> dict:
     """Replay a draft and report what happened.
 
@@ -103,6 +152,20 @@ def run_replay(
     execute = _executor(profile_slug, token, timeout_ms=timeout_ms)
 
     results: list[list[dict]] = []
+    if entry_url:
+        try:
+            failed = _return_to_entry(execute, entry_url)
+        except SessionNotReadyError as exc:
+            report = build_report([], [])
+            report["status"] = "login_required"
+            report["detail"] = str(exc)
+            return report
+        if failed is not None:
+            results.append([failed])
+            report = build_report(ops[:1], results)
+            report["detail"] = failed["error"]
+            return report
+
     for op in ops:
         steps = substitute_parameters(op, parameter_values)
         step_results: list[dict] = []

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -201,9 +201,21 @@ def _left_the_app(here: str, entry_url: str, known: set[str]) -> bool:
     return _origin(here) != _origin(entry_url)
 
 
+def _page_identity(url: str) -> str:
+    """A URL reduced to the page it names.
+
+    Drops the query string and any path parameter. ICICI's statement portal
+    carries its session as `;jsessionid=...`, so the page the browser is on and
+    the page the recording named are the same page in different clothes -- and a
+    comparison that stripped only `?` decided they were different, blocking the
+    one operation that was being tested.
+    """
+    return url.split("?")[0].split(";")[0].rstrip("/")
+
+
 def _same_page(a: str, b: str) -> bool:
-    """Same page, ignoring a trailing slash."""
-    return a.rstrip("/") == b.rstrip("/")
+    """Same page, ignoring a trailing slash, a query string, or a jsessionid."""
+    return _page_identity(a) == _page_identity(b)
 
 
 def _entry_path(entry_url: str) -> str:
@@ -590,7 +602,7 @@ def run_replay(
                         info = execute("get_page_info", {})
                         here = str((info.get("data") or info).get("url") or "")
                         if not here or _same_page(
-                            here.split("?")[0], starts_from.split("?")[0]
+                            here, starts_from
                         ):
                             break
                         if time.monotonic() >= deadline:
@@ -608,7 +620,7 @@ def run_replay(
                     return report
                 except Exception:  # noqa: BLE001 — unreadable url: let the steps report
                     here = ""
-                if here and not _same_page(here.split("?")[0], starts_from.split("?")[0]):
+                if here and not _same_page(here, starts_from):
                     results.append([{
                         "command": "starts_from",
                         "params": {"url": starts_from},

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -787,6 +787,42 @@ def run_replay(
                     return report
                 except Exception:  # noqa: BLE001 — unreadable url: let the steps report
                     here = ""
+                # The page that can do the work, not the URL it was recorded at.
+                #
+                # A portal can serve the SAME screen from more than one entry
+                # URL. ICICI's statement form was recorded at /corp/Finacle and
+                # a replay arrives at /corp/AuthenticationController -- same
+                # form, both #PDF_Download and #DOWNLOAD_ESTATEMENT_PDF present,
+                # same radios, same selects. The URL check refused every time,
+                # so set_checked Annual and both select_options -- the steps
+                # that decide WHICH statement -- never ran, and the session sat
+                # on Monthly looking correct.
+                #
+                # Ask the page instead: if this operation's first step resolves
+                # here, this is the screen it was written for. That keeps the
+                # guard's whole point -- it still refuses when the controls are
+                # absent, which is the case it exists to catch -- while dropping
+                # an assumption about URLs the portal never promised.
+                if here and not _same_page(here, starts_from):
+                    first_selector = ""
+                    for candidate in steps or []:
+                        params = candidate.get("params") or {}
+                        if isinstance(params.get("selector"), str) and params["selector"]:
+                            first_selector = params["selector"]
+                            break
+                    resolves_here = False
+                    if first_selector:
+                        try:
+                            probe = execute(
+                                "wait_for_selector",
+                                {"selector": first_selector, "timeout_ms": 4000},
+                            )
+                            resolves_here = bool(probe)
+                        except Exception:  # noqa: BLE001 — absent is the answer, not an error
+                            resolves_here = False
+                    if resolves_here:
+                        here = ""
+
                 if here and not _same_page(here, starts_from):
                     results.append(
                         [
@@ -830,6 +866,10 @@ def run_replay(
                     else _ARRIVAL_BUDGET_S
                 )
                 _await_first_control(execute, steps, budget)
+            # Per OPERATION, not per run: a control hidden on one screen may be
+            # perfectly actionable on the next, so the knowledge must not outlive
+            # the page it was learned on.
+            unactionable_targets: set[str] = set()
             try:
                 for i, step in enumerate(steps):
                     result = replay_step(
@@ -838,6 +878,7 @@ def run_replay(
                         recorded=recorded,
                         approvals=approvals,
                         known_downloads=known_downloads,
+                        unactionable_targets=unactionable_targets,
                         following=steps[i + 1 :],
                     )
                     step_results.append(result)
@@ -882,6 +923,9 @@ def run_replay(
             if failed is not None:
                 results.append([failed])
                 continue
+        # Per OPERATION, as above: a control hidden on one screen may be
+        # actionable on the next.
+        unactionable_targets = set()
         try:
             for i, step in enumerate(steps):
                 result = replay_step(
@@ -890,6 +934,7 @@ def run_replay(
                     recorded=recorded,
                     approvals=approvals,
                     known_downloads=known_downloads,
+                    unactionable_targets=unactionable_targets,
                     following=steps[i + 1 :],
                 )
                 step_results.append(result)

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -241,36 +241,44 @@ proceed the instant the control appears and only give up when this elapses.
 
 
 def _await_first_control(execute: Any, steps: list[dict], budget_s: float) -> None:
-    """Wait for the arriving operation's first target, not for a fixed time.
+    """Wait for the arriving PAGE to be ready, not for a specific control.
 
-    A fixed sleep was wrong twice: 3s was too short for ICICI's statement portal
-    (the control was there when probed by hand a minute later) and long enough
-    to be dead weight on every fast page. Polling for the thing we are about to
-    click is both faster and more tolerant.
+    An earlier version polled the first step's own selector. That is wrong for
+    this whole class of app: the first control is often INTERACTION-GATED --
+    ICICI's "Credit Cards" submenu item does not exist in the DOM until a hover
+    reveals it, and its period radio and year select sit behind a styled overlay
+    that hides them. Neither `visible` nor `attached` can ever come true for such
+    a control before the step's own hover_first/force runs, so this polled its
+    full 20s budget on THREE operations of every replay -- ~90s -- on a page
+    that had reported ready in under a second. Measured: arrivals of ~30s each,
+    unchanged by switching visible->attached, because the control simply is not
+    there yet.
 
-    Only when that first step names a selector. There is no wait-by-text, and
-    guessing one would wait for the wrong element.
+    The honest precondition is that the PAGE has finished loading. The step
+    itself already waits up to 12s for its control (see wait_for_selector in
+    replay), and reveals it if gated, so there is nothing for this to add beyond
+    "the document is ready". Return the instant readyState reports complete.
+
+    Never raises: a page we cannot read is one the first step will report on.
     """
-    first = steps[0] if steps else None
-    selector = ((first or {}).get("params") or {}).get("selector")
-    if not selector:
-        time.sleep(min(_RESET_SETTLE_MS / 1000.0, budget_s))
-        return
-
     deadline = time.monotonic() + budget_s
-    while True:
+    # A short unconditional beat: a postback that has not started yet reads as
+    # ready, the same reason _wait_until_the_page_stops_moving opens with one.
+    settled_floor = min(_RESET_SETTLE_MS / 1000.0, budget_s)
+    time.sleep(settled_floor)
+    while time.monotonic() < deadline:
         try:
-            execute(
-                "wait_for_selector",
-                {"selector": selector, "state": "visible", "timeout_ms": 1500},
-            )
-            return
+            info = execute("get_page_info", {})
+            ready = str((info.get("data") or info).get("ready_state") or "")
         except SessionNotReadyError:
             raise
-        except Exception:  # noqa: BLE001 — not there yet is the normal case
-            if time.monotonic() >= deadline:
-                return  # let the step itself report what it finds
-            time.sleep(1.0)
+        except Exception:  # noqa: BLE001 — unreadable now, the step will say so
+            return
+        # Empty means the worker does not report readiness; the floor above is
+        # then all we have, which is how this behaved before readiness existed.
+        if ready in ("", "complete", "unknown"):
+            return
+        time.sleep(_STABILISE_POLL_S)
 
 
 def _settle_after_reset(operations: list[dict]) -> float:
@@ -763,20 +771,71 @@ def run_replay(
                 # the browser still on /credit-card, and the portal appeared a
                 # moment later. Checking instantly blocked the next operation on
                 # a page that was in the middle of becoming the right one.
+                # What this operation begins by acting on, and the pages the
+                # recording actually visited. Computed once, used to end the wait
+                # the instant the screen is ready instead of polling to the cap.
+                first_selector = ""
+                for candidate in steps or []:
+                    params = candidate.get("params") or {}
+                    if isinstance(params.get("selector"), str) and params["selector"]:
+                        first_selector = params["selector"]
+                        break
+                known_pages = set()
+                for other in ops:
+                    for key in ("starts_from", "url", "work_url"):
+                        value = str(other.get(key) or "").strip()
+                        if value:
+                            known_pages.add(_page_identity(value))
+
+                def _ready(
+                    here_url: str,
+                    *,
+                    starts_from: str = starts_from,
+                    first_selector: str = first_selector,
+                    known_pages: set = known_pages,
+                ) -> bool:
+                    # The recorded URL is the fast path. Otherwise: a portal can
+                    # serve one screen from more than one entry (ICICI's form
+                    # answers at both /corp/Finacle and
+                    # /corp/AuthenticationController), so accept a DIFFERENT page
+                    # only when the recording visited it AND this operation's
+                    # first control is attached there. That keeps the guard --
+                    # a predecessor that stranded us on an unrecorded page still
+                    # fails -- while ending the wait the moment the work can be
+                    # done, rather than 8s later.
+                    if _same_page(here_url, starts_from):
+                        return True
+                    if not (first_selector and _page_identity(here_url) in known_pages):
+                        return False
+                    try:
+                        return bool(
+                            execute(
+                                "wait_for_selector",
+                                {
+                                    "selector": first_selector,
+                                    "state": "attached",
+                                    "timeout_ms": 500,
+                                },
+                            )
+                        )
+                    except Exception:  # noqa: BLE001 — absent means not ready yet
+                        return False
+
                 deadline = time.monotonic() + _STARTS_FROM_WAIT_S
                 try:
                     while True:
                         info = execute("get_page_info", {})
                         here = str((info.get("data") or info).get("url") or "")
-                        if not here or _same_page(here, starts_from):
+                        # A cross-origin hop returns ok before it lands, so an
+                        # empty read is "still arriving", not "wrong page".
+                        if here and _ready(here):
+                            here = ""
                             break
                         if time.monotonic() >= deadline:
                             break
-                        # Gently. Polling twice a second across several
-                        # operations tripped the API's rate limit (HTTP 429) and
-                        # every later step failed on that instead of on
-                        # anything real -- a check for a page turning into
-                        # another page must not cost more than the wait itself.
+                        # Gently: polling twice a second across operations tripped
+                        # the API rate limit, and a check must not cost more than
+                        # the wait it guards.
                         time.sleep(_STARTS_FROM_POLL_S)
                 except SessionNotReadyError as exc:
                     report = build_report(
@@ -787,22 +846,7 @@ def run_replay(
                     return report
                 except Exception:  # noqa: BLE001 — unreadable url: let the steps report
                     here = ""
-                # The page that can do the work, not the URL it was recorded at.
-                #
-                # A portal can serve the SAME screen from more than one entry
-                # URL. ICICI's statement form was recorded at /corp/Finacle and
-                # a replay arrives at /corp/AuthenticationController -- same
-                # form, both #PDF_Download and #DOWNLOAD_ESTATEMENT_PDF present,
-                # same radios, same selects. The URL check refused every time,
-                # so set_checked Annual and both select_options -- the steps
-                # that decide WHICH statement -- never ran, and the session sat
-                # on Monthly looking correct.
-                #
-                # Ask the page instead: if this operation's first step resolves
-                # here, this is the screen it was written for. That keeps the
-                # guard's whole point -- it still refuses when the controls are
-                # absent, which is the case it exists to catch -- while dropping
-                # an assumption about URLs the portal never promised.
+
                 if here and not _same_page(here, starts_from):
                     first_selector = ""
                     for candidate in steps or []:
@@ -902,7 +946,9 @@ def run_replay(
                     )
                     step_results.append(result)
                     if result.get("status") == OK:
+                        _settle_started = time.monotonic()
                         _let_the_step_land(step, execute)
+                        result["settle_ms"] = round((time.monotonic() - _settle_started) * 1000)
             except SessionNotReadyError as exc:
                 results.append(step_results)
                 report = build_report(
@@ -958,7 +1004,9 @@ def run_replay(
                 )
                 step_results.append(result)
                 if result.get("status") == OK:
+                    _settle_started = time.monotonic()
                     _let_the_step_land(step, execute)
+                    result["settle_ms"] = round((time.monotonic() - _settle_started) * 1000)
         except SessionNotReadyError as exc:
             results.append(step_results)
             report = build_report(

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -31,6 +31,7 @@ from typing import Any
 from noui_core import tabby_client
 from noui_core.capture.split import _is_login_flow_url
 from noui_core.verify.replay import (
+    OK,
     SessionNotReadyError,
     build_report,
     plan_operations,
@@ -108,6 +109,33 @@ worked perfectly.
 Only after an actual move: a reset that found the browser already at the entry
 changed nothing, so there is nothing to wait for.
 """
+
+
+_INTER_STEP_CAP_S = 15.0
+"""Longest we pause after a step before the next one, whatever was recorded."""
+
+
+def _let_the_step_land(step: dict) -> None:
+    """Wait after acting, the way the human did, before the next step fires.
+
+    A portal processes a click server-side, and firing the next one into that
+    window is not a no-op: ICICI answered "You clicked on a link or a button
+    when your previous click was still under process. The system is considering
+    your first request." -- and kept the FIRST request. The replay had set the
+    Annual radio, pressed GO, and immediately clicked on; the bank discarded the
+    second action and stayed on Monthly.
+
+    The gap is the recorder's own settle for that step, which until now only
+    decided how long a control could take to become visible. It is equally the
+    answer to "how long did this take to be processed", because the human did
+    not act again until it was.
+
+    Capped, because some of a recorded gap is a human reading; and skipped
+    entirely when nothing was measured, so a fast page costs nothing.
+    """
+    settle = (step.get("expect") or {}).get("settle_ms")
+    if isinstance(settle, int) and settle > 0:
+        time.sleep(min(settle / 1000.0, _INTER_STEP_CAP_S))
 
 
 _ARRIVAL_BUDGET_S = 20.0
@@ -661,9 +689,12 @@ def run_replay(
                 _await_first_control(execute, steps, budget)
             try:
                 for step in steps:
-                    step_results.append(
-                        replay_step(execute, step, recorded=recorded, approvals=approvals)
+                    result = replay_step(
+                        execute, step, recorded=recorded, approvals=approvals
                     )
+                    step_results.append(result)
+                    if result.get("status") == OK:
+                        _let_the_step_land(step)
             except SessionNotReadyError as exc:
                 results.append(step_results)
                 report = build_report(ops[: len(results)], results)
@@ -701,9 +732,10 @@ def run_replay(
                 continue
         try:
             for step in steps:
-                step_results.append(
-                    replay_step(execute, step, recorded=recorded, approvals=approvals)
-                )
+                result = replay_step(execute, step, recorded=recorded, approvals=approvals)
+                step_results.append(result)
+                if result.get("status") == OK:
+                    _let_the_step_land(step)
         except SessionNotReadyError as exc:
             results.append(step_results)
             report = build_report(ops[: len(results)], results)

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -145,9 +145,24 @@ def _let_the_step_land(step: dict, execute: Any = None) -> None:
     if isinstance(settle, int) and settle > 0:
         time.sleep(min(settle / 1000.0, _INTER_STEP_CAP_S))
         return
+    # A beat first, THEN watch the page.
+    #
+    # Watching the URL alone is too weak a signal for a form postback: ICICI's
+    # statement portal re-renders in place, so two readings agree immediately and
+    # the wait collapses to nothing. Observed on screen -- the replay chose
+    # FY2025-26, the portal was still processing the previous click, and the page
+    # came back showing FY2024-25 with "Currently, we are unable to process your
+    # request". The step reported ok; the wrong year was selected.
+    #
+    # The human's own gaps on this portal were 17-29s. Three seconds is a floor,
+    # not an imitation of that, and it only applies where the recording measured
+    # nothing at all.
     if execute is not None:
         _wait_until_the_page_stops_moving(execute)
 
+
+_UNMEASURED_SETTLE_S = 3.0
+"""Minimum pause after a step the recording measured no settle for."""
 
 _STABILISE_POLL_S = 1.0
 """Gap between two readings of where the browser is."""
@@ -188,17 +203,27 @@ def _wait_until_the_page_stops_moving(execute: Any) -> None:
 
     Never raises. A page we cannot read is one the next step will report on.
     """
+    # A beat first. A postback that has not started yet looks identical to one
+    # that has finished, and both read as "stable" on the first sample.
+    time.sleep(_UNMEASURED_SETTLE_S)
+
     deadline = time.monotonic() + _STABILISE_BUDGET_S
     previous: str | None = None
     while time.monotonic() < deadline:
         try:
             info = execute("get_page_info", {})
-            here = str((info.get("data") or info).get("url") or "")
+            data = info.get("data") or info
+            here = str(data.get("url") or "")
+            ready = str(data.get("ready_state") or "")
         except SessionNotReadyError:
             raise
         except Exception:  # noqa: BLE001 — unreadable now, the step will say so
             return
-        if previous is not None and here == previous:
+        # A page still loading is not somewhere to click, whatever its URL says.
+        # Workers that do not report readiness leave this empty, and then the URL
+        # is all there is -- which is how this behaved before.
+        settled = ready in ("", "complete", "unknown")
+        if settled and previous is not None and here == previous:
             return
         previous = here
         time.sleep(_STABILISE_POLL_S)
@@ -612,7 +637,25 @@ def run_replay(
     # Files already accounted for, for the whole run. The browser reports its
     # downloads cumulatively, so without a running record every download check
     # after the first one passes on a file some earlier step fetched.
+    #
+    # Seeded from what is on disk BEFORE anything runs. A session accumulates
+    # downloads for its whole life, not just this replay, so a statement fetched
+    # by a previous run sat there looking like evidence -- and a run that
+    # downloaded nothing reported its goal reached on the strength of it.
     known_downloads: set[str] = set()
+    try:
+        listed = execute("list_downloads", {}) or {}
+        for record in ((listed.get("data") or listed) or {}).get("downloads") or []:
+            if isinstance(record, dict) and record.get("id") is not None:
+                known_downloads.add(str(record["id"]))
+    except Exception:  # noqa: BLE001 — best-effort, including "no session yet"
+        # Deliberately swallows SessionNotReadyError too. Taking a baseline must
+        # never decide whether the run happens: an amendment recorded against a
+        # skill with no live session was being lost because this probe raised
+        # before anything ran. The first real step raises it again, where the
+        # sign-in path already handles it.
+        pass
+    baseline_downloads = set(known_downloads)
 
     known = _workflow_urls(ops, entry_url or "")
     reset_notes: list = []
@@ -723,7 +766,7 @@ def run_replay(
                         # another page must not cost more than the wait itself.
                         time.sleep(_STARTS_FROM_POLL_S)
                 except SessionNotReadyError as exc:
-                    report = build_report(ops[: len(results)], results)
+                    report = build_report(ops[: len(results)], results, already_downloaded=baseline_downloads)
                     report["status"] = "login_required"
                     report["detail"] = str(exc)
                     return report
@@ -780,7 +823,7 @@ def run_replay(
                         _let_the_step_land(step, execute)
             except SessionNotReadyError as exc:
                 results.append(step_results)
-                report = build_report(ops[: len(results)], results)
+                report = build_report(ops[: len(results)], results, already_downloaded=baseline_downloads)
                 report["status"] = "login_required"
                 report["detail"] = str(exc)
                 return report
@@ -806,7 +849,7 @@ def run_replay(
                 )
             except SessionNotReadyError as exc:
                 results.append(step_results)
-                report = build_report(ops[: len(results)], results)
+                report = build_report(ops[: len(results)], results, already_downloaded=baseline_downloads)
                 report["status"] = "login_required"
                 report["detail"] = str(exc)
                 return report
@@ -825,13 +868,13 @@ def run_replay(
                     _let_the_step_land(step, execute)
         except SessionNotReadyError as exc:
             results.append(step_results)
-            report = build_report(ops[: len(results)], results)
+            report = build_report(ops[: len(results)], results, already_downloaded=baseline_downloads)
             report["status"] = "login_required"
             report["detail"] = str(exc)
             return report
         results.append(step_results)
 
-    report = build_report(ops, results)
+    report = build_report(ops, results, already_downloaded=baseline_downloads)
     if reset_notes:
         # Surfaced, not buried: a member reviewing this should see which resets
         # were taken from the live page rather than from the recording.

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -518,7 +518,13 @@ def run_replay(
     #
     # A skill compiled before segments existed has none, and runs exactly as it
     # did.
-    segmented = all(op.get("segment_steps") is not None for op in ops) and len(ops) > 1
+    # No count condition. `len(ops) > 1` was here to leave single-operation
+    # skills on the old path, and it silently undid segments the moment --only
+    # narrowed a run to one: download_statement fell back to the legacy branch,
+    # which resets before every operation, and was sent to /overview from the
+    # portal it had just reached. Carrying segments is the property that
+    # matters, not how many operations happen to be running.
+    segmented = bool(ops) and all(op.get("segment_steps") is not None for op in ops)
 
     for index, op in enumerate(ops):
         source = op if not segmented else {**op, "steps": op.get("segment_steps") or []}

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -179,6 +179,34 @@ def _cannot_reset(entry_url: str, here: str, why: str) -> dict:
     }
 
 
+def _recorded_way_back(operations: list[dict], entry_url: str) -> dict | None:
+    """A control the RECORDING watched land on this entry page.
+
+    The preferred way to reposition on a browser-driven app is a click, because
+    navigate is banned there -- a full load destroys the session. But WHICH
+    click matters: hunting the live page for something that looks like a way
+    home is a guess, while a step whose recorded outcome arrived at this exact
+    page is evidence.
+
+    Often there is none. A journey that went forward and never returned never
+    watched anyone go back, and then the caller falls through to the guess --
+    which is fine, as long as it is not mistaken for something observed.
+    """
+    want = entry_url.split("?")[0].split(";")[0].rstrip("/")
+    if not want:
+        return None
+    for op in operations or []:
+        for step in op.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            got = str(((step.get("expect") or {}).get("url")) or "")
+            if not got:
+                continue
+            if got.split("?")[0].split(";")[0].rstrip("/") == want:
+                return {"command": step.get("command"), "params": dict(step.get("params") or {})}
+    return None
+
+
 def _entry_for_origin(here: str, entry_url: str, by_origin: dict | None) -> str:
     """The entry page on the host we are ALREADY on.
 
@@ -199,6 +227,8 @@ def _return_to_entry(
     entry_url: str,
     known_urls: set[str] | None = None,
     entry_by_origin: dict | None = None,
+    operations: list[dict] | None = None,
+    notes: list | None = None,
 ) -> dict | None:
     """Put the browser back at the start of the journey before replaying it.
 
@@ -246,6 +276,24 @@ def _return_to_entry(
             f"the browser is on the sign-in flow ({here}), so there is no signed-in "
             "session to replay against"
         )
+
+    # A recorded control first: on a browser-driven app the way to reposition is
+    # a click, and a click the recording watched arrive HERE is evidence rather
+    # than a guess. Usually absent -- a journey that never went back never
+    # watched anyone go back -- in which case we fall through.
+    back = _recorded_way_back(operations or [], entry_url)
+    if back and back.get("command"):
+        try:
+            execute(back["command"], back.get("params") or {})
+            info = execute("get_page_info", {})
+            landed = str((info.get("data") or info).get("url") or "")
+            if _same_page(landed, entry_url):
+                return None
+            here = landed or here
+        except SessionNotReadyError:
+            raise
+        except Exception:  # noqa: BLE001 — recorded once is not guaranteed now
+            pass
 
     # History FIRST: same tab, same cookies, and for an in-app SPA hop a
     # client-side pop rather than a load. A recorded journey can cross origins
@@ -305,6 +353,19 @@ def _return_to_entry(
             "found on the page",
         )
 
+    # Nobody watched a human click this. It is the live page's own link back,
+    # matched on where it points -- a reasonable guess and still a guess, so it
+    # is recorded as one rather than passing as observed behaviour.
+    if notes is not None:
+        notes.append(
+            {
+                "kind": "unobserved_reset",
+                "entry_url": entry_url,
+                "control": dict(home.get("params") or {}),
+                "why": "no recorded control was seen arriving at this page, so the "
+                "way back was taken from the live page",
+            }
+        )
     try:
         execute(home["command"], home["params"])
         info = execute("get_page_info", {})
@@ -354,6 +415,7 @@ def run_replay(
     execute = _executor(profile_slug, token, timeout_ms=timeout_ms)
 
     known = _workflow_urls(ops, entry_url or "")
+    reset_notes: list = []
     results: list[list[dict]] = []
     for op in ops:
         steps = substitute_parameters(op, parameter_values)
@@ -372,7 +434,9 @@ def run_replay(
         # and does nothing when it matches.
         if entry_url:
             try:
-                failed = _return_to_entry(execute, entry_url, known, entry_by_origin)
+                failed = _return_to_entry(
+                    execute, entry_url, known, entry_by_origin, ops, reset_notes
+                )
             except SessionNotReadyError as exc:
                 results.append(step_results)
                 report = build_report(ops[: len(results)], results)
@@ -395,4 +459,9 @@ def run_replay(
             return report
         results.append(step_results)
 
-    return build_report(ops, results)
+    report = build_report(ops, results)
+    if reset_notes:
+        # Surfaced, not buried: a member reviewing this should see which resets
+        # were taken from the live page rather than from the recording.
+        report["unobserved_resets"] = reset_notes
+    return report

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -110,6 +110,50 @@ changed nothing, so there is nothing to wait for.
 """
 
 
+_ARRIVAL_BUDGET_S = 20.0
+"""Longest we will wait for an arriving page to produce its first control.
+
+From the recording: the human's own gap between the click that caused a hop and
+their next interaction was 17-29s on ICICI. That is an UPPER BOUND on when the
+page became usable -- they could not have clicked before the control existed,
+but they also spent some of it reading. So it is a ceiling, not a target: we
+proceed the instant the control appears and only give up when this elapses.
+"""
+
+
+def _await_first_control(execute: Any, steps: list[dict], budget_s: float) -> None:
+    """Wait for the arriving operation's first target, not for a fixed time.
+
+    A fixed sleep was wrong twice: 3s was too short for ICICI's statement portal
+    (the control was there when probed by hand a minute later) and long enough
+    to be dead weight on every fast page. Polling for the thing we are about to
+    click is both faster and more tolerant.
+
+    Only when that first step names a selector. There is no wait-by-text, and
+    guessing one would wait for the wrong element.
+    """
+    first = steps[0] if steps else None
+    selector = ((first or {}).get("params") or {}).get("selector")
+    if not selector:
+        time.sleep(min(_RESET_SETTLE_MS / 1000.0, budget_s))
+        return
+
+    deadline = time.monotonic() + budget_s
+    while True:
+        try:
+            execute(
+                "wait_for_selector",
+                {"selector": selector, "state": "visible", "timeout_ms": 1500},
+            )
+            return
+        except SessionNotReadyError:
+            raise
+        except Exception:  # noqa: BLE001 — not there yet is the normal case
+            if time.monotonic() >= deadline:
+                return  # let the step itself report what it finds
+            time.sleep(1.0)
+
+
 def _settle_after_reset(operations: list[dict]) -> float:
     """Seconds to wait, preferring what the recording measured.
 
@@ -563,9 +607,7 @@ def run_replay(
                 # the form was still building. Probed by hand a minute later,
                 # that control was there. The reset already learned this; an
                 # arrival needs the same courtesy.
-                prev = ops[index - 1]
-                prev_steps = (prev.get("segment_steps") if segmented else prev.get("steps")) or []
-                time.sleep(_settle_after_reset([{"steps": list(reversed(prev_steps))}]))
+                _await_first_control(execute, steps, _ARRIVAL_BUDGET_S)
             try:
                 for step in steps:
                     step_results.append(

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -329,30 +329,23 @@ def _return_to_entry(
         except Exception:  # noqa: BLE001 — recorded once is not guaranteed now
             pass
 
-    # History FIRST: same tab, same cookies, and for an in-app SPA hop a
-    # client-side pop rather than a load. A recorded journey can cross origins
-    # -- ICICI's statement portal is a different host from the net-banking SPA
-    # -- and from there nothing links back to the landing page and navigate is
-    # refused, so every operation after the first had no way home.
-    for _ in range(_MAX_BACK_STEPS):
-        try:
-            res = execute("go_back", {})
-        except SessionNotReadyError:
-            raise
-        except Exception:  # noqa: BLE001 — no history, or the app refuses it
-            break
-        data = (res.get("data") or res) or {}
-        here = str(data.get("url") or here)
-        if _same_page(here, entry_url):
-            time.sleep(_settle_after_reset(operations or []))
-            return None
-        if _left_the_app(here, entry_url, known):
-            # Overshot. Stop pressing -- every further press goes further from
-            # the app -- and let navigate or the home link try from here. The
-            # session itself is usually still valid; only the page is wrong.
-            break
-        if not data.get("moved"):
-            break  # history exhausted; walking further only wastes calls
+    # NO history walk here, deliberately.
+    #
+    # go_back looked cheap and harmless and is neither. The SPA's back stack on
+    # ICICI is [about:blank, /login-page, /overview, ...], so a press from a
+    # shallow point lands the LIVE session on the sign-in page -- which is
+    # exactly "your session has expired" from the member's side. Watched
+    # happening: the session died the moment a replay started, every time, and
+    # never while it sat idle. The overshoot guard stops the walk continuing;
+    # it cannot undo the press that already landed.
+    #
+    # It also never once got home during a real replay. The only time it worked
+    # was an isolated trace where the previous history entry happened to be the
+    # entry page. A mechanism that cannot be relied on to help and can destroy
+    # the session being tested does not belong in front of the ones that can.
+    #
+    # (The worker still exposes go_back; it is a legitimate primitive for a
+    # caller that knows where it is. Nothing here guesses with it.)
 
     # navigate NEXT, because on an app that allows it this is one call and
     # lands exactly where we mean. It is not always allowed: a portal that

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -543,6 +543,11 @@ def run_replay(
     recorded = recorded_controls(ops)
     execute = _executor(profile_slug, token, timeout_ms=timeout_ms)
 
+    # Files already accounted for, for the whole run. The browser reports its
+    # downloads cumulatively, so without a running record every download check
+    # after the first one passes on a file some earlier step fetched.
+    known_downloads: set[str] = set()
+
     known = _workflow_urls(ops, entry_url or "")
     reset_notes: list = []
     results: list[list[dict]] = []
@@ -690,7 +695,8 @@ def run_replay(
             try:
                 for step in steps:
                     result = replay_step(
-                        execute, step, recorded=recorded, approvals=approvals
+                        execute, step, recorded=recorded, approvals=approvals,
+                        known_downloads=known_downloads,
                     )
                     step_results.append(result)
                     if result.get("status") == OK:
@@ -732,7 +738,10 @@ def run_replay(
                 continue
         try:
             for step in steps:
-                result = replay_step(execute, step, recorded=recorded, approvals=approvals)
+                result = replay_step(
+                    execute, step, recorded=recorded, approvals=approvals,
+                    known_downloads=known_downloads,
+                )
                 step_results.append(result)
                 if result.get("status") == OK:
                     _let_the_step_land(step)

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -607,7 +607,18 @@ def run_replay(
                 # the form was still building. Probed by hand a minute later,
                 # that control was there. The reset already learned this; an
                 # arrival needs the same courtesy.
-                _await_first_control(execute, steps, _ARRIVAL_BUDGET_S)
+                # The budget is the human's own gap after the click that caused
+                # this arrival, buffered and capped at compile time. It sits on
+                # the operation that CAUSED the arrival, which is the one the
+                # gap was measured from. Falls back to the constant for skills
+                # compiled before that was recorded.
+                measured = (ops[index - 1] or {}).get("causes_arrival_budget_ms")
+                budget = (
+                    float(measured) / 1000.0
+                    if isinstance(measured, int) and measured > 0
+                    else _ARRIVAL_BUDGET_S
+                )
+                _await_first_control(execute, steps, budget)
             try:
                 for step in steps:
                     step_results.append(

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -810,8 +810,27 @@ def run_replay(
                         if isinstance(params.get("selector"), str) and params["selector"]:
                             first_selector = params["selector"]
                             break
+                    # Only a page the RECORDING itself visited.
+                    #
+                    # The relaxation exists for a portal that serves one screen
+                    # from two entry paths -- ICICI's statement form answers at
+                    # both /corp/Finacle and /corp/AuthenticationController -- not
+                    # for landing anywhere that happens to carry a similarly
+                    # named control. So the page we are actually on has to be one
+                    # the journey recorded: another operation's starts_from, or
+                    # its url. A predecessor that failed and left the browser
+                    # somewhere the recording never saw is still reported, never
+                    # replayed over, which is the guarantee this guard is for.
+                    known_pages = set()
+                    for other in ops:
+                        for key in ("starts_from", "url", "work_url"):
+                            value = str(other.get(key) or "").strip()
+                            if value:
+                                known_pages.add(_page_identity(value))
+                    on_a_recorded_page = _page_identity(here) in known_pages
+
                     resolves_here = False
-                    if first_selector:
+                    if first_selector and on_a_recorded_page:
                         try:
                             probe = execute(
                                 "wait_for_selector",

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -549,6 +549,23 @@ def run_replay(
                         ),
                     }])
                     continue
+                # Arrived -- now let it PAINT.
+                #
+                # Measured from the step that CAUSED the arrival -- the
+                # previous operation's last one. That is where the recorder
+                # stamped how long this page took to come up; the arriving
+                # operation's own first step describes what it does once here.
+                #
+                # The URL matches the moment the navigation resolves, while the
+                # DOM is still coming up. ICICI's statement portal is reached by
+                # a cross-origin hop that completes after the click returns, and
+                # the next operation's first step asked for #PDF_Download while
+                # the form was still building. Probed by hand a minute later,
+                # that control was there. The reset already learned this; an
+                # arrival needs the same courtesy.
+                prev = ops[index - 1]
+                prev_steps = (prev.get("segment_steps") if segmented else prev.get("steps")) or []
+                time.sleep(_settle_after_reset([{"steps": list(reversed(prev_steps))}]))
             try:
                 for step in steps:
                     step_results.append(

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -179,8 +179,26 @@ def _cannot_reset(entry_url: str, here: str, why: str) -> dict:
     }
 
 
+def _entry_for_origin(here: str, entry_url: str, by_origin: dict | None) -> str:
+    """The entry page on the host we are ALREADY on.
+
+    Resetting across hosts means inventing a route the recording never took: the
+    journey went forward only, so nothing was ever observed going back from the
+    statement portal to the net-banking landing page. Whatever host the browser
+    is on, the reset aims at the first page the recording reached there.
+    """
+    if not by_origin:
+        return entry_url
+    m = re.match(r"^[a-z]+://[^/]+", here or "", re.I)
+    origin = (m.group(0) if m else "").lower()
+    return str(by_origin.get(origin) or entry_url)
+
+
 def _return_to_entry(
-    execute: Any, entry_url: str, known_urls: set[str] | None = None
+    execute: Any,
+    entry_url: str,
+    known_urls: set[str] | None = None,
+    entry_by_origin: dict | None = None,
 ) -> dict | None:
     """Put the browser back at the start of the journey before replaying it.
 
@@ -207,6 +225,8 @@ def _return_to_entry(
         raise
     except Exception:  # noqa: BLE001 — an unreadable url just means "reset anyway"
         here = ""
+
+    entry_url = _entry_for_origin(here, entry_url, entry_by_origin)
 
     if here and _same_page(here, entry_url):
         return None  # already at the start; moving would only cost a load
@@ -310,6 +330,7 @@ def run_replay(
     parameter_values: dict[str, str] | None = None,
     timeout_ms: int = 30000,
     entry_url: str | None = None,
+    entry_by_origin: dict | None = None,
 ) -> dict:
     """Replay a draft and report what happened.
 
@@ -351,7 +372,7 @@ def run_replay(
         # and does nothing when it matches.
         if entry_url:
             try:
-                failed = _return_to_entry(execute, entry_url, known)
+                failed = _return_to_entry(execute, entry_url, known, entry_by_origin)
             except SessionNotReadyError as exc:
                 results.append(step_results)
                 report = build_report(ops[: len(results)], results)

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import re
+import time
 from typing import Any
 
 from noui_core import tabby_client
@@ -78,6 +79,38 @@ _MAX_BACK_STEPS = 8
 """How far to walk history home. Bounded: a replay that cannot find the entry
 page in eight steps is lost, and pressing back forever would eventually leave
 the app entirely."""
+
+
+_RESET_SETTLE_MS = 3000
+"""How long to let the entry page paint after a reset MOVED it.
+
+A history restore does not render instantly. The reset would land on /overview,
+return success, and the very next step would ask whether the sidebar control was
+visible -- on a page still coming up. It resolved and was not yet visible, so
+every operation after the first failed at step 0 while the reset itself had
+worked perfectly.
+
+Only after an actual move: a reset that found the browser already at the entry
+changed nothing, so there is nothing to wait for.
+"""
+
+
+def _settle_after_reset(operations: list[dict]) -> float:
+    """Seconds to wait, preferring what the recording measured.
+
+    The first step of an operation carries the settle its own page needed when
+    recorded (4.3s on the ICICI nav). That is a real measurement of this app on
+    this connection, which beats a constant -- the constant is only the floor.
+    """
+    observed = 0
+    for op in operations or []:
+        for step in op.get("steps") or []:
+            if isinstance(step, dict):
+                got = (step.get("expect") or {}).get("settle_ms")
+                if isinstance(got, int):
+                    observed = max(observed, got)
+                break
+    return min(max(observed, _RESET_SETTLE_MS), 10_000) / 1000.0
 
 
 def _origin(url: str) -> str:
@@ -288,6 +321,7 @@ def _return_to_entry(
             info = execute("get_page_info", {})
             landed = str((info.get("data") or info).get("url") or "")
             if _same_page(landed, entry_url):
+                time.sleep(_settle_after_reset(operations or []))
                 return None
             here = landed or here
         except SessionNotReadyError:
@@ -310,6 +344,7 @@ def _return_to_entry(
         data = (res.get("data") or res) or {}
         here = str(data.get("url") or here)
         if _same_page(here, entry_url):
+            time.sleep(_settle_after_reset(operations or []))
             return None
         if _left_the_app(here, entry_url, known):
             # Overshot. Stop pressing -- every further press goes further from
@@ -326,6 +361,7 @@ def _return_to_entry(
     # this reset failed, using the one command the app forbids.
     try:
         execute("navigate", {"url": entry_url})
+        time.sleep(_settle_after_reset(operations or []))
         return None
     except SessionNotReadyError:
         raise
@@ -379,6 +415,7 @@ def _return_to_entry(
         return _cannot_reset(
             entry_url, landed, "clicking the way back did not land on the start"
         )
+    time.sleep(_settle_after_reset(operations or []))
     return None
 
 

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -81,6 +81,21 @@ page in eight steps is lost, and pressing back forever would eventually leave
 the app entirely."""
 
 
+_STARTS_FROM_WAIT_S = 8.0
+"""How long to let a hop land before deciding an operation is on the wrong page.
+
+A click that causes a cross-origin navigation returns ok before the navigation
+completes -- "download previous statement" reported success with the browser
+still on /credit-card, and the statement portal appeared a moment later. The
+first version of this guard sampled once and blocked the next operation on a
+page that was in the middle of becoming the right one.
+"""
+
+_STARTS_FROM_POLL_S = 2.0
+"""Seconds between checks while waiting for a hop to land. Four samples over the
+eight-second window, not sixteen: this is watching for a navigation, not racing
+it."""
+
 _RESET_SETTLE_MS = 3000
 """How long to let the entry page paint after a reset MOVED it.
 
@@ -490,9 +505,30 @@ def run_replay(
                 # say so instead of running steps against the wrong page -- an
                 # operation that reads whatever loaded is how a skill claims to
                 # have fetched a statement it never opened.
+                # WAIT for it, do not sample it once.
+                #
+                # A click that causes a cross-origin hop returns ok before the
+                # hop lands: "download previous statement" reported success with
+                # the browser still on /credit-card, and the portal appeared a
+                # moment later. Checking instantly blocked the next operation on
+                # a page that was in the middle of becoming the right one.
+                deadline = time.monotonic() + _STARTS_FROM_WAIT_S
                 try:
-                    info = execute("get_page_info", {})
-                    here = str((info.get("data") or info).get("url") or "")
+                    while True:
+                        info = execute("get_page_info", {})
+                        here = str((info.get("data") or info).get("url") or "")
+                        if not here or _same_page(
+                            here.split("?")[0], starts_from.split("?")[0]
+                        ):
+                            break
+                        if time.monotonic() >= deadline:
+                            break
+                        # Gently. Polling twice a second across several
+                        # operations tripped the API's rate limit (HTTP 429) and
+                        # every later step failed on that instead of on
+                        # anything real -- a check for a page turning into
+                        # another page must not cost more than the wait itself.
+                        time.sleep(_STARTS_FROM_POLL_S)
                 except SessionNotReadyError as exc:
                     report = build_report(ops[: len(results)], results)
                     report["status"] = "login_required"

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -1,0 +1,122 @@
+"""Running a draft replay against a FRESH Tabby session for the profile.
+
+Replay deliberately uses the ordinary profile session — the same one an
+installed skill gets — rather than trying to inherit the recording's auth.
+
+Inheriting it was the obvious idea and it does not survive contact with real
+apps. A bank's session is not always in a cookie: ICICI's statement portal
+carries it in the URL (``AuthenticationController;jsessionid=…``), and SPAs
+routinely keep their access token in ``sessionStorage``. Seeding cookies into a
+cold browser reproduces none of that, so replay would fail for reasons that have
+nothing to do with the plan being tested.
+
+Using a real profile session costs one extra sign-in and buys three things:
+
+  - it is exactly how the skill will run once installed, so a pass means what it
+    looks like it means;
+  - it validates the PROFILE too — if its login or keepalive cannot sustain a
+    session on this app, the skill fails in production however good its steps
+    are, and that is worth learning now;
+  - keepalive holds it, so the amend-and-replay loop costs nothing after the
+    first sign-in.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from noui_core import tabby_client
+from noui_core.verify.replay import (
+    SessionNotReadyError,
+    build_report,
+    plan_operations,
+    recorded_controls,
+    replay_step,
+    substitute_parameters,
+)
+
+#: Tabby answers /execute/browser with 404/409 when there is no active profile or
+#: no healthy session. noui's HTTP client folds the status into the message.
+_NO_SESSION = re.compile(r"HTTP (404|409) from POST /execute/browser")
+
+
+def _executor(profile_slug: str, token: str, *, timeout_ms: int = 30000) -> Any:
+    def execute(command: str, params: dict) -> dict:
+        try:
+            return tabby_client.execute_browser(
+                profile_slug, command, params, token=token, timeout_ms=timeout_ms
+            )
+        except RuntimeError as exc:
+            if _NO_SESSION.search(str(exc)):
+                raise SessionNotReadyError(str(exc)) from exc
+            raise
+
+    return execute
+
+
+def session_is_ready(profile_slug: str, token: str) -> bool:
+    """Is there a signed-in session to replay against?
+
+    Probed with get_page_info, which reads nothing and changes nothing — asking
+    the question must not itself be an action against the app.
+    """
+    try:
+        _executor(profile_slug, token)("get_page_info", {})
+    except SessionNotReadyError:
+        return False
+    except RuntimeError:
+        # Reachable but unhappy (a transient worker error). Let the replay run
+        # and report per step rather than refusing to start.
+        return True
+    return True
+
+
+def run_replay(
+    operations: list[dict],
+    *,
+    profile_slug: str,
+    token: str,
+    approvals: set[str] | None = None,
+    parameter_values: dict[str, str] | None = None,
+    timeout_ms: int = 30000,
+) -> dict:
+    """Replay a draft and report what happened.
+
+    Returns the report from ``build_report``, or ``{"status": "login_required"}``
+    when there is no session to replay against — the caller shows the sign-in
+    card and calls again. Partial results are kept if the session dies mid-run:
+    the steps that already ran are still evidence, and discarding them would make
+    a timed-out session look like a plan that does nothing.
+    """
+    ops = plan_operations(operations)
+    if not ops:
+        return {
+            "operations": [],
+            "all_goals_reached": False,
+            "needs_approval": False,
+            "installable": False,
+            "detail": "no browser operations to replay",
+        }
+
+    recorded = recorded_controls(ops)
+    execute = _executor(profile_slug, token, timeout_ms=timeout_ms)
+
+    results: list[list[dict]] = []
+    for op in ops:
+        steps = substitute_parameters(op, parameter_values)
+        step_results: list[dict] = []
+        try:
+            for step in steps:
+                step_results.append(
+                    replay_step(execute, step, recorded=recorded, approvals=approvals)
+                )
+        except SessionNotReadyError as exc:
+            results.append(step_results)
+            report = build_report(ops[: len(results)], results)
+            report["status"] = "login_required"
+            report["detail"] = str(exc)
+            return report
+        results.append(step_results)
+
+    return build_report(ops, results)

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -530,7 +530,14 @@ def run_replay(
             # entry page, which is the one position the recording observed. The
             # rest continue from their predecessor, so a reset would undo it.
             starts_from = op.get("starts_from")
-            if index == 0:
+            # "Begins the journey" is a property of the operation, not its
+            # position in the list. An operation with no starts_from is the one
+            # a fresh session lands on; one WITH it continues from that page.
+            #
+            # Using the index broke as soon as --only ran a single operation:
+            # download_statement became index 0 and was sent back to /overview
+            # from the statement portal, where it had correctly just arrived.
+            if not starts_from:
                 if entry_url:
                     try:
                         # The JOURNEY's entry, not this host's.

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -491,9 +491,7 @@ def _return_to_entry(
     # turns into login_required, which is what puts a sign-in card in front of
     # them.
     known = known_urls or set()
-    on_known_page = any(
-        here.split("?")[0].split(";")[0].rstrip("/").startswith(k) for k in known
-    )
+    on_known_page = any(here.split("?")[0].split(";")[0].rstrip("/").startswith(k) for k in known)
     if here and not on_known_page and _is_login_flow_url(here):
         raise SessionNotReadyError(
             f"the browser is on the sign-in flow ({here}), so there is no signed-in "
@@ -568,8 +566,7 @@ def _return_to_entry(
         return _cannot_reset(
             entry_url,
             here,
-            "this app does not allow navigate, and no link back to the start was "
-            "found on the page",
+            "this app does not allow navigate, and no link back to the start was found on the page",
         )
 
     # Nobody watched a human click this. It is the live page's own link back,
@@ -595,9 +592,7 @@ def _return_to_entry(
         return _cannot_reset(entry_url, here, f"clicking the way back failed: {exc}")
 
     if not _same_page(landed, entry_url):
-        return _cannot_reset(
-            entry_url, landed, "clicking the way back did not land on the start"
-        )
+        return _cannot_reset(entry_url, landed, "clicking the way back did not land on the start")
     time.sleep(_settle_after_reset(operations or []))
     return None
 
@@ -737,9 +732,7 @@ def run_replay(
                         #
                         # Operation 0 is where the journey begins, and a fresh
                         # session lands there. Aim at it.
-                        failed = _return_to_entry(
-                            execute, entry_url, known, None, ops, reset_notes
-                        )
+                        failed = _return_to_entry(execute, entry_url, known, None, ops, reset_notes)
                     except SessionNotReadyError as exc:
                         report = build_report([], [])
                         report["status"] = "login_required"
@@ -775,9 +768,7 @@ def run_replay(
                     while True:
                         info = execute("get_page_info", {})
                         here = str((info.get("data") or info).get("url") or "")
-                        if not here or _same_page(
-                            here, starts_from
-                        ):
+                        if not here or _same_page(here, starts_from):
                             break
                         if time.monotonic() >= deadline:
                             break
@@ -788,24 +779,30 @@ def run_replay(
                         # another page must not cost more than the wait itself.
                         time.sleep(_STARTS_FROM_POLL_S)
                 except SessionNotReadyError as exc:
-                    report = build_report(ops[: len(results)], results, already_downloaded=baseline_downloads)
+                    report = build_report(
+                        ops[: len(results)], results, already_downloaded=baseline_downloads
+                    )
                     report["status"] = "login_required"
                     report["detail"] = str(exc)
                     return report
                 except Exception:  # noqa: BLE001 — unreadable url: let the steps report
                     here = ""
                 if here and not _same_page(here, starts_from):
-                    results.append([{
-                        "command": "starts_from",
-                        "params": {"url": starts_from},
-                        "status": "blocked",
-                        "error": (
-                            f"this operation continues from {starts_from}, but the "
-                            f"browser is on {here}. The operation before it did not "
-                            "arrive, so running these steps here would act on the "
-                            "wrong page and report whatever it found."
-                        ),
-                    }])
+                    results.append(
+                        [
+                            {
+                                "command": "starts_from",
+                                "params": {"url": starts_from},
+                                "status": "blocked",
+                                "error": (
+                                    f"this operation continues from {starts_from}, but the "
+                                    f"browser is on {here}. The operation before it did not "
+                                    "arrive, so running these steps here would act on the "
+                                    "wrong page and report whatever it found."
+                                ),
+                            }
+                        ]
+                    )
                     continue
                 # Arrived -- now let it PAINT.
                 #
@@ -836,7 +833,10 @@ def run_replay(
             try:
                 for i, step in enumerate(steps):
                     result = replay_step(
-                        execute, step, recorded=recorded, approvals=approvals,
+                        execute,
+                        step,
+                        recorded=recorded,
+                        approvals=approvals,
                         known_downloads=known_downloads,
                         following=steps[i + 1 :],
                     )
@@ -845,7 +845,9 @@ def run_replay(
                         _let_the_step_land(step, execute)
             except SessionNotReadyError as exc:
                 results.append(step_results)
-                report = build_report(ops[: len(results)], results, already_downloaded=baseline_downloads)
+                report = build_report(
+                    ops[: len(results)], results, already_downloaded=baseline_downloads
+                )
                 report["status"] = "login_required"
                 report["detail"] = str(exc)
                 return report
@@ -871,7 +873,9 @@ def run_replay(
                 )
             except SessionNotReadyError as exc:
                 results.append(step_results)
-                report = build_report(ops[: len(results)], results, already_downloaded=baseline_downloads)
+                report = build_report(
+                    ops[: len(results)], results, already_downloaded=baseline_downloads
+                )
                 report["status"] = "login_required"
                 report["detail"] = str(exc)
                 return report
@@ -881,7 +885,10 @@ def run_replay(
         try:
             for i, step in enumerate(steps):
                 result = replay_step(
-                    execute, step, recorded=recorded, approvals=approvals,
+                    execute,
+                    step,
+                    recorded=recorded,
+                    approvals=approvals,
                     known_downloads=known_downloads,
                     following=steps[i + 1 :],
                 )
@@ -890,7 +897,9 @@ def run_replay(
                     _let_the_step_land(step, execute)
         except SessionNotReadyError as exc:
             results.append(step_results)
-            report = build_report(ops[: len(results)], results, already_downloaded=baseline_downloads)
+            report = build_report(
+                ops[: len(results)], results, already_downloaded=baseline_downloads
+            )
             report["status"] = "login_required"
             report["detail"] = str(exc)
             return report

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -115,7 +115,7 @@ _INTER_STEP_CAP_S = 15.0
 """Longest we pause after a step before the next one, whatever was recorded."""
 
 
-def _let_the_step_land(step: dict) -> None:
+def _let_the_step_land(step: dict, execute: Any = None) -> None:
     """Wait after acting, the way the human did, before the next step fires.
 
     A portal processes a click server-side, and firing the next one into that
@@ -130,12 +130,78 @@ def _let_the_step_land(step: dict) -> None:
     answer to "how long did this take to be processed", because the human did
     not act again until it was.
 
-    Capped, because some of a recorded gap is a human reading; and skipped
-    entirely when nothing was measured, so a fast page costs nothing.
+    Capped, because some of a recorded gap is a human reading.
+
+    When the recording measured NOTHING, watch the live page instead. ICICI's
+    statement portal reports an empty outcome for every click on it --
+    `navigated: false, to_url: null, settled_ms: null` -- because the hop is
+    cross-origin and completes after the click returns, so there is no recorded
+    gap to honour for ANY step there, `set_checked` included. Selecting the
+    Annual radio navigates; the replay could not know that and fired the next
+    step into a page mid-load, which this portal treats as a double click and
+    answers by expiring the session.
     """
     settle = (step.get("expect") or {}).get("settle_ms")
     if isinstance(settle, int) and settle > 0:
         time.sleep(min(settle / 1000.0, _INTER_STEP_CAP_S))
+        return
+    if execute is not None:
+        _wait_until_the_page_stops_moving(execute)
+
+
+_STABILISE_POLL_S = 1.0
+"""Gap between two readings of where the browser is."""
+
+_STABILISE_BUDGET_S = 10.0
+"""Longest we watch for a page to stop moving before proceeding anyway.
+
+Proceeding is right on expiry: the step itself waits for its own control and
+reports what it finds, which is a better error than a timeout here."""
+
+
+def _starts_from_for(op: dict, values: Any) -> Any:
+    """Where THIS variant of an operation begins.
+
+    A folded operation has one `starts_from` inherited from the first variant,
+    but the variants need not share a page: ICICI produces the monthly statement
+    on /corp/AuthenticationController, and choosing Annual navigates to
+    /corp/Finacle. The annual variant therefore carried the monthly page as its
+    precondition, and its guard refused it while standing on exactly the page it
+    was supposed to run on.
+    """
+    spec = op.get("starts_from_by")
+    if isinstance(spec, dict):
+        chosen = str((values or {}).get(spec.get("param"), "") or "")
+        url = (spec.get("by") or {}).get(chosen)
+        if url:
+            return url
+    return op.get("starts_from")
+
+
+def _wait_until_the_page_stops_moving(execute: Any) -> None:
+    """Return once two consecutive readings agree on where the browser is.
+
+    The cheapest honest definition of "the click has been processed" when the
+    recording says nothing: the URL has stopped changing. A portal that answers
+    a click with a server round trip and a new page shows a different URL on the
+    second reading, so this waits exactly as long as that takes and no longer.
+
+    Never raises. A page we cannot read is one the next step will report on.
+    """
+    deadline = time.monotonic() + _STABILISE_BUDGET_S
+    previous: str | None = None
+    while time.monotonic() < deadline:
+        try:
+            info = execute("get_page_info", {})
+            here = str((info.get("data") or info).get("url") or "")
+        except SessionNotReadyError:
+            raise
+        except Exception:  # noqa: BLE001 — unreadable now, the step will say so
+            return
+        if previous is not None and here == previous:
+            return
+        previous = here
+        time.sleep(_STABILISE_POLL_S)
 
 
 _ARRIVAL_BUDGET_S = 20.0
@@ -580,7 +646,7 @@ def run_replay(
             # Only the first operation may reset: a fresh session lands on the
             # entry page, which is the one position the recording observed. The
             # rest continue from their predecessor, so a reset would undo it.
-            starts_from = op.get("starts_from")
+            starts_from = _starts_from_for(op, parameter_values)
             # "Begins the journey" is a property of the operation, not its
             # position in the list. An operation with no starts_from is the one
             # a fresh session lands on; one WITH it continues from that page.
@@ -693,14 +759,15 @@ def run_replay(
                 )
                 _await_first_control(execute, steps, budget)
             try:
-                for step in steps:
+                for i, step in enumerate(steps):
                     result = replay_step(
                         execute, step, recorded=recorded, approvals=approvals,
                         known_downloads=known_downloads,
+                        following=steps[i + 1 :],
                     )
                     step_results.append(result)
                     if result.get("status") == OK:
-                        _let_the_step_land(step)
+                        _let_the_step_land(step, execute)
             except SessionNotReadyError as exc:
                 results.append(step_results)
                 report = build_report(ops[: len(results)], results)
@@ -737,14 +804,15 @@ def run_replay(
                 results.append([failed])
                 continue
         try:
-            for step in steps:
+            for i, step in enumerate(steps):
                 result = replay_step(
                     execute, step, recorded=recorded, approvals=approvals,
                     known_downloads=known_downloads,
+                    following=steps[i + 1 :],
                 )
                 step_results.append(result)
                 if result.get("status") == OK:
-                    _let_the_step_land(step)
+                    _let_the_step_land(step, execute)
         except SessionNotReadyError as exc:
             results.append(step_results)
             report = build_report(ops[: len(results)], results)

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -447,9 +447,86 @@ def run_replay(
     known = _workflow_urls(ops, entry_url or "")
     reset_notes: list = []
     results: list[list[dict]] = []
-    for op in ops:
-        steps = substitute_parameters(op, parameter_values)
+    # Segments: run the recorded journey ONCE, in order, each operation
+    # continuing where the last one ended.
+    #
+    # `steps` repeats the whole chain from the entry page into every operation,
+    # so replaying operation 2 demands being back somewhere the recording left
+    # once and never returned to -- and the reset had to invent a route there.
+    # Watched failing: operations 2-5 reported "could not return to the start of
+    # the journey" while the browser sat on /credit-card with the next recorded
+    # click visible on screen.
+    #
+    # A skill compiled before segments existed has none, and runs exactly as it
+    # did.
+    segmented = all(op.get("segment_steps") is not None for op in ops) and len(ops) > 1
+
+    for index, op in enumerate(ops):
+        source = op if not segmented else {**op, "steps": op.get("segment_steps") or []}
+        steps = substitute_parameters(source, parameter_values)
         step_results: list[dict] = []
+
+        if segmented:
+            # Only the first operation may reset: a fresh session lands on the
+            # entry page, which is the one position the recording observed. The
+            # rest continue from their predecessor, so a reset would undo it.
+            starts_from = op.get("starts_from")
+            if index == 0:
+                if entry_url:
+                    try:
+                        failed = _return_to_entry(
+                            execute, entry_url, known, entry_by_origin, ops, reset_notes
+                        )
+                    except SessionNotReadyError as exc:
+                        report = build_report([], [])
+                        report["status"] = "login_required"
+                        report["detail"] = str(exc)
+                        return report
+                    if failed is not None:
+                        results.append([failed])
+                        continue
+            elif starts_from:
+                # The predecessor was supposed to leave us here. When it did not,
+                # say so instead of running steps against the wrong page -- an
+                # operation that reads whatever loaded is how a skill claims to
+                # have fetched a statement it never opened.
+                try:
+                    info = execute("get_page_info", {})
+                    here = str((info.get("data") or info).get("url") or "")
+                except SessionNotReadyError as exc:
+                    report = build_report(ops[: len(results)], results)
+                    report["status"] = "login_required"
+                    report["detail"] = str(exc)
+                    return report
+                except Exception:  # noqa: BLE001 — unreadable url: let the steps report
+                    here = ""
+                if here and not _same_page(here.split("?")[0], starts_from.split("?")[0]):
+                    results.append([{
+                        "command": "starts_from",
+                        "params": {"url": starts_from},
+                        "status": "blocked",
+                        "error": (
+                            f"this operation continues from {starts_from}, but the "
+                            f"browser is on {here}. The operation before it did not "
+                            "arrive, so running these steps here would act on the "
+                            "wrong page and report whatever it found."
+                        ),
+                    }])
+                    continue
+            try:
+                for step in steps:
+                    step_results.append(
+                        replay_step(execute, step, recorded=recorded, approvals=approvals)
+                    )
+            except SessionNotReadyError as exc:
+                results.append(step_results)
+                report = build_report(ops[: len(results)], results)
+                report["status"] = "login_required"
+                report["detail"] = str(exc)
+                return report
+            results.append(step_results)
+            continue
+
         # Before EVERY operation, not once per replay.
         #
         # Each operation carries the whole chain from the entry page -- they are

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -678,7 +678,29 @@ def run_replay(
     # which resets before every operation, and was sent to /overview from the
     # portal it had just reached. Carrying segments is the property that
     # matters, not how many operations happen to be running.
-    segmented = bool(ops) and all(op.get("segment_steps") is not None for op in ops)
+    # Segments are all-or-nothing, and a MIXTURE is a compile fault -- say so
+    # rather than quietly running a different model.
+    #
+    # `all(...)` meant one operation without a segment silently downgraded the
+    # entire replay to the legacy path, which resets before every operation.
+    # Seen live: a stray `read_overview` with no segment turned a five-operation
+    # segmented run into one operation that executed nothing and reported every
+    # goal reached. Nothing in the report said the model had changed.
+    with_segments = [op for op in ops if op.get("segment_steps") is not None]
+    if ops and 0 < len(with_segments) < len(ops):
+        missing = [op.get("name") for op in ops if op.get("segment_steps") is None]
+        report = build_report([], [])
+        report["status"] = "not_replayable"
+        report["detail"] = (
+            "These operations carry no segment while the others do: "
+            f"{', '.join(str(m) for m in missing)}. Segments decide how the whole "
+            "replay executes, so a mixture would silently run every operation the "
+            "old way -- resetting to the entry page before each one. Recompile the "
+            "skill; do not replay this."
+        )
+        return report
+
+    segmented = bool(ops) and len(with_segments) == len(ops)
 
     for index, op in enumerate(ops):
         source = op if not segmented else {**op, "steps": op.get("segment_steps") or []}

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -23,6 +23,7 @@ Using a real profile session costs one extra sign-in and buys three things:
 
 from __future__ import annotations
 
+import json
 import re
 from typing import Any
 
@@ -110,6 +111,25 @@ def _home_control(controls: dict, entry_url: str) -> dict | None:
     return None
 
 
+def _workflow_urls(ops: list[dict], entry_url: str) -> set[str]:
+    """Pages the RECORDING visited, from the plan's own arrival expectations.
+
+    A word list cannot tell a sign-in page from an app page: ICICI's statement
+    portal is served by a controller literally named AuthenticationController,
+    so "auth" in the path flagged a signed-in session as signed out and refused
+    to replay against it. What the recording actually visited is not a guess.
+    """
+    # Every URL the plan mentions, not only arrival expectations: the deeper
+    # hops of an SPA are often not recorded as navigations at all, so ICICI's
+    # statement portal appeared in no expect.url and the page the replay had
+    # just legitimately reached was still read as a sign-in screen. The
+    # operation descriptions name it ("Read the rendered contents of ..."), and
+    # anything the compiler wrote into the plan came from the recording.
+    urls = {entry_url} if entry_url else set()
+    urls.update(re.findall(r"https?://[^\s\"'\\]+", json.dumps(ops or [])))
+    return {u.split("?")[0].split(";")[0].rstrip("/") for u in urls if u}
+
+
 def _cannot_reset(entry_url: str, here: str, why: str) -> dict:
     return {
         "command": "return_to_entry",
@@ -124,7 +144,9 @@ def _cannot_reset(entry_url: str, here: str, why: str) -> dict:
     }
 
 
-def _return_to_entry(execute: Any, entry_url: str) -> dict | None:
+def _return_to_entry(
+    execute: Any, entry_url: str, known_urls: set[str] | None = None
+) -> dict | None:
     """Put the browser back at the start of the journey before replaying it.
 
     A replay does not get a fresh browser -- the session is deliberately kept
@@ -160,7 +182,11 @@ def _return_to_entry(execute: Any, entry_url: str) -> dict | None:
     # where the real answer is "sign in". SessionNotReadyError is what run_replay
     # turns into login_required, which is what puts a sign-in card in front of
     # them.
-    if here and _is_login_flow_url(here):
+    known = known_urls or set()
+    on_known_page = any(
+        here.split("?")[0].split(";")[0].rstrip("/").startswith(k) for k in known
+    )
+    if here and not on_known_page and _is_login_flow_url(here):
         raise SessionNotReadyError(
             f"the browser is on the sign-in flow ({here}), so there is no signed-in "
             "session to replay against"
@@ -247,24 +273,35 @@ def run_replay(
     recorded = recorded_controls(ops)
     execute = _executor(profile_slug, token, timeout_ms=timeout_ms)
 
+    known = _workflow_urls(ops, entry_url or "")
     results: list[list[dict]] = []
-    if entry_url:
-        try:
-            failed = _return_to_entry(execute, entry_url)
-        except SessionNotReadyError as exc:
-            report = build_report([], [])
-            report["status"] = "login_required"
-            report["detail"] = str(exc)
-            return report
-        if failed is not None:
-            results.append([failed])
-            report = build_report(ops[:1], results)
-            report["detail"] = failed["error"]
-            return report
-
     for op in ops:
         steps = substitute_parameters(op, parameter_values)
         step_results: list[dict] = []
+        # Before EVERY operation, not once per replay.
+        #
+        # Each operation carries the whole chain from the entry page -- they are
+        # one recorded journey cut into pieces, and every piece starts by walking
+        # the nav again. So an operation leaves the browser wherever it ended,
+        # and the next one opens by hovering a menu that only exists on the
+        # landing page. Observed: two ICICI operations passed, the second ended
+        # on the statement page, and the third timed out hovering a nav that was
+        # no longer on screen.
+        #
+        # Cheap when it is already there: _return_to_entry reads the URL first
+        # and does nothing when it matches.
+        if entry_url:
+            try:
+                failed = _return_to_entry(execute, entry_url, known)
+            except SessionNotReadyError as exc:
+                results.append(step_results)
+                report = build_report(ops[: len(results)], results)
+                report["status"] = "login_required"
+                report["detail"] = str(exc)
+                return report
+            if failed is not None:
+                results.append([failed])
+                continue
         try:
             for step in steps:
                 step_results.append(

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -27,6 +27,7 @@ import re
 from typing import Any
 
 from noui_core import tabby_client
+from noui_core.capture.split import _is_login_flow_url
 from noui_core.verify.replay import (
     SessionNotReadyError,
     build_report,
@@ -152,6 +153,18 @@ def _return_to_entry(execute: Any, entry_url: str) -> dict | None:
 
     if here and _same_page(here, entry_url):
         return None  # already at the start; moving would only cost a load
+
+    # Sitting on the sign-in flow is not a broken skill and not a page we can
+    # find our way off: a login screen has no link to the landing page, so the
+    # reset would report "no way back" and the member would read a plan failure
+    # where the real answer is "sign in". SessionNotReadyError is what run_replay
+    # turns into login_required, which is what puts a sign-in card in front of
+    # them.
+    if here and _is_login_flow_url(here):
+        raise SessionNotReadyError(
+            f"the browser is on the sign-in flow ({here}), so there is no signed-in "
+            "session to replay against"
+        )
 
     # navigate FIRST, because on an app that allows it this is one call and
     # lands exactly where we mean. It is not always allowed: a portal that

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -683,6 +683,16 @@ def run_replay(
                     if failed is not None:
                         results.append([failed])
                         continue
+                # Let the entry page finish arriving before acting on it.
+                #
+                # Nothing precedes the first step, so nothing waited for the
+                # page -- and the first thing this replay does is open a hover
+                # menu, whose item does not exist until the nav has rendered. On
+                # a freshly loaded /overview that was a coin flip: the run failed
+                # at step 0 roughly half the time and passed on an immediate
+                # retry with nothing changed. A retry that fixes it is a wait
+                # that was missing.
+                _wait_until_the_page_stops_moving(execute)
             elif starts_from:
                 # The predecessor was supposed to leave us here. When it did not,
                 # say so instead of running steps against the wrong page -- an

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -74,6 +74,12 @@ def session_is_ready(profile_slug: str, token: str) -> bool:
     return True
 
 
+_MAX_BACK_STEPS = 8
+"""How far to walk history home. Bounded: a replay that cannot find the entry
+page in eight steps is lost, and pressing back forever would eventually leave
+the app entirely."""
+
+
 def _same_page(a: str, b: str) -> bool:
     """Same page, ignoring a trailing slash."""
     return a.rstrip("/") == b.rstrip("/")
@@ -192,7 +198,26 @@ def _return_to_entry(
             "session to replay against"
         )
 
-    # navigate FIRST, because on an app that allows it this is one call and
+    # History FIRST: same tab, same cookies, and for an in-app SPA hop a
+    # client-side pop rather than a load. A recorded journey can cross origins
+    # -- ICICI's statement portal is a different host from the net-banking SPA
+    # -- and from there nothing links back to the landing page and navigate is
+    # refused, so every operation after the first had no way home.
+    for _ in range(_MAX_BACK_STEPS):
+        try:
+            res = execute("go_back", {})
+        except SessionNotReadyError:
+            raise
+        except Exception:  # noqa: BLE001 — no history, or the app refuses it
+            break
+        data = (res.get("data") or res) or {}
+        here = str(data.get("url") or here)
+        if _same_page(here, entry_url):
+            return None
+        if not data.get("moved"):
+            break  # history exhausted; walking further only wastes calls
+
+    # navigate NEXT, because on an app that allows it this is one call and
     # lands exactly where we mean. It is not always allowed: a portal that
     # carries its session in the URL loses it on a full page load, and the
     # worker refuses the command outright -- which is how the first live run of

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -533,8 +533,23 @@ def run_replay(
             if index == 0:
                 if entry_url:
                     try:
+                        # The JOURNEY's entry, not this host's.
+                        #
+                        # Per-origin is right for an operation that starts
+                        # mid-journey -- never invent a cross-host route the
+                        # recording did not take. It is wrong for the first one:
+                        # a replay that ended on the statement portal leaves the
+                        # browser there, "home" then resolves to the portal's own
+                        # entry, the reset does nothing, and operation 0 runs its
+                        # net-banking steps against the wrong host. That is what
+                        # made runs alternate pass/fail with no change between:
+                        # a passing run ends on the portal, so the next one
+                        # starts there and cannot get back.
+                        #
+                        # Operation 0 is where the journey begins, and a fresh
+                        # session lands there. Aim at it.
                         failed = _return_to_entry(
-                            execute, entry_url, known, entry_by_origin, ops, reset_notes
+                            execute, entry_url, known, None, ops, reset_notes
                         )
                     except SessionNotReadyError as exc:
                         report = build_report([], [])

--- a/skills/noui/noui_core/verify/session.py
+++ b/skills/noui/noui_core/verify/session.py
@@ -80,6 +80,35 @@ page in eight steps is lost, and pressing back forever would eventually leave
 the app entirely."""
 
 
+def _origin(url: str) -> str:
+    m = re.match(r"^[a-z]+://[^/]+", url or "", re.I)
+    return (m.group(0) if m else "").lower()
+
+
+def _left_the_app(here: str, entry_url: str, known: set[str]) -> bool:
+    """Has walking back taken us somewhere the journey never was?
+
+    History does not stop at the landing page. On ICICI the stack below
+    /overview is [about:blank, /login-page, /overview, ...], so one press too
+    many lands on the SIGN-IN PAGE of a session that is still perfectly valid --
+    which looks exactly like being logged out, and was very likely read as that.
+    Pressing on from there reaches about:blank and abandons the app entirely.
+    """
+    if not here or here == "about:blank":
+        return True
+    # Known pages FIRST. The statement portal is part of the journey, on another
+    # host, and served by a controller named AuthenticationController -- so the
+    # login-word test below calls it a sign-in page and would stop the walk at
+    # the very page it needs to walk back from. Same precedence trap as the
+    # sign-in detector.
+    bare = here.split("?")[0].split(";")[0].rstrip("/")
+    if any(bare.startswith(k) for k in known):
+        return False
+    if _is_login_flow_url(here):
+        return True
+    return _origin(here) != _origin(entry_url)
+
+
 def _same_page(a: str, b: str) -> bool:
     """Same page, ignoring a trailing slash."""
     return a.rstrip("/") == b.rstrip("/")
@@ -214,6 +243,11 @@ def _return_to_entry(
         here = str(data.get("url") or here)
         if _same_page(here, entry_url):
             return None
+        if _left_the_app(here, entry_url, known):
+            # Overshot. Stop pressing -- every further press goes further from
+            # the app -- and let navigate or the home link try from here. The
+            # session itself is usually still valid; only the page is wrong.
+            break
         if not data.get("moved"):
             break  # history exhausted; walking further only wastes calls
 

--- a/skills/noui/references/pillar-1-capture.md
+++ b/skills/noui/references/pillar-1-capture.md
@@ -1,6 +1,19 @@
 # Pillar 1 — Capture
 
-Record a login or workflow as a **bundle** = `{har, click_events, url_events}` (HAR with response bodies). Capture runs **server-side inside Tabby's worker** — NoUI never touches the page.
+Record a login or workflow as a **bundle** = `{har, click_events, url_events, cookies}`. Capture runs **server-side inside Tabby's worker** — NoUI never touches the page.
+
+Workflow recordings from Tabby `schema_version >= 5` carry considerably more, and the browser compiler depends on all of it:
+
+| Field | What it is | Why it matters |
+|---|---|---|
+| `click_events[].candidates` | Ranked ways to address the element, each with `match_count` — how many nodes it matched **at record time** | A candidate matching several nodes cannot identify that element. This is what turns ambiguity into a compile-time fact instead of a production misclick. |
+| `click_events[].element` | Role, accessible name, visibility, occlusion, bounding box | Occlusion is the overlay-swallows-the-click problem, answered at the only moment it is knowable. |
+| `click_events[].outcome` | What the interaction caused: navigation and where, requests fired, settle time, download started | Causality is recorded rather than inferred from timestamps, and it becomes each step's postcondition. |
+| `download_events` | Files that arrived, with name and origin page | A `blob:` download never touches the network, so HAR cannot see it. For most browser skills this is the success condition. |
+| `url_events[].page_id` | Which document a transition happened in (`0` = the page the human started on) | Bank portals open statements in a new tab; without this the human's clicks there are invisible. |
+| `schema_version` | Capture-format revision | Absent means a pre-`seq` bundle. Detect fields per event rather than dispatching on this — a bundle can lose fields in transit. |
+
+**HAR content depends on the skill kind.** A `browser_driven` workflow recording reduces the HAR to metadata — method, path, status, timing; no bodies, headers or query strings — because a browser skill never replays a request and a bank portal's payloads have no business sitting in a bundle. Login recordings and non-browser workflow recordings keep the full HAR, which is what the replay compiler needs.
 
 ## Two modes
 

--- a/skills/noui/scripts/activate_install.py
+++ b/skills/noui/scripts/activate_install.py
@@ -15,6 +15,7 @@ import sys
 import _bootstrap  # noqa: F401
 
 from noui_core.activate.install import SKILL_AGENTS, install_skill, uninstall_skill
+from noui_core.verify.gate import NotApprovedError, check_installable
 
 
 def main() -> int:
@@ -23,6 +24,14 @@ def main() -> int:
     p.add_argument("agent", choices=SKILL_AGENTS)
     p.add_argument("--project", action="store_true", help="project-scoped install path")
     p.add_argument("--uninstall", action="store_true", help="remove instead of install")
+    p.add_argument(
+        "--skip-replay-gate",
+        action="store_true",
+        help="install a browser skill without an approved replay. For recovering a "
+        "known-good skill, not for shipping a new one: a browser skill that has "
+        "never been run against the live app is exactly the kind that looks "
+        "correct in review and fails in production.",
+    )
     args = p.parse_args()
 
     try:
@@ -30,9 +39,17 @@ def main() -> int:
             removed = uninstall_skill(args.skill_dir, args.agent, project=args.project)
             print("removed" if removed else "nothing to remove")
             return 0
+        # A browser skill installs only after a human approved its replay. The
+        # check is here rather than in the caller so no path -- an agent in a
+        # hurry, a script, a retry -- can install one that was never run.
+        if not args.skip_replay_gate:
+            check_installable(args.skill_dir)
         dest = install_skill(args.skill_dir, args.agent, project=args.project)
         print(f"installed → {dest}")
         return 0
+    except NotApprovedError as exc:
+        print(f"Refusing to install: {exc}", file=sys.stderr)
+        return 2
     except (RuntimeError, ValueError) as exc:
         print(f"Install failed: {exc}", file=sys.stderr)
         return 1

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -27,7 +27,7 @@ from noui_core.activate import register
 from noui_core.capture import ledger, recording
 from noui_core.capture.bundle import save_bundle
 from noui_core.capture.classify import COMBINED, LOGIN, WORKFLOW
-from noui_core.capture.split import split_bundle
+from noui_core.capture.split import split_diagnosis, split_bundle
 from noui_core.compile.login import compile_login_bundle
 from noui_core.compile.workflow import compile_workflow_bundle
 
@@ -177,6 +177,10 @@ def _run_combined(args: argparse.Namespace, bundle: dict) -> int:
     Falls back to workflow-only when the capture has no login segment.
     """
     parts = split_bundle(bundle)
+    # Always say what the splitter saw. The decision turns on one thing and used
+    # to be invisible, so a member who HAD recorded a login was asked to record
+    # it again with nothing anywhere explaining why.
+    print(split_diagnosis(bundle), file=sys.stderr)
     if parts is None:
         print(
             "No login segment detected — compiling workflow-only. Pass --profile-slug "

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -149,7 +149,8 @@ def _report_workflow(result: dict, args: argparse.Namespace) -> int:
     # this is the recommendation surfaced to a user authoring a skill in the
     # harness, so browser mode is never picked silently.
     _report_kind(result, skill, declared=bool(getattr(args, "browser_driven", False)))
-    _apply_folds(skill, getattr(args, "fold", []) or []) or _report_folds(skill)
+    if not _apply_folds(skill, getattr(args, "fold", []) or []):
+        _report_folds(skill)
     if args.auth_type == "api-key":
         secrets = (skill.get("secrets_required") if skill else None) or (
             mcp.get("secrets_required") if mcp else None

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -272,13 +272,27 @@ def _run_combined(args: argparse.Namespace, bundle: dict) -> int:
         return 1
     try:
         prov = register.register_login(compiled, tenant_id=_default_tenant(args.tenant_id))
+        profile_slug = prov.get("profile_id", "")
+        print(f"Registered login App Template → profile slug '{profile_slug}'.", file=sys.stderr)
     except RuntimeError as exc:
-        print(f"Login register failed: {exc}", file=sys.stderr)
-        print(json.dumps({"compiled": compiled.get("service_profile_draft", {})}, indent=2))
-        return 1
-
-    profile_slug = prov.get("profile_id", "")
-    print(f"Registered login App Template → profile slug '{profile_slug}'.", file=sys.stderr)
+        # An App Template that already exists is not a failure -- it is the
+        # SECOND import of the same recording, which is what re-compiling after
+        # a compiler fix looks like. Failing here left operations.json stale at
+        # the previous compile while the run reported an error about the login
+        # half, so the fix appeared not to have worked.
+        if "409" not in str(exc) and "already exists" not in str(exc).lower():
+            print(f"Login register failed: {exc}", file=sys.stderr)
+            print(json.dumps({"compiled": compiled.get("service_profile_draft", {})}, indent=2))
+            return 1
+        profile_slug = (compiled.get("service_profile_draft") or {}).get("profile_id", "") or (
+            args.profile_slug or ""
+        )
+        print(
+            f"Login App Template '{profile_slug}' already exists — keeping it and "
+            "compiling the workflow half. The login was recorded once; re-registering "
+            "it would only overwrite a profile that is already serving sessions.",
+            file=sys.stderr,
+        )
 
     # The login compile ran on the login SLICE (not the workflow hosts), so its
     # target_urls won't cover the workflow's hosts — passing its declared headers

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -419,6 +419,22 @@ def main() -> int:
     bundle_path = save_bundle(bundle, args.name or args.session_id)
     print(f"Saved capture bundle → {bundle_path}", file=sys.stderr)
 
+    # The kind travels with the recording, not with this command line.
+    #
+    # capture_record took --browser-driven, provisioned with it and never wrote
+    # it down, so the decision had to be repeated here. Forget it -- easily
+    # done, since nothing in the recording says so -- and an app that must be
+    # driven compiles to replayed API calls instead: an ICICI capture asked for
+    # as a BROWSER BASED skill shipped as two Finacle POSTs.
+    if not getattr(args, "browser_driven", False) and ledger.declared_browser_driven(
+        args.session_id
+    ):
+        args.browser_driven = True
+        print(
+            "browser-driven: carried from the recording (it was provisioned that way).",
+            file=sys.stderr,
+        )
+
     mode, source = _resolve_mode(args, inferred)
     _report_mode(mode, source, inferred, bundle)
 

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -95,6 +95,49 @@ def _default_tenant(tenant_id: str) -> str:
     return auth.tenant_id_from_token(recording.resolve_agent_token())
 
 
+def _report_kind(result: dict, skill: dict | None, *, declared: bool) -> None:
+    """Say which KIND was compiled, why, and ask when nobody chose it.
+
+    This used to speak only when browser mode was auto-selected, so choosing
+    REPLAY was silent -- and an ICICI capture asked for as a browser skill
+    compiled to two Finacle POSTs with nothing anywhere saying a decision had
+    been taken. A default is fine; a default nobody is told about is not.
+
+    Auto-detection remains the default answer. What changes is that the answer
+    is stated, with its basis, and when the member never said which kind they
+    wanted the agent is told to confirm before installing -- the kind decides
+    whether the skill drives the page or replays requests, and changing it means
+    compiling again.
+    """
+    det = result.get("browser_detection") or {}
+    app = (skill.get("skill_id") if skill else None) or "this app"
+    browser = bool(det.get("unreplayable")) or declared
+
+    if browser:
+        from noui_core.compile.unreplayable import recommendation_message
+
+        basis = "you asked for it" if declared else recommendation_message(det, app_name=app)
+        print(f"KIND: browser-driven — {basis}", file=sys.stderr)
+    else:
+        reasons = "; ".join(det.get("reasons") or []) or "no unreplayable fingerprint in the HAR"
+        print(
+            f"KIND: replay (call_web_api) — auto-detected: {reasons}. The skill will "
+            f"fire the recorded requests rather than drive the page.",
+            file=sys.stderr,
+        )
+
+    if not declared:
+        print(
+            "CONFIRM THE KIND WITH THE MEMBER BEFORE INSTALLING. Nobody chose this; "
+            "it was detected. If they asked for a browser-driven skill -- or the app "
+            "encrypts or signs its requests in the page, so replay will 403 later -- "
+            "re-import with --browser-driven. Changing it afterwards means compiling "
+            "again, and a replay skill that looks fine today fails the first time the "
+            "app rotates what it signs.",
+            file=sys.stderr,
+        )
+
+
 def _report_workflow(result: dict, args: argparse.Namespace) -> int:
     mcp = result.get("mcp") or {}
     skill = result.get("skill") or {}
@@ -105,16 +148,7 @@ def _report_workflow(result: dict, args: argparse.Namespace) -> int:
     # Tell the operator when the app was auto-routed to browser mode, and why —
     # this is the recommendation surfaced to a user authoring a skill in the
     # harness, so browser mode is never picked silently.
-    det = result.get("browser_detection") or {}
-    if det.get("unreplayable"):
-        from noui_core.compile.unreplayable import recommendation_message
-
-        app = (skill.get("skill_id") if skill else None) or "this app"
-        print(
-            "Browser mode auto-selected —",
-            recommendation_message(det, app_name=app),
-            file=sys.stderr,
-        )
+    _report_kind(result, skill, declared=bool(getattr(args, "browser_driven", False)))
     if args.auth_type == "api-key":
         secrets = (skill.get("secrets_required") if skill else None) or (
             mcp.get("secrets_required") if mcp else None

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -149,6 +149,7 @@ def _report_workflow(result: dict, args: argparse.Namespace) -> int:
     # this is the recommendation surfaced to a user authoring a skill in the
     # harness, so browser mode is never picked silently.
     _report_kind(result, skill, declared=bool(getattr(args, "browser_driven", False)))
+    _report_folds(skill)
     if args.auth_type == "api-key":
         secrets = (skill.get("secrets_required") if skill else None) or (
             mcp.get("secrets_required") if mcp else None
@@ -327,6 +328,34 @@ def _run_combined(args: argparse.Namespace, bundle: dict) -> int:
         file=sys.stderr,
     )
     return rc
+
+
+def _report_folds(skill: dict) -> None:
+    """Surface operations that are one workflow with a choice in the middle.
+
+    Reported, never applied: naming the choice is a judgement from a person. A
+    parameter called "corp_finacle" -- the page an annual statement happened to
+    be served from -- is worse than the two operations it replaced, because the
+    model reads these names to decide what to call.
+    """
+    try:
+        from noui_core.compile.browser_skill import fold_candidates
+    except Exception:  # noqa: BLE001 — a missing fold report never fails an import
+        return
+    for f in fold_candidates(skill.get("operations") or []):
+        a, b = f["operations"]
+        print(
+            f"\n{a} and {b} are one workflow with a choice in the middle: "
+            f"{f['prefix']} identical steps to reach the same page, then they "
+            f"diverge, then the same ending.\n"
+            f"  As two operations each replays the whole journey, so every call "
+            f"has to start from the landing page. As ONE operation with a "
+            f"parameter, the caller just picks the variant.\n"
+            f"  ASK THE MEMBER what the choice is called and what to call each "
+            f"side (e.g. timeframe=monthly|annual). The recorded names say where "
+            f"the pages were served from, not what they mean.",
+            file=sys.stderr,
+        )
 
 
 def main() -> int:

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -27,7 +27,7 @@ from noui_core.activate import register
 from noui_core.capture import ledger, recording
 from noui_core.capture.bundle import save_bundle
 from noui_core.capture.classify import COMBINED, LOGIN, WORKFLOW
-from noui_core.capture.split import split_diagnosis, split_bundle
+from noui_core.capture.split import SplitError, split_bundle, split_diagnosis
 from noui_core.compile.login import compile_login_bundle
 from noui_core.compile.workflow import compile_workflow_bundle
 
@@ -212,7 +212,12 @@ def _run_combined(args: argparse.Namespace, bundle: dict) -> int:
     feeding the login's own declared headers straight in (no Tabby round-trip).
     Falls back to workflow-only when the capture has no login segment.
     """
-    parts = split_bundle(bundle)
+    try:
+        parts = split_bundle(bundle)
+    except SplitError as exc:
+        print(split_diagnosis(bundle), file=sys.stderr)
+        print(f"Cannot split this capture: {exc}", file=sys.stderr)
+        return 1
     # Always say what the splitter saw. The decision turns on one thing and used
     # to be invisible, so a member who HAD recorded a login was asked to record
     # it again with nothing anywhere explaining why.

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -149,7 +149,7 @@ def _report_workflow(result: dict, args: argparse.Namespace) -> int:
     # this is the recommendation surfaced to a user authoring a skill in the
     # harness, so browser mode is never picked silently.
     _report_kind(result, skill, declared=bool(getattr(args, "browser_driven", False)))
-    _report_folds(skill)
+    _apply_folds(skill, getattr(args, "fold", []) or []) or _report_folds(skill)
     if args.auth_type == "api-key":
         secrets = (skill.get("secrets_required") if skill else None) or (
             mcp.get("secrets_required") if mcp else None
@@ -330,6 +330,83 @@ def _run_combined(args: argparse.Namespace, bundle: dict) -> int:
     return rc
 
 
+def _apply_folds(skill: dict, specs: list[str]) -> bool:
+    """Fold named pairs in the written skill. True when anything was folded.
+
+    Rewrites operations.json AND re-stamps the manifest's steps digest: folding
+    changes the steps, and a skill whose digest no longer matches its manifest
+    cannot install however well it replays. The compiler is doing this fold, so
+    re-stamping is the honest record -- these are still exactly the recorded
+    steps, in the recorded order, with a condition naming which variant each
+    belongs to.
+    """
+    if not specs:
+        return False
+    from pathlib import Path
+
+    from noui_core.compile import provenance
+    from noui_core.config import settings
+    from noui_core.compile.browser_skill import apply_fold, fold_candidates
+
+    skill_dir = Path(settings.workbench_dir) / "skills" / str(skill.get("skill_id") or "")
+    ops_path, man_path = skill_dir / "operations.json", skill_dir / "manifest.json"
+    try:
+        doc = json.loads(ops_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"Cannot fold: {ops_path} is unreadable ({exc}).", file=sys.stderr)
+        return False
+
+    operations = doc.get("operations") or []
+    for raw in specs:
+        try:
+            spec = json.loads(raw)
+        except ValueError as exc:
+            print(f"--fold expects a JSON object, got {raw[:60]!r}: {exc}", file=sys.stderr)
+            return False
+        wanted = [str(n) for n in (spec.get("operations") or [])]
+        match = next(
+            (f for f in fold_candidates(operations) if list(f["operations"]) == wanted), None
+        )
+        if match is None:
+            print(
+                f"{' and '.join(wanted) or 'those operations'} are not a foldable pair. "
+                "Run the import without --fold to see which are, in the order the "
+                "report names them.",
+                file=sys.stderr,
+            )
+            return False
+        values = [str(v) for v in (spec.get("values") or [])]
+        if len(values) != 2 or not spec.get("name") or not spec.get("param"):
+            print(
+                "--fold needs 'name', 'param', and exactly two 'values' -- one per "
+                "branch, in the order the report listed them.",
+                file=sys.stderr,
+            )
+            return False
+        operations = apply_fold(
+            operations, match, name=str(spec["name"]), param=str(spec["param"]), values=values
+        )
+        print(
+            f"Folded {' + '.join(wanted)} -> {spec['name']} "
+            f"({spec['param']}: {', '.join(values)}).",
+            file=sys.stderr,
+        )
+
+    doc["operations"] = operations
+    ops_path.write_text(json.dumps(doc, indent=2, ensure_ascii=False), encoding="utf-8")
+    try:
+        manifest = json.loads(man_path.read_text(encoding="utf-8"))
+        manifest.setdefault("provenance", {})["steps_sha256"] = provenance.steps_digest(operations)
+        man_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8")
+    except (OSError, ValueError) as exc:
+        print(
+            f"Folded, but could not re-stamp {man_path} ({exc}) -- the skill will be "
+            "refused at install until it is recompiled.",
+            file=sys.stderr,
+        )
+    return True
+
+
 def _report_folds(skill: dict) -> None:
     """Surface operations that are one workflow with a choice in the middle.
 
@@ -481,6 +558,18 @@ def main() -> int:
         help="(login/takeover) glob the LOGGED-IN url matches but the login page does NOT "
         "(e.g. '**/lightning/**'). Enables auto-resolve: reaching it completes login with no "
         "'Mark as Resolved' click. Needed for same-origin apps where it can't be auto-derived.",
+    )
+    p.add_argument(
+        "--fold",
+        action="append",
+        default=[],
+        metavar="JSON",
+        help="fold two operations that are one workflow with a choice into ONE, "
+        'as a JSON object: {"operations": ["a", "b"], "name": "download_statement", '
+        '"param": "timeframe", "values": ["monthly", "annual"]}. Run the import '
+        "once without this to see which pairs are foldable, ASK THE MEMBER what "
+        "the choice is called, then re-run. The recorded names say where the "
+        "pages were served from, not what they mean.",
     )
     args = p.parse_args()
 

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -27,7 +27,6 @@ capture is skipped and a command to reuse that profile is printed instead
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 
 import _bootstrap  # noqa: F401  (sys.path side effect)
@@ -107,12 +106,6 @@ def main() -> int:
         "--browser-driven",
         dest="browser_driven",
         action="store_true",
-        # Defaults from NOUI_BROWSER_DRIVEN, which the platform sets when the
-        # member's own request asked for a browser skill. The kind is their
-        # decision, and it used to survive only if the agent remembered to type
-        # the flag -- an ICICI capture asked for as a "BROWSER BASED skill"
-        # shipped as replayed API calls because nobody did.
-        default=os.environ.get("NOUI_BROWSER_DRIVEN", "").strip().lower() in ("1", "true", "yes"),
         help="this recording will be compiled into a BROWSER-DRIVEN skill, so "
         "Tabby reduces the workflow HAR to metadata — no request/response bodies, "
         "headers or query strings. Use when the kind is already known (the app "

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -248,6 +248,7 @@ def main() -> int:
                 profile=args.profile,
                 from_session=args.from_session,
                 residential=args.residential_proxy,
+                browser_driven=args.browser_driven,
             )
         except (OSError, ValueError) as exc:
             print(

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -199,6 +199,26 @@ def main() -> int:
     # mode is behaviorally inert, so one session records login + workflow in one HAR.
     # NoUI splits it at import, routed by the provision ledger written below.
     tabby_mode = "login" if args.mode == "combined" else args.mode
+
+    # A combined capture ALWAYS asks Tabby for locator evidence, whether or not
+    # the caller passed --browser-driven.
+    #
+    # Whether a skill must be browser-driven is decided at COMPILE time, by
+    # inspecting the HAR for unreplayable requests — that is, after the recording
+    # is over. Tabby gates rich capture (locator candidates, element evidence) on
+    # this flag, so leaving it off until the kind is known meant the evidence was
+    # never captured for the one recording that turned out to need it: an ICICI
+    # capture came back with 718 HAR entries, auto-detected as browser-driven,
+    # and not one click interaction to compile steps from. The only way out was
+    # to record the whole thing again.
+    #
+    # Evidence is cheap and unknowable in advance; the recording is expensive and
+    # unrepeatable. So capture it always and decide the kind later.
+    #
+    # This does NOT reduce the HAR. Tabby strips bodies only for a WORKFLOW-mode
+    # browser-driven recording, and a combined capture is provisioned as 'login'
+    # precisely so its HAR stays whole for App Template registration.
+    want_evidence = args.browser_driven or args.mode == "combined"
     try:
         result = recording.provision_live_link(
             tabby_mode,
@@ -206,7 +226,7 @@ def main() -> int:
             profile=args.profile,
             from_session=args.from_session,
             residential=args.residential_proxy,
-            browser_driven=args.browser_driven,
+            browser_driven=want_evidence,
         )
     except (RuntimeError, ValueError) as exc:
         print(f"Provisioning failed: {exc}", file=sys.stderr)

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -102,6 +102,19 @@ def main() -> int:
         "datacenter IPs, e.g. bank portals. Requires the residential proxy to be "
         "configured on Tabby; otherwise the recording-shell app default applies.",
     )
+    p.add_argument(
+        "--browser-driven",
+        dest="browser_driven",
+        action="store_true",
+        help="this recording will be compiled into a BROWSER-DRIVEN skill, so "
+        "Tabby reduces the workflow HAR to metadata — no request/response bodies, "
+        "headers or query strings. Use when the kind is already known (the app "
+        "encrypts its requests, or replay is known to fail on it), which keeps a "
+        "bank's balances, account numbers and live tokens out of the bundle. Leave "
+        "it off for anything unknown: it is the skill KIND, not the capture phase, "
+        "and a workflow recording of an ordinary REST app still compiles by HAR "
+        "replay and needs the full HAR.",
+    )
     args = p.parse_args()
 
     # Default to ONE session for the login AND the workflow. Recording them
@@ -193,6 +206,7 @@ def main() -> int:
             profile=args.profile,
             from_session=args.from_session,
             residential=args.residential_proxy,
+            browser_driven=args.browser_driven,
         )
     except (RuntimeError, ValueError) as exc:
         print(f"Provisioning failed: {exc}", file=sys.stderr)

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -104,15 +104,14 @@ def main() -> int:
     )
     p.add_argument(
         "--kind",
-        choices=("browser", "api", "auto", "replay"),
+        choices=("browser", "api", "auto"),
         default=None,
         help="What KIND of skill this recording is for. REQUIRED. 'browser' drives "
         "the live page (call_web_browser); 'api' fires the recorded requests "
         "(call_web_api); 'auto' lets the compiler decide from the HAR. NOTE: this "
         "is the skill kind, NOT the live replay that verifies a draft before "
-        "install -- 'replay' is accepted as a deprecated alias for 'api' because "
-        "that word already means the verification step. Matches the manifest's own "
-        "operation_style. There is no default on purpose: the kind "
+        "install -- those are different things, which is why this is not called "
+        "'replay'. Matches the manifest's own operation_style. There is no default on purpose: the kind "
         "decides which compiler runs, and a recording made for the wrong one "
         "cannot be fixed by relabelling it afterwards -- it has to be recorded "
         "again. The member's request usually says which ('a browser based skill'); "
@@ -238,16 +237,6 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
-    if args.kind == "replay":
-        # 'replay' already means the live verification of a draft; the manifest
-        # calls this kind 'api'. Accepted so nothing breaks, normalised so the
-        # two senses of the word never have to be told apart again.
-        print(
-            "note: --kind replay means the API/HAR kind; 'api' is the clearer name "
-            "(replay is the verification step). Reading it as --kind api.",
-            file=sys.stderr,
-        )
-        args.kind = "api"
     if args.kind == "browser":
         args.browser_driven = True
 

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -27,6 +27,7 @@ capture is skipped and a command to reuse that profile is printed instead
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 
 import _bootstrap  # noqa: F401  (sys.path side effect)
@@ -106,6 +107,12 @@ def main() -> int:
         "--browser-driven",
         dest="browser_driven",
         action="store_true",
+        # Defaults from NOUI_BROWSER_DRIVEN, which the platform sets when the
+        # member's own request asked for a browser skill. The kind is their
+        # decision, and it used to survive only if the agent remembered to type
+        # the flag -- an ICICI capture asked for as a "BROWSER BASED skill"
+        # shipped as replayed API calls because nobody did.
+        default=os.environ.get("NOUI_BROWSER_DRIVEN", "").strip().lower() in ("1", "true", "yes"),
         help="this recording will be compiled into a BROWSER-DRIVEN skill, so "
         "Tabby reduces the workflow HAR to metadata — no request/response bodies, "
         "headers or query strings. Use when the kind is already known (the app "

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -103,6 +103,18 @@ def main() -> int:
         "configured on Tabby; otherwise the recording-shell app default applies.",
     )
     p.add_argument(
+        "--kind",
+        choices=("browser", "replay", "auto"),
+        default=None,
+        help="What KIND of skill this recording is for. REQUIRED. 'browser' drives "
+        "the live page; 'replay' fires the recorded requests; 'auto' lets the "
+        "compiler decide from the HAR. There is no default on purpose: the kind "
+        "decides which compiler runs, and a recording made for the wrong one "
+        "cannot be fixed by relabelling it afterwards -- it has to be recorded "
+        "again. The member's request usually says which ('a browser based skill'); "
+        "if it does not, ask before spending their time on a recording.",
+    )
+    p.add_argument(
         "--browser-driven",
         dest="browser_driven",
         action="store_true",
@@ -198,6 +210,31 @@ def main() -> int:
     # A combined capture is provisioned as a normal 'login' session — the server-side
     # mode is behaviorally inert, so one session records login + workflow in one HAR.
     # NoUI splits it at import, routed by the provision ledger written below.
+    # The kind is decided BEFORE a single click is recorded.
+    #
+    # It used to be an optional flag, so a request that opened with the words
+    # "BROWSER BASED skill" still recorded with the kind unset, auto-detection
+    # chose replay, and the first compile was wrong. Everything after that --
+    # patching the manifest, recompiling, re-recording -- was compensation for a
+    # decision nobody was asked to make while it was still cheap.
+    if args.kind is None and not args.browser_driven:
+        print(
+            "--kind is required: browser | replay | auto.\n"
+            "\n"
+            "It decides which compiler runs, and a recording made for the wrong "
+            "one cannot be relabelled afterwards -- it has to be recorded again, "
+            "which costs the member another sign-in and another walkthrough.\n"
+            "\n"
+            "The request usually says which: 'a browser based skill' means "
+            "--kind browser. If it truly does not say, ask before recording; "
+            "--kind auto lets the compiler decide from the HAR, and is a choice "
+            "rather than a default.",
+            file=sys.stderr,
+        )
+        return 1
+    if args.kind == "browser":
+        args.browser_driven = True
+
     tabby_mode = "login" if args.mode == "combined" else args.mode
 
     # A combined capture ALWAYS asks Tabby for locator evidence, whether or not

--- a/skills/noui/scripts/capture_record.py
+++ b/skills/noui/scripts/capture_record.py
@@ -104,11 +104,15 @@ def main() -> int:
     )
     p.add_argument(
         "--kind",
-        choices=("browser", "replay", "auto"),
+        choices=("browser", "api", "auto", "replay"),
         default=None,
         help="What KIND of skill this recording is for. REQUIRED. 'browser' drives "
-        "the live page; 'replay' fires the recorded requests; 'auto' lets the "
-        "compiler decide from the HAR. There is no default on purpose: the kind "
+        "the live page (call_web_browser); 'api' fires the recorded requests "
+        "(call_web_api); 'auto' lets the compiler decide from the HAR. NOTE: this "
+        "is the skill kind, NOT the live replay that verifies a draft before "
+        "install -- 'replay' is accepted as a deprecated alias for 'api' because "
+        "that word already means the verification step. Matches the manifest's own "
+        "operation_style. There is no default on purpose: the kind "
         "decides which compiler runs, and a recording made for the wrong one "
         "cannot be fixed by relabelling it afterwards -- it has to be recorded "
         "again. The member's request usually says which ('a browser based skill'); "
@@ -219,7 +223,7 @@ def main() -> int:
     # decision nobody was asked to make while it was still cheap.
     if args.kind is None and not args.browser_driven:
         print(
-            "--kind is required: browser | replay | auto.\n"
+            "--kind is required: browser | api | auto.\n"
             "\n"
             "It decides which compiler runs, and a recording made for the wrong "
             "one cannot be relabelled afterwards -- it has to be recorded again, "
@@ -228,10 +232,22 @@ def main() -> int:
             "The request usually says which: 'a browser based skill' means "
             "--kind browser. If it truly does not say, ask before recording; "
             "--kind auto lets the compiler decide from the HAR, and is a choice "
-            "rather than a default.",
+            "rather than a default. ('api' is the kind that fires recorded "
+            "requests -- not to be confused with the live replay that verifies a "
+            "draft before install.)",
             file=sys.stderr,
         )
         return 1
+    if args.kind == "replay":
+        # 'replay' already means the live verification of a draft; the manifest
+        # calls this kind 'api'. Accepted so nothing breaks, normalised so the
+        # two senses of the word never have to be told apart again.
+        print(
+            "note: --kind replay means the API/HAR kind; 'api' is the clearer name "
+            "(replay is the verification step). Reading it as --kind api.",
+            file=sys.stderr,
+        )
+        args.kind = "api"
     if args.kind == "browser":
         args.browser_driven = True
 

--- a/skills/noui/scripts/migrate_provenance.py
+++ b/skills/noui/scripts/migrate_provenance.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Attach a recording to a browser skill compiled before provenance existed.
+
+    python scripts/migrate_provenance.py workbench/skills/<app>
+    python scripts/migrate_provenance.py workbench/skills/<app> --bundle <path>
+
+Browser skills compiled before the installer started checking provenance carry
+no `manifest.provenance` and no `recording_bundle.json`, so they are refused on
+their next install. They were compiled from a real recording, and capture always
+saves the bundle, so the fix is to re-attach the recording they already have --
+no re-recording, and no re-compiling.
+
+THIS IS NOT A WAY TO BLESS A SKILL. It runs the same check the installer runs:
+every locator the operations drive must appear in the recording. A skill written
+by hand fails it, because its selectors were never in any bundle -- pointing this
+at an arbitrary recording will not make one pass. That is the point of having it
+verify rather than just stamp.
+
+Finds the bundle by the session id in the manifest when --bundle is omitted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+
+from noui_core.compile import provenance
+from noui_core.config import settings
+
+
+def _bundles_dir() -> Path:
+    return Path(settings.workbench_dir) / "bundles"
+
+
+def find_bundle(manifest: dict, explicit: str = "") -> tuple[Path | None, str]:
+    """The recording this skill was compiled from, and why we think so."""
+    if explicit:
+        p = Path(explicit)
+        return (p, "given with --bundle") if p.is_file() else (None, f"{p} does not exist")
+
+    session_id = str((manifest.get("workflow") or {}).get("workflow_session_id") or "")
+    root = _bundles_dir()
+    if not root.is_dir():
+        return None, f"no bundles directory at {root}"
+    candidates = sorted(root.glob("*.json"))
+    if not candidates:
+        return None, f"no saved bundles in {root}"
+
+    if session_id:
+        for path in candidates:
+            try:
+                if str(json.loads(path.read_text()).get("session_id") or "") == session_id:
+                    return path, f"session id {session_id} matches the manifest"
+            except (OSError, ValueError):
+                continue
+        return None, (
+            f"no saved bundle has session id {session_id} — the capture may have been "
+            f"pruned. Pass --bundle explicitly, or re-record."
+        )
+    return None, "the manifest names no workflow_session_id; pass --bundle explicitly"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("skill_dir", help="compiled browser skill directory")
+    p.add_argument(
+        "--bundle", default="", help="recording bundle JSON (default: find by session id)"
+    )
+    p.add_argument("--dry-run", action="store_true", help="report what would happen, write nothing")
+    args = p.parse_args()
+
+    skill_dir = Path(args.skill_dir)
+    try:
+        manifest = json.loads((skill_dir / "manifest.json").read_text(encoding="utf-8"))
+        ops_doc = json.loads((skill_dir / "operations.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"Cannot read the skill at {skill_dir}: {exc}", file=sys.stderr)
+        return 1
+
+    if (manifest.get("runtime") or {}).get("operation_style") != "browser":
+        print(
+            "This is not a browser skill — provenance is only checked for skills that "
+            "drive a live browser, so there is nothing to migrate.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if manifest.get("provenance") and (skill_dir / provenance.BUNDLE_FILE).is_file():
+        print("Already has provenance and a recording beside it — nothing to do.")
+        return 0
+
+    bundle_path, why = find_bundle(manifest, args.bundle)
+    if bundle_path is None:
+        print(
+            f"No recording to attach: {why}.\n"
+            "\n"
+            "Without the bundle this skill was compiled from, there is nothing that "
+            "proves its steps were ever observed. Re-record the workflow and compile "
+            "again — that is the only honest way back.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"Cannot read {bundle_path}: {exc}", file=sys.stderr)
+        return 1
+
+    operations = ops_doc.get("operations") or []
+    unobserved = provenance.unobserved_locators(operations, bundle)
+    if unobserved:
+        shown = ", ".join(repr(u) for u in unobserved[:5])
+        more = f" (and {len(unobserved) - 5} more)" if len(unobserved) > 5 else ""
+        print(
+            f"Refusing to attach {bundle_path.name}: these locators do not appear in "
+            f"it: {shown}{more}.\n"
+            "\n"
+            "Either this is the wrong recording — try --bundle with another — or the "
+            "operations were not compiled from any recording, in which case attaching "
+            "one would only disguise that. Re-record and compile.",
+            file=sys.stderr,
+        )
+        return 1
+
+    prov = provenance.build(bundle, bundle_file=provenance.BUNDLE_FILE)
+    if args.dry_run:
+        print(f"Would attach {bundle_path} ({why}).")
+        print(json.dumps(prov, indent=2))
+        return 0
+
+    (skill_dir / provenance.BUNDLE_FILE).write_text(
+        json.dumps(bundle, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    manifest["provenance"] = prov
+    (skill_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(
+        f"Attached {bundle_path.name} ({why}).\n"
+        f"  {prov['recorded_events']} recorded interactions, "
+        f"{prov['observed_selectors']} observed locators, all steps accounted for.\n"
+        "The skill installs again. Its approval is unaffected — the operations did "
+        "not change, so the fingerprint still matches."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/noui/scripts/verify_approve.py
+++ b/skills/noui/scripts/verify_approve.py
@@ -57,8 +57,13 @@ def main() -> int:
 
     if report.get("status") == "login_required":
         print(
-            "That replay never ran — there was no signed-in session. Sign in and "
-            "replay before approving anything.",
+            "That replay never ran — there was no signed-in session, so there is "
+            "nothing to approve. Approving here would mean vouching for a workflow "
+            "nobody has seen work.\n"
+            "\n"
+            "Stop and wait for the member to sign in. Do not retry this, and do not "
+            "install: the installer refuses an unapproved browser skill, so every "
+            "attempt fails and hides the fact that you are waiting for them.",
             file=sys.stderr,
         )
         return 1

--- a/skills/noui/scripts/verify_approve.py
+++ b/skills/noui/scripts/verify_approve.py
@@ -45,10 +45,19 @@ def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("skill_dir", help="compiled skill directory (must contain replay_report.json)")
     p.add_argument(
+        "--accept-failing",
+        action="append",
+        default=[],
+        metavar="OPERATION",
+        help="approve although THIS operation did not reach its goal. One flag per "
+        "operation, named. The member has to have said so about each one, knowing "
+        "what that operation was for -- a skill whose whole point failed is not a "
+        "skill with a caveat.",
+    )
+    p.add_argument(
         "--force",
         action="store_true",
-        help="approve although the replay did not reach every goal. The member has "
-        "to have said so explicitly, knowing which operation failed.",
+        help=argparse.SUPPRESS,  # replaced by --accept-failing; kept to say so
     )
     p.add_argument(
         "--approve-amendment",
@@ -86,15 +95,68 @@ def main() -> int:
         )
         return 1
 
-    if not report.get("all_goals_reached") and not args.force:
-        failed = [
-            o.get("name") for o in report.get("operations") or [] if not o.get("goal_reached")
-        ]
+    # A waiver has to name what it waives.
+    #
+    # `--force` was one flag that covered everything, and a build reached for it
+    # with 3 of 7 goals reached -- the failures being the statement download, the
+    # entire thing the member had asked for. It then drafted the member's
+    # approval sentence and asked them to paste it back. Naming each operation
+    # makes the cost specific, puts it in the approval record, and makes a stale
+    # or copied list fail instead of passing quietly.
+    if args.force:
+        print(
+            "--force is gone. Name each operation you are asking the member to give "
+            "up: --accept-failing OPERATION, one flag each. A waiver nobody can read "
+            "is not a decision anybody made.",
+            file=sys.stderr,
+        )
+        return 1
+
+    failing = [
+        str(o.get("name"))
+        for o in report.get("operations") or []
+        if not o.get("goal_reached")
+    ]
+    accepted = [str(n) for n in (args.accept_failing or [])]
+    if failing and not accepted:
         print(
             "Refusing to approve: the replay did not reach every goal "
-            f"({', '.join(str(f) for f in failed) or 'unknown'}). Amend the workflow "
-            "and replay again, or pass --force if the member decided to ship it "
-            "knowing which operation failed.",
+            f"({', '.join(failing)}). Fix what blocked them and replay again -- that "
+            "is almost always the right move, especially when a failing operation is "
+            "the one the member asked for.\n"
+            "\n"
+            "If the member has decided to ship without them, knowing what each one "
+            "was for, name them: "
+            + " ".join(f"--accept-failing {n}" for n in failing),
+            file=sys.stderr,
+        )
+        return 1
+
+    unknown = [n for n in accepted if n not in {str(o.get("name")) for o in report.get("operations") or []}]
+    if unknown:
+        print(
+            f"No operation named {', '.join(sorted(unknown))} in this replay. A waiver "
+            "that names nothing real records a decision about nothing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    passed = [n for n in accepted if n not in failing]
+    if passed:
+        print(
+            f"{', '.join(sorted(passed))} reached its goal -- there is nothing to "
+            "waive. This usually means the list was carried over from an earlier "
+            "replay; check which operations actually failed in THIS one.",
+            file=sys.stderr,
+        )
+        return 1
+
+    unnamed = [n for n in failing if n not in accepted]
+    if unnamed:
+        print(
+            f"Not approved: {', '.join(unnamed)} also failed and you did not name "
+            "them. Every failing operation has to be named, so the member is "
+            "answering about all of them and not just the ones that were mentioned.",
             file=sys.stderr,
         )
         return 1
@@ -171,6 +233,25 @@ def main() -> int:
         record = approve(report)
         if approved_ids:
             record["approved_amendments"] = approved_ids
+        if failing:
+            # Built from the report, never from what the caller said about it, so
+            # the installer and the member's card see the same thing the replay
+            # actually produced.
+            record["accepted_failing"] = [
+                {
+                    "operation": str(op.get("name")),
+                    "blocked": [
+                        {
+                            "command": st.get("command"),
+                            "error": st.get("error"),
+                        }
+                        for st in op.get("steps") or []
+                        if str(st.get("status") or "") != "ok"
+                    ],
+                }
+                for op in report.get("operations") or []
+                if not op.get("goal_reached")
+            ]
         path = write_approval(skill_dir, record)
     except (OSError, ValueError) as exc:
         print(f"Could not record the approval: {exc}", file=sys.stderr)

--- a/skills/noui/scripts/verify_approve.py
+++ b/skills/noui/scripts/verify_approve.py
@@ -26,10 +26,19 @@ from pathlib import Path
 
 import _bootstrap  # noqa: F401
 
+from noui_core.compile import amendments as amendments_mod
 from noui_core.verify.gate import write_approval
 from noui_core.verify.replay import approve
 
 REPORT_FILE = "replay_report.json"
+
+
+def _read(path) -> str:
+    """File contents, or "" when absent — an unreadable file is not amendments."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
 
 
 def main() -> int:
@@ -40,6 +49,15 @@ def main() -> int:
         action="store_true",
         help="approve although the replay did not reach every goal. The member has "
         "to have said so explicitly, knowing which operation failed.",
+    )
+    p.add_argument(
+        "--approve-amendment",
+        action="append",
+        default=[],
+        metavar="ID",
+        help="approve one step that was discovered at replay rather than recorded. "
+        "One flag per amendment, by the id in the replay report. The member has to "
+        "have seen and answered on each: nobody watched a human perform these.",
     )
     args = p.parse_args()
 
@@ -81,11 +99,63 @@ def main() -> int:
         )
         return 1
 
+    # Record which amendments the member approved, by id.
+    #
+    # An amendment is a step discovered at replay, not one a human was watched
+    # performing, and the installer approves those ONE AT A TIME -- approving the
+    # skill as a whole would wave through exactly the steps that most need
+    # looking at. Nothing wrote this field, so an amended skill could never
+    # install however carefully it was reviewed.
+    amendments = amendments_mod.load(_read(skill_dir / amendments_mod.AMENDMENTS_FILE))
+    approved_ids: list[str] = []
+    if amendments:
+        wanted = set(args.approve_amendment or [])
+        unknown = wanted - {amendments_mod.amendment_id(a) for a in amendments}
+        if unknown:
+            print(
+                f"No amendment has id {', '.join(sorted(unknown))}. Ids come from the "
+                f"replay report; approving one that does not exist would record a "
+                f"decision about nothing.",
+                file=sys.stderr,
+            )
+            return 1
+        approved_ids = [
+            amendments_mod.amendment_id(a)
+            for a in amendments
+            if amendments_mod.amendment_id(a) in wanted
+        ]
+        outstanding = [a for a in amendments if amendments_mod.amendment_id(a) not in wanted]
+        if outstanding:
+            print(
+                f"{len(outstanding)} amendment(s) not approved -- the installer will "
+                f"refuse until the member answers on each:",
+                file=sys.stderr,
+            )
+            for a in outstanding:
+                print(
+                    f"  [{amendments_mod.amendment_id(a)}] {amendments_mod.describe(a)}",
+                    file=sys.stderr,
+                )
+
     try:
-        path = write_approval(skill_dir, approve(report))
+        record = approve(report)
+        if approved_ids:
+            record["approved_amendments"] = approved_ids
+        path = write_approval(skill_dir, record)
     except (OSError, ValueError) as exc:
         print(f"Could not record the approval: {exc}", file=sys.stderr)
         return 1
+
+    if amendments and len(approved_ids) < len(amendments):
+        # Do not say installable when it is not. The installer refuses on an
+        # unapproved amendment, and a message that contradicts it just sends the
+        # caller to an install that fails.
+        print(
+            f"Approved — recorded at {path}. The skill will NOT install yet: "
+            f"{len(amendments) - len(approved_ids)} amendment(s) still need the "
+            f"member's answer (see above)."
+        )
+        return 0
 
     print(f"Approved — recorded at {path}. The skill may now be installed.")
     return 0

--- a/skills/noui/scripts/verify_approve.py
+++ b/skills/noui/scripts/verify_approve.py
@@ -33,7 +33,7 @@ from noui_core.verify.replay import approve
 REPORT_FILE = "replay_report.json"
 
 
-def _read(path) -> str:
+def _read(path: Path) -> str:
     """File contents, or "" when absent — an unreadable file is not amendments."""
     try:
         return path.read_text(encoding="utf-8")
@@ -113,9 +113,7 @@ def main() -> int:
         return 1
 
     failing = [
-        str(o.get("name"))
-        for o in report.get("operations") or []
-        if not o.get("goal_reached")
+        str(o.get("name")) for o in report.get("operations") or [] if not o.get("goal_reached")
     ]
     accepted = [str(n) for n in (args.accept_failing or [])]
     if failing and not accepted:
@@ -126,13 +124,14 @@ def main() -> int:
             "the one the member asked for.\n"
             "\n"
             "If the member has decided to ship without them, knowing what each one "
-            "was for, name them: "
-            + " ".join(f"--accept-failing {n}" for n in failing),
+            "was for, name them: " + " ".join(f"--accept-failing {n}" for n in failing),
             file=sys.stderr,
         )
         return 1
 
-    unknown = [n for n in accepted if n not in {str(o.get("name")) for o in report.get("operations") or []}]
+    unknown = [
+        n for n in accepted if n not in {str(o.get("name")) for o in report.get("operations") or []}
+    ]
     if unknown:
         print(
             f"No operation named {', '.join(sorted(unknown))} in this replay. A waiver "
@@ -172,7 +171,7 @@ def main() -> int:
     approved_ids: list[str] = []
     if amendments:
         wanted = set(args.approve_amendment or [])
-        unknown = wanted - {amendments_mod.amendment_id(a) for a in amendments}
+        unknown = sorted(set(wanted) - {amendments_mod.amendment_id(a) for a in amendments})
         if unknown:
             print(
                 f"No amendment has id {', '.join(sorted(unknown))}. Ids come from the "

--- a/skills/noui/scripts/verify_approve.py
+++ b/skills/noui/scripts/verify_approve.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Record a member's approval of a replayed draft, so it may be installed.
+
+    python scripts/verify_approve.py workbench/skills/<app>
+
+Run this ONLY after showing the member the replay result and getting their
+answer. It is the record of a human decision, not a formality to clear on the
+way to installing — approving on someone's behalf defeats the entire gate.
+
+Refuses when the replay did not reach every goal. An operation that did not do
+what it exists for is not something to wave through, and the fix is to amend and
+replay again rather than to approve anyway.
+
+Writes ``replay_approval.json`` beside the skill. The installer checks it, and
+checks that its fingerprint still matches the operations on disk — so amending a
+step after approval invalidates the approval rather than smuggling a change past
+the member who approved something else.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+
+from noui_core.verify.gate import write_approval
+from noui_core.verify.replay import approve
+
+REPORT_FILE = "replay_report.json"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("skill_dir", help="compiled skill directory (must contain replay_report.json)")
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="approve although the replay did not reach every goal. The member has "
+        "to have said so explicitly, knowing which operation failed.",
+    )
+    args = p.parse_args()
+
+    skill_dir = Path(args.skill_dir)
+    report_path = skill_dir / REPORT_FILE
+    try:
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(
+            f"Cannot read {report_path}: {exc}. Replay the draft first "
+            f"(scripts/verify_replay.py) — there is nothing to approve.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if report.get("status") == "login_required":
+        print(
+            "That replay never ran — there was no signed-in session. Sign in and "
+            "replay before approving anything.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not report.get("all_goals_reached") and not args.force:
+        failed = [
+            o.get("name") for o in report.get("operations") or [] if not o.get("goal_reached")
+        ]
+        print(
+            "Refusing to approve: the replay did not reach every goal "
+            f"({', '.join(str(f) for f in failed) or 'unknown'}). Amend the workflow "
+            "and replay again, or pass --force if the member decided to ship it "
+            "knowing which operation failed.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        path = write_approval(skill_dir, approve(report))
+    except (OSError, ValueError) as exc:
+        print(f"Could not record the approval: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Approved — recorded at {path}. The skill may now be installed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/noui/scripts/verify_approve.py
+++ b/skills/noui/scripts/verify_approve.py
@@ -119,6 +119,36 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 1
+        # An amendment the replay never ran is not approvable. One build
+        # confirmed a single control by hand, amended that step across six
+        # operations, and four of them were blocked long before the amended step
+        # could run -- all six then read "confirmed working in live session".
+        # Approving those would put the member's name on steps nothing has ever
+        # executed, which is the one thing this whole file exists to prevent.
+        unexercised = [
+            a
+            for a in amendments
+            if amendments_mod.amendment_id(a) in wanted and not amendments_mod.is_verified(a)
+        ]
+        if unexercised:
+            print(
+                f"{len(unexercised)} of the amendment(s) you are approving never ran "
+                f"in the replay:",
+                file=sys.stderr,
+            )
+            for a in unexercised:
+                print(
+                    f"  [{amendments_mod.amendment_id(a)}] {amendments_mod.describe(a)}",
+                    file=sys.stderr,
+                )
+            print(
+                "\nConfirming a control by hand on one page says nothing about the "
+                "same step in an operation the replay never reached. Fix what blocked "
+                "those operations and replay again -- then these carry evidence and "
+                "the member has something real to decide on.",
+                file=sys.stderr,
+            )
+            return 1
         approved_ids = [
             amendments_mod.amendment_id(a)
             for a in amendments

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import _bootstrap  # noqa: F401
 
 from noui_core.capture.recording import resolve_agent_token
+from noui_core.compile import provenance
 from noui_core.verify.replay import plan_operations
 from noui_core.verify.session import run_replay
 
@@ -73,6 +74,39 @@ def main() -> int:
         # Not a failure: a HAR-replay skill is verified by its own test loop.
         print("No browser operations — nothing for this gate to replay.", file=sys.stderr)
         return 1
+
+    # Check provenance BEFORE spending a live session on it. The installer checks
+    # this too, but by then a replay has already run: one build rewrote the
+    # compiled operations, replayed, and spent the whole session improvising --
+    # clicking, screenshotting, hunting a nav that its invented steps could not
+    # find -- before anything said the steps were not the recorded ones.
+    bundle_path = skill_dir / provenance.BUNDLE_FILE
+    if bundle_path.is_file():
+        try:
+            bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            print(f"Cannot read {bundle_path}: {exc}", file=sys.stderr)
+            return 1
+        unobserved = provenance.unobserved_locators(operations, bundle)
+        if unobserved:
+            shown = ", ".join(repr(u) for u in unobserved[:5])
+            more = f" (and {len(unobserved) - 5} more)" if len(unobserved) > 5 else ""
+            print(
+                f"These steps target controls the recording never saw: {shown}{more}.\n"
+                "\n"
+                "The operations no longer match what was compiled from the recording, "
+                "which almost always means they were edited by hand after compiling. "
+                "Replaying now would drive a live session through steps nobody has "
+                "seen work, and when they miss, the run improvises and wanders.\n"
+                "\n"
+                "You may rename an operation, reword its description, or add a "
+                "parameter. You may NOT change what a step targets, reorder steps, or "
+                "add an operation that was not recorded -- those come from the "
+                "recording and nothing else can supply them. Restore the compiled "
+                "operations.json, or re-record the part you meant to change.",
+                file=sys.stderr,
+            )
+            return 1
 
     values = {}
     for raw in args.param:

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -232,6 +232,9 @@ def main() -> int:
         # Every invocation restarts the journey rather than resuming it, so an
         # amended step is judged from the same place the original one was.
         entry_url=(doc.get("entry_url") if isinstance(doc, dict) else None),
+        # One entry per host: a reset never changes hosts, because no route
+        # between them was ever recorded.
+        entry_by_origin=(doc.get("entry_urls") if isinstance(doc, dict) else None),
     )
 
     # Amendments are persisted AFTER the replay, stamped with what it proved

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -28,11 +28,20 @@ from pathlib import Path
 import _bootstrap  # noqa: F401
 
 from noui_core.capture.recording import resolve_agent_token
+from noui_core.compile import amendments as amendments_mod
 from noui_core.compile import provenance
 from noui_core.verify.replay import plan_operations
 from noui_core.verify.session import run_replay
 
 REPORT_FILE = "replay_report.json"
+
+
+def _read_text(path) -> str:
+    """File contents, or "" when absent."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
 
 
 def main() -> int:
@@ -55,6 +64,18 @@ def main() -> int:
         help="pre-approve a step the risk rules would otherwise stop on (a control "
         "that moves money, is irreversible, or the human never touched). One flag "
         "per control; the member must have said so.",
+    )
+    p.add_argument(
+        "--amend",
+        action="append",
+        default=[],
+        metavar="JSON",
+        help="replace ONE step with a control discovered at replay, as a JSON object: "
+        '{"operation": "...", "step_index": 0, "replacement": {"command": "...", '
+        '"params": {...}}, "why": "..."}. Use this instead of editing '
+        "operations.json -- editing it destroys the provenance that makes the whole "
+        "skill installable, and an amendment recorded here survives review as what it "
+        "is: a step observed working once, which the member approves separately.",
     )
     args = p.parse_args()
 
@@ -134,6 +155,62 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 1
+
+    # Amendments: a step whose recorded locator no longer matches, replaced by a
+    # control discovered at replay. Recorded HERE rather than by editing
+    # operations.json, which is what three builds did -- destroying the digest
+    # that proves the rest came from a recording, and losing the discovery along
+    # with the evidence when the gate then refused the skill.
+    pending: list[dict] = []
+    for raw in args.amend:
+        try:
+            a = json.loads(raw)
+        except ValueError as exc:
+            print(f"--amend expects a JSON object, got {raw[:60]!r}: {exc}", file=sys.stderr)
+            return 1
+        if not (isinstance(a, dict) and a.get("operation") and a.get("replacement")):
+            print("--amend needs at least 'operation' and 'replacement'.", file=sys.stderr)
+            return 1
+        a.setdefault("why", "the recorded locator matched nothing at replay")
+        pending.append(a)
+
+    if pending:
+        by_name = {o.get("name"): o for o in operations}
+        for a in pending:
+            op = by_name.get(a["operation"])
+            if op is None:
+                print(f"No operation named {a['operation']!r} to amend.", file=sys.stderr)
+                return 1
+            idx = a.get("step_index")
+            steps = op.get("steps") or []
+            if not isinstance(idx, int) or not (0 <= idx < len(steps)):
+                print(
+                    f"step_index {idx!r} is out of range for {a['operation']} "
+                    f"({len(steps)} steps).",
+                    file=sys.stderr,
+                )
+                return 1
+            # Applied to the in-memory plan only. operations.json stays exactly as
+            # compiled, so its digest keeps proving what the recording showed.
+            steps[idx] = a["replacement"]
+
+        existing = amendments_mod.load(_read_text(skill_dir / amendments_mod.AMENDMENTS_FILE))
+        seen = {amendments_mod.amendment_id(a) for a in existing}
+        merged = existing + [a for a in pending if amendments_mod.amendment_id(a) not in seen]
+        (skill_dir / amendments_mod.AMENDMENTS_FILE).write_text(
+            json.dumps({"amendments": merged}, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        print(
+            f"Recorded {len(pending)} amendment(s). These are NOT part of the "
+            f"recording -- the member approves each one separately "
+            f"(verify_approve --approve-amendment ID):",
+            file=sys.stderr,
+        )
+        for a in pending:
+            print(
+                f"  [{amendments_mod.amendment_id(a)}] {amendments_mod.describe(a)}",
+                file=sys.stderr,
+            )
 
     values = {}
     for raw in args.param:

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -259,31 +259,19 @@ def main() -> int:
             return 1
         values[name] = value
 
-    # A control plane that never answers is not a fault in the skill, and it must
-    # not cost the member the amendment they just recorded or dump a raw urllib
-    # traceback. run_replay already turns "no session" (HTTP 404/409) into
-    # login_required; the gap is BEFORE it -- resolving the agent token, or the
-    # very first call -- when Tabby is down entirely. Treat that the same way: no
-    # replay ran, so nothing reached its goal, the amendments below are recorded
-    # unverified, and the message says plainly what was unreachable.
-    try:
-        token = resolve_agent_token()
-        report = run_replay(
-            operations,
-            profile_slug=args.profile_slug,
-            token=token,
-            approvals=set(args.approve_step) or None,
-            parameter_values=values or None,
-            # Every invocation restarts the journey rather than resuming it, so an
-            # amended step is judged from the same place the original one was.
-            entry_url=(doc.get("entry_url") if isinstance(doc, dict) else None),
-            # One entry per host: a reset never changes hosts, because no route
-            # between them was ever recorded.
-            entry_by_origin=(doc.get("entry_urls") if isinstance(doc, dict) else None),
-        )
-    except TabbyUnreachableError as exc:
-        print(str(exc), file=sys.stderr)
-        report = {
+    # Not being able to replay is not a fault in the skill, and it must not cost
+    # the member the amendment they just recorded or dump a raw traceback. Two
+    # gates sit BEFORE run_replay can turn "no session" (HTTP 404/409) into
+    # login_required, and either can fail with nothing having run:
+    #   - resolving the agent token: no credentials/broker token configured, or
+    #     the auth endpoint is unreachable. Any failure here means there is no
+    #     token, so there is no session to replay against.
+    #   - the very first browser call, when the control plane is down entirely
+    #     (TabbyUnreachableError rather than a 404).
+    # Treat both the same way: no replay ran, nothing reached its goal, the
+    # amendments below are recorded unverified, and the message says plainly why.
+    def _not_replayed() -> dict:
+        return {
             "operations": [
                 {"name": o.get("name"), "goal_reached": False, "steps": []} for o in operations
             ],
@@ -292,6 +280,33 @@ def main() -> int:
             "installable": False,
             "status": "unreachable",
         }
+
+    try:
+        token = resolve_agent_token()
+    except RuntimeError as exc:
+        # No token, no session — missing creds/broker token, or the auth endpoint
+        # is down. resolve_agent_token raises ONLY for "cannot obtain a token"
+        # reasons, so catching RuntimeError here cannot swallow a replay bug.
+        print(str(exc), file=sys.stderr)
+        report = _not_replayed()
+    else:
+        try:
+            report = run_replay(
+                operations,
+                profile_slug=args.profile_slug,
+                token=token,
+                approvals=set(args.approve_step) or None,
+                parameter_values=values or None,
+                # Every invocation restarts the journey rather than resuming it, so
+                # an amended step is judged from the same place the original one was.
+                entry_url=(doc.get("entry_url") if isinstance(doc, dict) else None),
+                # One entry per host: a reset never changes hosts, because no route
+                # between them was ever recorded.
+                entry_by_origin=(doc.get("entry_urls") if isinstance(doc, dict) else None),
+            )
+        except TabbyUnreachableError as exc:
+            print(str(exc), file=sys.stderr)
+            report = _not_replayed()
 
     # Amendments are persisted AFTER the replay, stamped with what it proved
     # about each one. Written beforehand they all looked equally confirmed: one

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -103,7 +103,20 @@ def main() -> int:
     if report.get("status") == "login_required":
         print(
             "\nNo signed-in session, so the workflow was never tried. This is not a "
-            "fault in the skill: show the sign-in card, then replay again.",
+            "fault in the skill.\n"
+            "\n"
+            "DO NOT start a recording session to fix this. A recording is a human "
+            "driving a browser so NoUI can capture it; this needs the profile's own "
+            "RUNTIME session, which is a different thing with a different sign-in "
+            "surface. Handing over a recording link here produces a viewer with a "
+            "'Finish & export' button, which is not what the member was asked for and "
+            "throws away the sign-in they just did.\n"
+            "\n"
+            "To get a runtime session: call the skill's own operation through "
+            "call_web_browser. It returns status=login_required with a sign-in link, "
+            "the platform renders the sign-in card, the member signs in there, and the "
+            "session stays warm. Then run this script again — replays after the first "
+            "sign-in are free.",
             file=sys.stderr,
         )
         return 2

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -87,6 +87,29 @@ def main() -> int:
         except (OSError, ValueError) as exc:
             print(f"Cannot read {bundle_path}: {exc}", file=sys.stderr)
             return 1
+        try:
+            manifest = json.loads((skill_dir / "manifest.json").read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            manifest = {}
+        stamped = str((manifest.get("provenance") or {}).get("steps_sha256") or "")
+        if stamped and stamped != provenance.steps_digest(operations):
+            print(
+                "These are not the operations that were compiled from the recording "
+                "— their steps changed after compiling.\n"
+                "\n"
+                "Renaming an operation or rewording a description does not trigger "
+                "this. Changing what a step targets, reordering steps, or adding an "
+                "operation does. Reassembling steps out of locators that appear in "
+                "the recording is not the same as having recorded them, and the "
+                "installer checks this too — replaying now spends a live session on "
+                "a skill that cannot install.\n"
+                "\n"
+                "Restore the compiled operations.json, or re-record the part you "
+                "meant to change.",
+                file=sys.stderr,
+            )
+            return 1
+
         unobserved = provenance.unobserved_locators(operations, bundle)
         if unobserved:
             shown = ", ".join(repr(u) for u in unobserved[:5])

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -116,7 +116,14 @@ def main() -> int:
             "call_web_browser. It returns status=login_required with a sign-in link, "
             "the platform renders the sign-in card, the member signs in there, and the "
             "session stays warm. Then run this script again — replays after the first "
-            "sign-in are free.",
+            "sign-in are free.\n"
+            "\n"
+            "THEN STOP AND WAIT. Tell the member you are waiting for their sign-in "
+            "and say nothing else until they answer. Do not approve, do not install, "
+            "do not re-run this script on a timer. None of those can succeed without "
+            "a session, and each failed attempt buries the one thing the member needs "
+            "to read: that you are waiting for them. A missing session is a WAIT, not "
+            "a failure to work around.",
             file=sys.stderr,
         )
         return 2

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Replay a compiled DRAFT against a live session, before anything is installed.
+
+    python scripts/verify_replay.py workbench/skills/<app> --profile-slug <slug>
+
+Compile first, replay here, show the result to the member, and only then
+install. A browser skill that has never been run against the live app is
+exactly the kind that looks correct in review and fails in production — every
+failure this pipeline has hit looked correct on paper.
+
+Writes ``replay_report.json`` beside the skill and prints it, so the caller can
+render the verification card. It does NOT approve anything: `installable` stays
+false until a member says otherwise (see verify_approve.py).
+
+Exit codes:
+  0  the replay ran — read the report to see whether the goals were reached
+  1  could not replay (no skill, no operations, bad arguments)
+  2  no signed-in session; show the sign-in card and run this again
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import _bootstrap  # noqa: F401
+
+from noui_core.capture.recording import resolve_agent_token
+from noui_core.verify.replay import plan_operations
+from noui_core.verify.session import run_replay
+
+REPORT_FILE = "replay_report.json"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("skill_dir", help="compiled skill directory (contains operations.json)")
+    p.add_argument("--profile-slug", required=True, help="Tabby profile the skill drives")
+    p.add_argument(
+        "--param",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help="override a recorded parameter for this replay. Omit to use what was "
+        "recorded, which is the run we have evidence for.",
+    )
+    p.add_argument(
+        "--approve-step",
+        action="append",
+        default=[],
+        metavar="SELECTOR|TEXT",
+        help="pre-approve a step the risk rules would otherwise stop on (a control "
+        "that moves money, is irreversible, or the human never touched). One flag "
+        "per control; the member must have said so.",
+    )
+    args = p.parse_args()
+
+    skill_dir = Path(args.skill_dir)
+    ops_path = skill_dir / "operations.json"
+    try:
+        doc = json.loads(ops_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"Cannot read {ops_path}: {exc}", file=sys.stderr)
+        return 1
+
+    operations = doc.get("operations") if isinstance(doc, dict) else None
+    if not operations:
+        print(f"{ops_path} has no operations to replay.", file=sys.stderr)
+        return 1
+    if not plan_operations(operations):
+        # Not a failure: a HAR-replay skill is verified by its own test loop.
+        print("No browser operations — nothing for this gate to replay.", file=sys.stderr)
+        return 1
+
+    values = {}
+    for raw in args.param:
+        name, _, value = raw.partition("=")
+        if not name or not _:
+            print(f"--param expects NAME=VALUE, got {raw!r}", file=sys.stderr)
+            return 1
+        values[name] = value
+
+    report = run_replay(
+        operations,
+        profile_slug=args.profile_slug,
+        token=resolve_agent_token(),
+        approvals=set(args.approve_step) or None,
+        parameter_values=values or None,
+    )
+
+    out = skill_dir / REPORT_FILE
+    try:
+        out.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+    except OSError as exc:
+        # The report still goes to stdout; losing the file is not worth failing a
+        # replay that already ran against a live session.
+        print(f"(warning: could not write {out}: {exc})", file=sys.stderr)
+
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+
+    if report.get("status") == "login_required":
+        print(
+            "\nNo signed-in session, so the workflow was never tried. This is not a "
+            "fault in the skill: show the sign-in card, then replay again.",
+            file=sys.stderr,
+        )
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -30,6 +30,7 @@ import _bootstrap  # noqa: F401
 from noui_core.capture.recording import resolve_agent_token
 from noui_core.compile import amendments as amendments_mod
 from noui_core.compile import provenance
+from noui_core.tabby_client import TabbyUnreachableError
 from noui_core.verify.replay import plan_operations
 from noui_core.verify.session import run_replay
 
@@ -258,19 +259,39 @@ def main() -> int:
             return 1
         values[name] = value
 
-    report = run_replay(
-        operations,
-        profile_slug=args.profile_slug,
-        token=resolve_agent_token(),
-        approvals=set(args.approve_step) or None,
-        parameter_values=values or None,
-        # Every invocation restarts the journey rather than resuming it, so an
-        # amended step is judged from the same place the original one was.
-        entry_url=(doc.get("entry_url") if isinstance(doc, dict) else None),
-        # One entry per host: a reset never changes hosts, because no route
-        # between them was ever recorded.
-        entry_by_origin=(doc.get("entry_urls") if isinstance(doc, dict) else None),
-    )
+    # A control plane that never answers is not a fault in the skill, and it must
+    # not cost the member the amendment they just recorded or dump a raw urllib
+    # traceback. run_replay already turns "no session" (HTTP 404/409) into
+    # login_required; the gap is BEFORE it -- resolving the agent token, or the
+    # very first call -- when Tabby is down entirely. Treat that the same way: no
+    # replay ran, so nothing reached its goal, the amendments below are recorded
+    # unverified, and the message says plainly what was unreachable.
+    try:
+        token = resolve_agent_token()
+        report = run_replay(
+            operations,
+            profile_slug=args.profile_slug,
+            token=token,
+            approvals=set(args.approve_step) or None,
+            parameter_values=values or None,
+            # Every invocation restarts the journey rather than resuming it, so an
+            # amended step is judged from the same place the original one was.
+            entry_url=(doc.get("entry_url") if isinstance(doc, dict) else None),
+            # One entry per host: a reset never changes hosts, because no route
+            # between them was ever recorded.
+            entry_by_origin=(doc.get("entry_urls") if isinstance(doc, dict) else None),
+        )
+    except TabbyUnreachableError as exc:
+        print(str(exc), file=sys.stderr)
+        report = {
+            "operations": [
+                {"name": o.get("name"), "goal_reached": False, "steps": []} for o in operations
+            ],
+            "all_goals_reached": False,
+            "needs_approval": False,
+            "installable": False,
+            "status": "unreachable",
+        }
 
     # Amendments are persisted AFTER the replay, stamped with what it proved
     # about each one. Written beforehand they all looked equally confirmed: one
@@ -355,6 +376,11 @@ def main() -> int:
             "a failure to work around.",
             file=sys.stderr,
         )
+        return 2
+    if report.get("status") == "unreachable":
+        # The reason was already printed above. Non-zero so nothing downstream
+        # reads this as a passing replay; same "re-run once the platform answers"
+        # family as login_required.
         return 2
     return 0
 

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -226,6 +226,9 @@ def main() -> int:
         token=resolve_agent_token(),
         approvals=set(args.approve_step) or None,
         parameter_values=values or None,
+        # Every invocation restarts the journey rather than resuming it, so an
+        # amended step is judged from the same place the original one was.
+        entry_url=(doc.get("entry_url") if isinstance(doc, dict) else None),
     )
 
     out = skill_dir / REPORT_FILE

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -80,34 +80,38 @@ def main() -> int:
     # compiled operations, replayed, and spent the whole session improvising --
     # clicking, screenshotting, hunting a nav that its invented steps could not
     # find -- before anything said the steps were not the recorded ones.
+    # The steps digest first, and OUTSIDE the bundle check: a rewrite is knowable
+    # from the manifest alone, and a build that had rewritten its operations was
+    # sent to replay them -- spending a live session, and a member's sign-in, on
+    # steps that could never install.
+    try:
+        manifest = json.loads((skill_dir / "manifest.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        manifest = {}
+    stamped = str((manifest.get("provenance") or {}).get("steps_sha256") or "")
+    if stamped and stamped != provenance.steps_digest(operations):
+        print(
+            "These are not the operations that were compiled from the recording "
+            "— their steps changed after compiling.\n"
+            "\n"
+            "Do NOT replay them: they cannot install however the replay goes, and "
+            "a live session spent on them is spent for nothing. Renaming an "
+            "operation or rewording a description is fine; changing what a step "
+            "targets, reordering steps, or adding an operation is not — those come "
+            "from the recording and nothing else can supply them.\n"
+            "\n"
+            "Restore the compiled operations.json, or re-record the part you meant "
+            "to change.",
+            file=sys.stderr,
+        )
+        return 1
+
     bundle_path = skill_dir / provenance.BUNDLE_FILE
     if bundle_path.is_file():
         try:
             bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
         except (OSError, ValueError) as exc:
             print(f"Cannot read {bundle_path}: {exc}", file=sys.stderr)
-            return 1
-        try:
-            manifest = json.loads((skill_dir / "manifest.json").read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            manifest = {}
-        stamped = str((manifest.get("provenance") or {}).get("steps_sha256") or "")
-        if stamped and stamped != provenance.steps_digest(operations):
-            print(
-                "These are not the operations that were compiled from the recording "
-                "— their steps changed after compiling.\n"
-                "\n"
-                "Renaming an operation or rewording a description does not trigger "
-                "this. Changing what a step targets, reordering steps, or adding an "
-                "operation does. Reassembling steps out of locators that appear in "
-                "the recording is not the same as having recorded them, and the "
-                "installer checks this too — replaying now spends a live session on "
-                "a skill that cannot install.\n"
-                "\n"
-                "Restore the compiled operations.json, or re-record the part you "
-                "meant to change.",
-                file=sys.stderr,
-            )
             return 1
 
         unobserved = provenance.unobserved_locators(operations, bundle)

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -44,6 +44,21 @@ def _read_text(path) -> str:
         return ""
 
 
+def _step_ran_ok(report: dict, operation: str, step_index: int) -> bool:
+    """Did this exact step run, and run cleanly, in the replay just performed?
+
+    Missing is not ok: when a replay dies early an operation has fewer step
+    results than steps, and every step past the failure simply never happened.
+    """
+    for op in report.get("operations") or []:
+        if op.get("name") != operation:
+            continue
+        steps = op.get("steps") or []
+        if 0 <= step_index < len(steps):
+            return str(steps[step_index].get("status") or "") == "ok"
+    return False
+
+
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("skill_dir", help="compiled skill directory (contains operations.json)")
@@ -116,10 +131,15 @@ def main() -> int:
             "— their steps changed after compiling.\n"
             "\n"
             "Do NOT replay them: they cannot install however the replay goes, and "
-            "a live session spent on them is spent for nothing. Renaming an "
-            "operation or rewording a description is fine; changing what a step "
-            "targets, reordering steps, or adding an operation is not — those come "
-            "from the recording and nothing else can supply them.\n"
+            "a live session spent on them is spent for nothing.\n"
+            "\n"
+            "Renaming an operation, rewording a description, or adding a parameter "
+            "is fine. These are not: changing what a step targets, reordering "
+            "steps, adding an operation, and REMOVING one — deleting an operation "
+            "you judged unnecessary changes the digest exactly as much as inventing "
+            "one, because the digest covers the whole list. If some operations look "
+            "like noise, leave them; one nobody calls costs nothing, and SKILL.md "
+            "is where you say which ones matter.\n"
             "\n"
             "Restore the compiled operations.json, or re-record the part you meant "
             "to change.",
@@ -148,10 +168,11 @@ def main() -> int:
                 "seen work, and when they miss, the run improvises and wanders.\n"
                 "\n"
                 "You may rename an operation, reword its description, or add a "
-                "parameter. You may NOT change what a step targets, reorder steps, or "
-                "add an operation that was not recorded -- those come from the "
-                "recording and nothing else can supply them. Restore the compiled "
-                "operations.json, or re-record the part you meant to change.",
+                "parameter. You may NOT change what a step targets, reorder steps, "
+                "add an operation that was not recorded, or remove one you judged "
+                "unnecessary -- those come from the recording and nothing else can "
+                "supply them. Restore the compiled operations.json, or re-record the "
+                "part you meant to change.",
                 file=sys.stderr,
             )
             return 1
@@ -194,24 +215,6 @@ def main() -> int:
             # compiled, so its digest keeps proving what the recording showed.
             steps[idx] = a["replacement"]
 
-        existing = amendments_mod.load(_read_text(skill_dir / amendments_mod.AMENDMENTS_FILE))
-        seen = {amendments_mod.amendment_id(a) for a in existing}
-        merged = existing + [a for a in pending if amendments_mod.amendment_id(a) not in seen]
-        (skill_dir / amendments_mod.AMENDMENTS_FILE).write_text(
-            json.dumps({"amendments": merged}, indent=2, ensure_ascii=False), encoding="utf-8"
-        )
-        print(
-            f"Recorded {len(pending)} amendment(s). These are NOT part of the "
-            f"recording -- the member approves each one separately "
-            f"(verify_approve --approve-amendment ID):",
-            file=sys.stderr,
-        )
-        for a in pending:
-            print(
-                f"  [{amendments_mod.amendment_id(a)}] {amendments_mod.describe(a)}",
-                file=sys.stderr,
-            )
-
     values = {}
     for raw in args.param:
         name, _, value = raw.partition("=")
@@ -230,6 +233,44 @@ def main() -> int:
         # amended step is judged from the same place the original one was.
         entry_url=(doc.get("entry_url") if isinstance(doc, dict) else None),
     )
+
+    # Amendments are persisted AFTER the replay, stamped with what it proved
+    # about each one. Written beforehand they all looked equally confirmed: one
+    # build verified a single control by hand, amended the same step across six
+    # operations, and four of those were blocked long before the amended step ran
+    # -- yet every one of them said "confirmed working in live session".
+    if pending:
+        for a in pending:
+            a["verified"] = _step_ran_ok(report, a["operation"], a["step_index"])
+        existing = amendments_mod.load(_read_text(skill_dir / amendments_mod.AMENDMENTS_FILE))
+        by_id = {amendments_mod.amendment_id(a): a for a in existing}
+        for a in pending:
+            by_id[amendments_mod.amendment_id(a)] = a  # a later replay re-judges it
+        (skill_dir / amendments_mod.AMENDMENTS_FILE).write_text(
+            json.dumps({"amendments": list(by_id.values())}, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        unverified = [a for a in pending if not amendments_mod.is_verified(a)]
+        print(
+            f"Recorded {len(pending)} amendment(s). These are NOT part of the "
+            f"recording -- the member approves each one separately "
+            f"(verify_approve --approve-amendment ID):",
+            file=sys.stderr,
+        )
+        for a in pending:
+            print(
+                f"  [{amendments_mod.amendment_id(a)}] {amendments_mod.describe(a)}",
+                file=sys.stderr,
+            )
+        if unverified:
+            print(
+                f"\n{len(unverified)} of them never ran. Confirming a control by hand "
+                "on one page is not evidence for the same step in another operation "
+                "the replay never reached -- fix what blocked those operations and "
+                "replay again, rather than asking the member to approve a step "
+                "nothing has exercised.",
+                file=sys.stderr,
+            )
 
     out = skill_dir / REPORT_FILE
     try:

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -92,6 +92,16 @@ def main() -> int:
         "skill installable, and an amendment recorded here survives review as what it "
         "is: a step observed working once, which the member approves separately.",
     )
+    p.add_argument(
+        "--only",
+        action="append",
+        default=[],
+        metavar="OPERATION",
+        help="replay just these operations, from wherever the browser already is. "
+        "For iterating on one operation without re-walking the journey to reach "
+        "it -- the run is NOT evidence the skill works end to end, and its report "
+        "says so.",
+    )
     args = p.parse_args()
 
     skill_dir = Path(args.skill_dir)
@@ -176,6 +186,31 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 1
+
+    # Narrow the run AFTER the provenance gates, never before.
+    #
+    # Filtering first made the digest check see a skill with four operations
+    # removed, and it refused -- correctly in its own terms, since removing an
+    # operation changes the digest exactly as much as inventing one. But --only
+    # is a choice about what to EXERCISE, not a change to what was compiled, and
+    # the gates must judge the file on disk. The other ordering is worse: it
+    # would let a genuinely edited skill through by passing --only.
+    if operations and args.only:
+        wanted = {str(n) for n in args.only}
+        missing = wanted - {str(o.get("name")) for o in operations}
+        if missing:
+            print(
+                f"No operation named {', '.join(sorted(missing))} in this skill.",
+                file=sys.stderr,
+            )
+            return 1
+        operations = [o for o in operations if str(o.get("name")) in wanted]
+        print(
+            f"Replaying {len(operations)} of {len(doc['operations'])} operations, from "
+            f"wherever the browser is. This is for iterating, not for approval: a "
+            f"partial run cannot show the skill works end to end.",
+            file=sys.stderr,
+        )
 
     # Amendments: a step whose recorded locator no longer matches, replaced by a
     # control discovered at replay. Recorded HERE rather than by editing
@@ -274,6 +309,15 @@ def main() -> int:
                 "nothing has exercised.",
                 file=sys.stderr,
             )
+
+    if args.only:
+        # Stamped BEFORE the file is written, not after. Marking only the copy
+        # printed to stdout left replay_report.json looking like a full run --
+        # and that file is what the card renders and the installer reads, which
+        # is how a skill gets approved on evidence that only ever covered one
+        # operation.
+        report["partial"] = sorted(str(n) for n in args.only)
+        report["installable"] = False
 
     out = skill_dir / REPORT_FILE
     try:

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -36,7 +36,7 @@ from noui_core.verify.session import run_replay
 REPORT_FILE = "replay_report.json"
 
 
-def _read_text(path) -> str:
+def _read_text(path: Path) -> str:
     """File contents, or "" when absent."""
     try:
         return path.read_text(encoding="utf-8")

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -166,6 +166,21 @@ def main() -> int:
             print(f"Cannot read {bundle_path}: {exc}", file=sys.stderr)
             return 1
 
+        unbacked = provenance.unbacked_control_steps(operations)
+        if unbacked:
+            shown = ", ".join(repr(u) for u in unbacked[:5])
+            more = f" (and {len(unbacked) - 5} more)" if len(unbacked) > 5 else ""
+            print(
+                f"These steps drive a control the recording could never have backed: {shown}{more}.\n"
+                "\n"
+                "A coordinate click or a key-press names no control the recording saw, so "
+                "nothing ties it to what was captured. The compiler never emits these; their "
+                "presence means the operations were written or edited by hand. Restore the "
+                "compiled operations.json, or re-record the part you meant to change.",
+                file=sys.stderr,
+            )
+            return 1
+
         unobserved = provenance.unobserved_locators(operations, bundle)
         if unobserved:
             shown = ", ".join(repr(u) for u in unobserved[:5])

--- a/tests/fixtures/icici_statement_bundle.json
+++ b/tests/fixtures/icici_statement_bundle.json
@@ -1,0 +1,1863 @@
+{
+ "click_events": [
+  {
+   "candidates": [
+    {
+     "kind": "text",
+     "match_count": 13,
+     "value": "Login to Net Banking User ID Mobile No QR Code User ID Please enter your User ID Remember User ID Get User IDPasswordGet"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#adobePageLoadTimeTracker > app-new-login > div > div:nth-of-type(1) > div"
+    }
+   ],
+   "class_name": "top-section",
+   "element": {
+    "accessible_name": "Login to Net Banking User ID Mobile No QR Code User ID Please enter your User ID Remember User ID Get User IDPasswordGet",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 660,
+     "w": 1456,
+     "x": -12,
+     "y": 66
+    },
+    "role": null,
+    "tag": "div",
+    "visible": true
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:45:48.782Z",
+   "event_type": "hover",
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "reveal": true,
+   "selector": "div.top-section",
+   "seq": 2,
+   "tag_name": "DIV",
+   "text_content": "Login to Net Banking User ID Mobile No QR Code User ID Please enter your User ID Remember User ID Get User IDPasswordGet",
+   "timestamp": "2026-08-13T03:45:48.782Z",
+   "url": "https://retailnetbanking.icici.bank.in/login-page"
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "role_name",
+     "match_count": 1,
+     "value": "button|QR Code"
+    },
+    {
+     "kind": "text",
+     "match_count": 1,
+     "value": "QR Code"
+    },
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "button.tab-btn:text-is(\"QR Code\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "div:nth-of-type(1) > div > div > app-login-landing > div > div > div:nth-of-type(2) > button:nth-of-type(3)"
+    }
+   ],
+   "class_name": "tab-btn",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "QR Code",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 32,
+     "w": 88,
+     "x": 1216,
+     "y": 167
+    },
+    "role": "button",
+    "tag": "button",
+    "visible": true
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:45:48.782Z",
+   "event_type": "click",
+   "href": null,
+   "input_type": "submit",
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 9,
+    "settled_ms": 1284,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "button.tab-btn",
+   "seq": 3,
+   "tag_name": "BUTTON",
+   "text_content": "QR Code",
+   "timestamp": "2026-08-13T03:45:48.782Z",
+   "url": "https://retailnetbanking.icici.bank.in/login-page",
+   "x": 1269,
+   "y": 174
+  },
+  {
+   "candidates": [
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "div.sidenav-icon-box.d-flex:has-text(\"Cards\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#scroll-container > div > div:nth-of-type(5)"
+    }
+   ],
+   "class_name": "sidenav-icon-box d-flex align-items-center atag",
+   "element": {
+    "accessible_name": null,
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 52,
+     "w": 245,
+     "x": 0,
+     "y": 288
+    },
+    "role": null,
+    "tag": "div",
+    "visible": true
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:14.035Z",
+   "event_type": "hover",
+   "outcome": {
+    "download": false,
+    "navigated": true,
+    "request_count": 25,
+    "settled_ms": 2308,
+    "to_url": "https://retailnetbanking.icici.bank.in/credit-card"
+   },
+   "reveal": true,
+   "selector": "div.sidenav-icon-box.d-flex",
+   "seq": 6,
+   "tag_name": "DIV",
+   "text_content": null,
+   "timestamp": "2026-08-13T03:46:14.035Z",
+   "url": "https://retailnetbanking.icici.bank.in/overview"
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "text",
+     "match_count": 36,
+     "value": "Credit Cards"
+    },
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "div.submenu-text:text-is(\"Credit Cards\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#subContainer4 > ul > li:nth-of-type(1) > a > div"
+    },
+    {
+     "kind": "row_scoped",
+     "match_count": -1,
+     "value": "li:has-text(\"Credit Cards\") div.submenu-text:text-is(\"Credit Cards\")"
+    }
+   ],
+   "class_name": "submenu-text",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Credit Cards",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 19,
+     "w": 91,
+     "x": 298,
+     "y": 304
+    },
+    "role": null,
+    "tag": "div",
+    "visible": true
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:14.034Z",
+   "event_type": "click",
+   "href": null,
+   "input_type": null,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "div.submenu-text",
+   "seq": 7,
+   "tag_name": "DIV",
+   "text_content": "Credit Cards",
+   "timestamp": "2026-08-13T03:46:14.035Z",
+   "url": "https://retailnetbanking.icici.bank.in/overview",
+   "x": 300,
+   "y": 304
+  },
+  {
+   "candidates": [
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "div.statementsRow:has-text(\"statements\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#cardStatementTrackerCard > div:nth-of-type(1)"
+    }
+   ],
+   "class_name": "statementsRow ng-tns-c2386082053-1",
+   "element": {
+    "accessible_name": null,
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 24,
+     "w": 511,
+     "x": 283,
+     "y": 457
+    },
+    "role": null,
+    "tag": "div",
+    "visible": true
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:20.038Z",
+   "event_type": "hover",
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "reveal": true,
+   "selector": "div.statementsRow.ng-tns-c2386082053-1",
+   "seq": 8,
+   "tag_name": "DIV",
+   "text_content": null,
+   "timestamp": "2026-08-13T03:46:20.038Z",
+   "url": "https://retailnetbanking.icici.bank.in/credit-card"
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "text",
+     "match_count": 1,
+     "value": "Past"
+    },
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "li.tabItem:text-is(\"Past\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#cardStatementTrackerCard > div:nth-of-type(2) > div > ul > li:nth-of-type(3)"
+    }
+   ],
+   "class_name": "tabItem ng-tns-c2386082053-1",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Past",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 22,
+     "w": 170,
+     "x": 454,
+     "y": 498
+    },
+    "role": null,
+    "tag": "li",
+    "visible": true
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:20.038Z",
+   "event_type": "click",
+   "href": null,
+   "input_type": null,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 8,
+    "settled_ms": 2166,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "li.tabItem.ng-tns-c2386082053-1",
+   "seq": 9,
+   "tag_name": "LI",
+   "text_content": "Past",
+   "timestamp": "2026-08-13T03:46:20.038Z",
+   "url": "https://retailnetbanking.icici.bank.in/credit-card",
+   "x": 537,
+   "y": 504
+  },
+  {
+   "candidates": [
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "div.tabbarContainer:has-text(\"Current\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#cardStatementTrackerCard > div:nth-of-type(2) > div"
+    }
+   ],
+   "class_name": "tabbarContainer ng-tns-c2386082053-1",
+   "element": {
+    "accessible_name": null,
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 409,
+     "w": 511,
+     "x": 283,
+     "y": 497
+    },
+    "role": null,
+    "tag": "div",
+    "visible": true
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:22.895Z",
+   "event_type": "hover",
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "reveal": true,
+   "selector": "div.tabbarContainer.ng-tns-c2386082053-1",
+   "seq": 10,
+   "tag_name": "DIV",
+   "text_content": null,
+   "timestamp": "2026-08-13T03:46:22.895Z",
+   "url": "https://retailnetbanking.icici.bank.in/credit-card"
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "text",
+     "match_count": 1,
+     "value": "download previous statement"
+    },
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "p.orange-text:text-is(\"download previous statement\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#cardStatementTrackerCard > div:nth-of-type(2) > div > div > div > div:nth-of-type(1) > div:nth-of-type(2) > p"
+    }
+   ],
+   "class_name": "orange-text ng-tns-c2386082053-1",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "download previous statement",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 16,
+     "w": 224,
+     "x": 283,
+     "y": 562
+    },
+    "role": null,
+    "tag": "p",
+    "visible": true
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:22.895Z",
+   "event_type": "click",
+   "href": null,
+   "input_type": null,
+   "outcome": {
+    "download": false,
+    "navigated": true,
+    "request_count": 56,
+    "settled_ms": 2680,
+    "to_url": "https://infinity.icici.bank.in/corp/AuthenticationController?FORMSGROUP_ID__=AuthenticationFG&__START_TRAN_FLAG__=Y&FG_BUTTONS__=LOAD&ACTION.LOAD=Y&AuthenticationFG.LOGIN_FLAG=1&BANK_ID=ICI&__CALL_MODE__=119&UX_TOKEN=Lt46dVNS3YrfCUrXfJRBJ1+pw6a6lDMDNwm+B5VSS5vV2GwiJNbGXwphexpkeRfMLjR+s2g1OjweXQXFNBN7pWgSJqrebUyWRYPeDal7Qmp8+Sh5PuLyiy8RdqkK4+n6BmteF9qdUbCmdqa5SeSm1AVCOsjyA4T7/R6N0xrGwvGEmxeS+zRGAL+VLEn93Qjov5BCCKzu/hgiX3ho4oz6ZnKCQrNpZVcjydWkXhspcdIZbhHXsrTfFuf7/P3dfs8AtiWnSPbR1hMJNp/D70UNT85h43ulbDsDUiMfegIdh8b9HtFbpkd8+/Bqe9ngthQSdB9sf5ymaUIn31ialDTncK2tNkIsbkXYKNUnvr2toejmxmDnjryJgqXhUi7SDh9p2HUsnGJUQtDB9AZLvQVeFObbDJ1y7AYkb0KpkqtSmHfJrOtxWG1PH4C+j3mAVe4DZgAnH0xMD6KNvMMZl7MgC8njCgysuePcARUmAUXLUrtm0fE/oFHuJwNNdxpjy5SdFJZW8CXHq3G+ooi8nHEotW8L29dvzrjlBgBsAd5m4nP4ZmFTLhy29G+gOboPWFlTBLiZ6k216t9PRYdtWDs7cnXqCWkpmiiwzAa7zqZ6m95Lnf6YvbNb2EmvNIt+pxF0WPf9AkPy2VgvfB1GnQRbWERZJqxqgMja2Yqv/8F4MjvP3GGWqlWoqe7RUuiFP8jcImCmB9eAWtjLaVsJsBnxryefpntX5oDTbOTeQSF+lRU9kSP/4WPyZp9cb1ScoDryIwev5hrCyaq/hwn/pYkOp9KpzYYShH9BLhttl80j1Rfe+KvqJtwtCvYByg9z2HBNA+nf+1KH6IrSn6MrLHaExo47dQLpcxORP7CPigwhNuTIho4HzrMSf38TOJ/GWp1Z3/1ibrlsEyfs/4vsWrgKT8l/GDCpc6wbjWS3/Fk2hFSyBNFZ+RCUDgPEyAoehAmNQo2wHwrvytM4lQRAjMsj3Cz2StGDhNVAyIJpi1HCvHGIzTfuyfkBjdXMAiMNkY5f&CTA_FLAG=CCPSTM"
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "p.orange-text.ng-tns-c2386082053-1",
+   "seq": 11,
+   "tag_name": "P",
+   "text_content": "download previous statement",
+   "timestamp": "2026-08-13T03:46:22.895Z",
+   "url": "https://retailnetbanking.icici.bank.in/credit-card",
+   "x": 438,
+   "y": 565
+  },
+  {
+   "candidates": [
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "body:has-text(\"Log in to Internet Banking\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "body"
+    }
+   ],
+   "class_name": null,
+   "element": {
+    "accessible_name": null,
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 778,
+     "w": 1439,
+     "x": 0,
+     "y": 0
+    },
+    "role": null,
+    "tag": "body",
+    "visible": true
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:25.328Z",
+   "event_type": "hover",
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "reveal": true,
+   "selector": "body",
+   "seq": 13,
+   "tag_name": "BODY",
+   "text_content": null,
+   "timestamp": "2026-08-13T03:46:25.329Z",
+   "url": "https://infinity.icici.bank.in/corp/AuthenticationController?FORMSGROUP_ID__=AuthenticationFG&__START_TRAN_FLAG__=Y&FG_BUTTONS__=LOAD&ACTION.LOAD=Y&AuthenticationFG.LOGIN_FLAG=1&BANK_ID=ICI&__CALL_MODE__=119&UX_TOKEN=Lt46dVNS3YrfCUrXfJRBJ1+pw6a6lDMDNwm+B5VSS5vV2GwiJNbGXwphexpkeRfMLjR+s2g1OjweXQXFNBN7pWgSJqrebUyWRYPeDal7Qmp8+Sh5PuLyiy8RdqkK4+n6BmteF9qdUbCmdqa5SeSm1AVCOsjyA4T7/R6N0xrGwvGEmxeS+zRGAL+VLEn93Qjov5BCCKzu/hgiX3ho4oz6ZnKCQrNpZVcjydWkXhspcdIZbhHXsrTfFuf7/P3dfs8AtiWnSPbR1hMJNp/D70UNT85h43ulbDsDUiMfegIdh8b9HtFbpkd8+/Bqe9ngthQSdB9sf5ymaUIn31ialDTncK2tNkIsbkXYKNUnvr2toejmxmDnjryJgqXhUi7SDh9p2HUsnGJUQtDB9AZLvQVeFObbDJ1y7AYkb0KpkqtSmHfJrOtxWG1PH4C+j3mAVe4DZgAnH0xMD6KNvMMZl7MgC8njCgysuePcARUmAUXLUrtm0fE/oFHuJwNNdxpjy5SdFJZW8CXHq3G+ooi8nHEotW8L29dvzrjlBgBsAd5m4nP4ZmFTLhy29G+gOboPWFlTBLiZ6k216t9PRYdtWDs7cnXqCWkpmiiwzAa7zqZ6m95Lnf6YvbNb2EmvNIt+pxF0WPf9AkPy2VgvfB1GnQRbWERZJqxqgMja2Yqv/8F4MjvP3GGWqlWoqe7RUuiFP8jcImCmB9eAWtjLaVsJsBnxryefpntX5oDTbOTeQSF+lRU9kSP/4WPyZp9cb1ScoDryIwev5hrCyaq/hwn/pYkOp9KpzYYShH9BLhttl80j1Rfe+KvqJtwtCvYByg9z2HBNA+nf+1KH6IrSn6MrLHaExo47dQLpcxORP7CPigwhNuTIho4HzrMSf38TOJ/GWp1Z3/1ibrlsEyfs/4vsWrgKT8l/GDCpc6wbjWS3/Fk2hFSyBNFZ+RCUDgPEyAoehAmNQo2wHwrvytM4lQRAjMsj3Cz2StGDhNVAyIJpi1HCvHGIzTfuyfkBjdXMAiMNkY5f&CTA_FLAG=CCPSTM"
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 1,
+     "value": "#DEH_LOGIN"
+    },
+    {
+     "kind": "name",
+     "match_count": 1,
+     "value": "input[name=\"Action\\.DEH_LOGIN\"]"
+    },
+    {
+     "kind": "role_name",
+     "match_count": 1,
+     "value": "button|Log In"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#DEH_LOGIN"
+    }
+   ],
+   "class_name": "completeHide",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Log In",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 0,
+     "w": 0,
+     "x": 0,
+     "y": 0
+    },
+    "role": "button",
+    "tag": "input",
+    "visible": false
+   },
+   "element_id": "DEH_LOGIN",
+   "event_time": "2026-08-13T03:46:25.328Z",
+   "event_type": "click",
+   "href": null,
+   "input_type": "submit",
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "#DEH_LOGIN",
+   "seq": 14,
+   "tag_name": "INPUT",
+   "text_content": null,
+   "timestamp": "2026-08-13T03:46:25.328Z",
+   "url": "https://infinity.icici.bank.in/corp/AuthenticationController?FORMSGROUP_ID__=AuthenticationFG&__START_TRAN_FLAG__=Y&FG_BUTTONS__=LOAD&ACTION.LOAD=Y&AuthenticationFG.LOGIN_FLAG=1&BANK_ID=ICI&__CALL_MODE__=119&UX_TOKEN=Lt46dVNS3YrfCUrXfJRBJ1+pw6a6lDMDNwm+B5VSS5vV2GwiJNbGXwphexpkeRfMLjR+s2g1OjweXQXFNBN7pWgSJqrebUyWRYPeDal7Qmp8+Sh5PuLyiy8RdqkK4+n6BmteF9qdUbCmdqa5SeSm1AVCOsjyA4T7/R6N0xrGwvGEmxeS+zRGAL+VLEn93Qjov5BCCKzu/hgiX3ho4oz6ZnKCQrNpZVcjydWkXhspcdIZbhHXsrTfFuf7/P3dfs8AtiWnSPbR1hMJNp/D70UNT85h43ulbDsDUiMfegIdh8b9HtFbpkd8+/Bqe9ngthQSdB9sf5ymaUIn31ialDTncK2tNkIsbkXYKNUnvr2toejmxmDnjryJgqXhUi7SDh9p2HUsnGJUQtDB9AZLvQVeFObbDJ1y7AYkb0KpkqtSmHfJrOtxWG1PH4C+j3mAVe4DZgAnH0xMD6KNvMMZl7MgC8njCgysuePcARUmAUXLUrtm0fE/oFHuJwNNdxpjy5SdFJZW8CXHq3G+ooi8nHEotW8L29dvzrjlBgBsAd5m4nP4ZmFTLhy29G+gOboPWFlTBLiZ6k216t9PRYdtWDs7cnXqCWkpmiiwzAa7zqZ6m95Lnf6YvbNb2EmvNIt+pxF0WPf9AkPy2VgvfB1GnQRbWERZJqxqgMja2Yqv/8F4MjvP3GGWqlWoqe7RUuiFP8jcImCmB9eAWtjLaVsJsBnxryefpntX5oDTbOTeQSF+lRU9kSP/4WPyZp9cb1ScoDryIwev5hrCyaq/hwn/pYkOp9KpzYYShH9BLhttl80j1Rfe+KvqJtwtCvYByg9z2HBNA+nf+1KH6IrSn6MrLHaExo47dQLpcxORP7CPigwhNuTIho4HzrMSf38TOJ/GWp1Z3/1ibrlsEyfs/4vsWrgKT8l/GDCpc6wbjWS3/Fk2hFSyBNFZ+RCUDgPEyAoehAmNQo2wHwrvytM4lQRAjMsj3Cz2StGDhNVAyIJpi1HCvHGIzTfuyfkBjdXMAiMNkY5f&CTA_FLAG=CCPSTM",
+   "x": 0,
+   "y": 0
+  },
+  {
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 1,
+     "value": "#DEH_LOGIN"
+    },
+    {
+     "kind": "name",
+     "match_count": 1,
+     "value": "input[name=\"Action\\.DEH_LOGIN\"]"
+    },
+    {
+     "kind": "role_name",
+     "match_count": 1,
+     "value": "button|Log In"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#DEH_LOGIN"
+    }
+   ],
+   "class_name": null,
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Log In",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 0,
+     "w": 0,
+     "x": 0,
+     "y": 0
+    },
+    "role": "button",
+    "tag": "input",
+    "visible": false
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:25.333Z",
+   "event_type": "submit",
+   "field_name": "AuthenticationFG",
+   "field_role": null,
+   "input_type": "form",
+   "is_redacted": false,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 2,
+    "settled_ms": 2725,
+    "to_url": null
+   },
+   "selector": "form[name=\"AuthenticationFG\"]",
+   "seq": 15,
+   "tag_name": "FORM",
+   "timestamp": "2026-08-13T03:46:25.333Z",
+   "url": "https://infinity.icici.bank.in/corp/AuthenticationController?FORMSGROUP_ID__=AuthenticationFG&__START_TRAN_FLAG__=Y&FG_BUTTONS__=LOAD&ACTION.LOAD=Y&AuthenticationFG.LOGIN_FLAG=1&BANK_ID=ICI&__CALL_MODE__=119&UX_TOKEN=Lt46dVNS3YrfCUrXfJRBJ1+pw6a6lDMDNwm+B5VSS5vV2GwiJNbGXwphexpkeRfMLjR+s2g1OjweXQXFNBN7pWgSJqrebUyWRYPeDal7Qmp8+Sh5PuLyiy8RdqkK4+n6BmteF9qdUbCmdqa5SeSm1AVCOsjyA4T7/R6N0xrGwvGEmxeS+zRGAL+VLEn93Qjov5BCCKzu/hgiX3ho4oz6ZnKCQrNpZVcjydWkXhspcdIZbhHXsrTfFuf7/P3dfs8AtiWnSPbR1hMJNp/D70UNT85h43ulbDsDUiMfegIdh8b9HtFbpkd8+/Bqe9ngthQSdB9sf5ymaUIn31ialDTncK2tNkIsbkXYKNUnvr2toejmxmDnjryJgqXhUi7SDh9p2HUsnGJUQtDB9AZLvQVeFObbDJ1y7AYkb0KpkqtSmHfJrOtxWG1PH4C+j3mAVe4DZgAnH0xMD6KNvMMZl7MgC8njCgysuePcARUmAUXLUrtm0fE/oFHuJwNNdxpjy5SdFJZW8CXHq3G+ooi8nHEotW8L29dvzrjlBgBsAd5m4nP4ZmFTLhy29G+gOboPWFlTBLiZ6k216t9PRYdtWDs7cnXqCWkpmiiwzAa7zqZ6m95Lnf6YvbNb2EmvNIt+pxF0WPf9AkPy2VgvfB1GnQRbWERZJqxqgMja2Yqv/8F4MjvP3GGWqlWoqe7RUuiFP8jcImCmB9eAWtjLaVsJsBnxryefpntX5oDTbOTeQSF+lRU9kSP/4WPyZp9cb1ScoDryIwev5hrCyaq/hwn/pYkOp9KpzYYShH9BLhttl80j1Rfe+KvqJtwtCvYByg9z2HBNA+nf+1KH6IrSn6MrLHaExo47dQLpcxORP7CPigwhNuTIho4HzrMSf38TOJ/GWp1Z3/1ibrlsEyfs/4vsWrgKT8l/GDCpc6wbjWS3/Fk2hFSyBNFZ+RCUDgPEyAoehAmNQo2wHwrvytM4lQRAjMsj3Cz2StGDhNVAyIJpi1HCvHGIzTfuyfkBjdXMAiMNkY5f&CTA_FLAG=CCPSTM",
+   "value": "https://infinity.icici.bank.in/corp/AuthenticationController;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=UK8t%2FhDi0cpVKGV1JqwMs5nkpeRm04aPR2YNw91NLao%3D"
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 1,
+     "value": "#CustomViewEStatementsFG\\.PERIOD"
+    },
+    {
+     "kind": "name",
+     "match_count": 1,
+     "value": "select[name=\"CustomViewEStatementsFG\\.PERIOD\"]"
+    },
+    {
+     "kind": "role_name",
+     "match_count": 1,
+     "value": "combobox|Period"
+    },
+    {
+     "kind": "label",
+     "match_count": 1,
+     "value": "Period"
+    },
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "select.dropdownexpandalbe:has-text(\"19/6/2026-18/7/2026\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#CustomViewEStatementsFG\\.PERIOD"
+    }
+   ],
+   "class_name": "dropdownexpandalbe",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Period",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 0,
+     "w": 0,
+     "x": 0,
+     "y": 0
+    },
+    "role": "combobox",
+    "tag": "select",
+    "visible": false
+   },
+   "element_id": "CustomViewEStatementsFG.PERIOD",
+   "event_time": "2026-08-13T03:46:29.943Z",
+   "event_type": "change",
+   "field_name": "CustomViewEStatementsFG.PERIOD",
+   "field_role": null,
+   "input_type": "select",
+   "is_redacted": false,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "#CustomViewEStatementsFG.PERIOD",
+   "seq": 17,
+   "tag_name": "SELECT",
+   "timestamp": "2026-08-13T03:46:29.943Z",
+   "url": "https://infinity.icici.bank.in/corp/AuthenticationController;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=UK8t%2FhDi0cpVKGV1JqwMs5nkpeRm04aPR2YNw91NLao%3D",
+   "value": "06/19/2026#07/18/2026"
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 1,
+     "value": "#FieldDropdown"
+    },
+    {
+     "kind": "name",
+     "match_count": 1,
+     "value": "select[name=\"FieldDropdown\"]"
+    },
+    {
+     "kind": "role_name",
+     "match_count": 1,
+     "value": "combobox|Upgrade Debit Card"
+    },
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "select.dropdownexpandalbe.hide:has-text(\"Select\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#FieldDropdown"
+    }
+   ],
+   "class_name": "dropdownexpandalbe hide",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Upgrade Debit Card",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 0,
+     "w": 0,
+     "x": 0,
+     "y": 0
+    },
+    "role": "combobox",
+    "tag": "select",
+    "visible": false
+   },
+   "element_id": "FieldDropdown",
+   "event_time": "2026-08-13T03:46:30.698Z",
+   "event_type": "change",
+   "field_name": "FieldDropdown",
+   "field_role": null,
+   "input_type": "select",
+   "is_redacted": false,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "#FieldDropdown",
+   "seq": 18,
+   "tag_name": "SELECT",
+   "timestamp": "2026-08-13T03:46:30.698Z",
+   "url": "https://infinity.icici.bank.in/corp/AuthenticationController;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=UK8t%2FhDi0cpVKGV1JqwMs5nkpeRm04aPR2YNw91NLao%3D",
+   "value": "Value"
+  },
+  {
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 5,
+     "value": "#InfoPanel1\\.Rowset1"
+    },
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "div.width100percent:has-text(\"Monthly\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 5,
+     "value": "#InfoPanel1\\.Rowset1"
+    }
+   ],
+   "class_name": "width100percent",
+   "element": {
+    "accessible_name": null,
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 188,
+     "w": 695,
+     "x": 483,
+     "y": 239
+    },
+    "role": null,
+    "tag": "div",
+    "visible": true
+   },
+   "element_id": "InfoPanel1.Rowset1",
+   "event_time": "2026-08-13T03:46:35.408Z",
+   "event_type": "hover",
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "reveal": true,
+   "selector": "#InfoPanel1.Rowset1",
+   "seq": 19,
+   "tag_name": "DIV",
+   "text_content": null,
+   "timestamp": "2026-08-13T03:46:35.409Z",
+   "url": "https://infinity.icici.bank.in/corp/AuthenticationController;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=UK8t%2FhDi0cpVKGV1JqwMs5nkpeRm04aPR2YNw91NLao%3D"
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 2,
+     "value": "#CustomViewEStatementsFG\\.PERIOD_TYPE"
+    },
+    {
+     "kind": "name",
+     "match_count": 2,
+     "value": "input[name=\"CustomViewEStatementsFG\\.PERIOD_TYPE\"]"
+    },
+    {
+     "kind": "name",
+     "match_count": 1,
+     "value": "input[name=\"CustomViewEStatementsFG\\.PERIOD_TYPE\"][value=\"Y\"]"
+    },
+    {
+     "kind": "role_name",
+     "match_count": 1,
+     "value": "radio|Annual"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 2,
+     "value": "#CustomViewEStatementsFG\\.PERIOD_TYPE"
+    }
+   ],
+   "class_name": "simpletext",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Annual",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 13,
+     "w": 13,
+     "x": 590,
+     "y": 270
+    },
+    "role": "radio",
+    "tag": "input",
+    "visible": true
+   },
+   "element_id": "CustomViewEStatementsFG.PERIOD_TYPE",
+   "event_time": "2026-08-13T03:46:35.408Z",
+   "event_type": "click",
+   "href": null,
+   "input_type": "radio",
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "#CustomViewEStatementsFG.PERIOD_TYPE",
+   "seq": 20,
+   "tag_name": "INPUT",
+   "text_content": null,
+   "timestamp": "2026-08-13T03:46:35.408Z",
+   "url": "https://infinity.icici.bank.in/corp/AuthenticationController;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=UK8t%2FhDi0cpVKGV1JqwMs5nkpeRm04aPR2YNw91NLao%3D",
+   "x": 593,
+   "y": 275
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 1,
+     "value": "#DUMMY1"
+    },
+    {
+     "kind": "name",
+     "match_count": 1,
+     "value": "input[name=\"Action\\.DUMMY1\"]"
+    },
+    {
+     "kind": "role_name",
+     "match_count": 2,
+     "value": "button|GO"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#DUMMY1"
+    }
+   ],
+   "class_name": "formbtn",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "GO",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 24,
+     "w": 34,
+     "x": 508,
+     "y": 172
+    },
+    "role": "button",
+    "tag": "input",
+    "visible": false
+   },
+   "element_id": "DUMMY1",
+   "event_time": "2026-08-13T03:46:35.413Z",
+   "event_type": "click",
+   "href": null,
+   "input_type": "submit",
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "#DUMMY1",
+   "seq": 21,
+   "tag_name": "INPUT",
+   "text_content": null,
+   "timestamp": "2026-08-13T03:46:35.413Z",
+   "url": "https://infinity.icici.bank.in/corp/AuthenticationController;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=UK8t%2FhDi0cpVKGV1JqwMs5nkpeRm04aPR2YNw91NLao%3D",
+   "x": 0,
+   "y": 0
+  },
+  {
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 1,
+     "value": "#DUMMY1"
+    },
+    {
+     "kind": "name",
+     "match_count": 1,
+     "value": "input[name=\"Action\\.DUMMY1\"]"
+    },
+    {
+     "kind": "role_name",
+     "match_count": 2,
+     "value": "button|GO"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#DUMMY1"
+    }
+   ],
+   "class_name": null,
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "GO",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 24,
+     "w": 34,
+     "x": 508,
+     "y": 172
+    },
+    "role": "button",
+    "tag": "input",
+    "visible": false
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:35.421Z",
+   "event_type": "submit",
+   "field_name": "CustomViewEStatementsFG",
+   "field_role": null,
+   "input_type": "form",
+   "is_redacted": false,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "selector": "form[name=\"CustomViewEStatementsFG\"]",
+   "seq": 22,
+   "tag_name": "FORM",
+   "timestamp": "2026-08-13T03:46:35.421Z",
+   "url": "https://infinity.icici.bank.in/corp/AuthenticationController;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=UK8t%2FhDi0cpVKGV1JqwMs5nkpeRm04aPR2YNw91NLao%3D",
+   "value": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D"
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 2,
+     "value": "#CustomViewEStatementsFG\\.PERIOD_TYPE"
+    },
+    {
+     "kind": "name",
+     "match_count": 2,
+     "value": "input[name=\"CustomViewEStatementsFG\\.PERIOD_TYPE\"]"
+    },
+    {
+     "kind": "name",
+     "match_count": 2,
+     "value": "input[name=\"CustomViewEStatementsFG\\.PERIOD_TYPE\"][value=\"Y\"]"
+    },
+    {
+     "kind": "role_name",
+     "match_count": 1,
+     "value": "radio|Annual"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 2,
+     "value": "#CustomViewEStatementsFG\\.PERIOD_TYPE"
+    }
+   ],
+   "class_name": "simpletext",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Annual",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 13,
+     "w": 13,
+     "x": 590,
+     "y": 270
+    },
+    "role": "radio",
+    "tag": "input",
+    "visible": true
+   },
+   "element_id": "CustomViewEStatementsFG.PERIOD_TYPE",
+   "event_time": "2026-08-13T03:46:35.424Z",
+   "event_type": "change",
+   "field_name": "CustomViewEStatementsFG.PERIOD_TYPE",
+   "field_role": null,
+   "input_type": "radio",
+   "is_redacted": false,
+   "outcome": {
+    "download": false,
+    "navigated": true,
+    "request_count": 150,
+    "settled_ms": 2472,
+    "to_url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D"
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "#CustomViewEStatementsFG.PERIOD_TYPE",
+   "seq": 23,
+   "tag_name": "INPUT",
+   "timestamp": "2026-08-13T03:46:35.424Z",
+   "url": "https://infinity.icici.bank.in/corp/AuthenticationController;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=UK8t%2FhDi0cpVKGV1JqwMs5nkpeRm04aPR2YNw91NLao%3D",
+   "value": "checked"
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 1,
+     "value": "#CustomViewEStatementsFG\\.PERIOD"
+    },
+    {
+     "kind": "name",
+     "match_count": 1,
+     "value": "select[name=\"CustomViewEStatementsFG\\.PERIOD\"]"
+    },
+    {
+     "kind": "role_name",
+     "match_count": 1,
+     "value": "combobox|Period"
+    },
+    {
+     "kind": "label",
+     "match_count": 1,
+     "value": "Period"
+    },
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "select.dropdownexpandalbe:has-text(\"FY2024-25\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#CustomViewEStatementsFG\\.PERIOD"
+    }
+   ],
+   "class_name": "dropdownexpandalbe",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Period",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 0,
+     "w": 0,
+     "x": 0,
+     "y": 0
+    },
+    "role": "combobox",
+    "tag": "select",
+    "visible": false
+   },
+   "element_id": "CustomViewEStatementsFG.PERIOD",
+   "event_time": "2026-08-13T03:46:37.876Z",
+   "event_type": "change",
+   "field_name": "CustomViewEStatementsFG.PERIOD",
+   "field_role": null,
+   "input_type": "select",
+   "is_redacted": false,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "#CustomViewEStatementsFG.PERIOD",
+   "seq": 25,
+   "tag_name": "SELECT",
+   "timestamp": "2026-08-13T03:46:37.877Z",
+   "url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D",
+   "value": "FY2024-25"
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 1,
+     "value": "#FieldDropdown"
+    },
+    {
+     "kind": "name",
+     "match_count": 1,
+     "value": "select[name=\"FieldDropdown\"]"
+    },
+    {
+     "kind": "role_name",
+     "match_count": 1,
+     "value": "combobox|Upgrade Debit Card"
+    },
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "select.dropdownexpandalbe.hide:has-text(\"Select\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#FieldDropdown"
+    }
+   ],
+   "class_name": "dropdownexpandalbe hide",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Upgrade Debit Card",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 0,
+     "w": 0,
+     "x": 0,
+     "y": 0
+    },
+    "role": "combobox",
+    "tag": "select",
+    "visible": false
+   },
+   "element_id": "FieldDropdown",
+   "event_time": "2026-08-13T03:46:38.816Z",
+   "event_type": "change",
+   "field_name": "FieldDropdown",
+   "field_role": null,
+   "input_type": "select",
+   "is_redacted": false,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "#FieldDropdown",
+   "seq": 26,
+   "tag_name": "SELECT",
+   "timestamp": "2026-08-13T03:46:38.817Z",
+   "url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D",
+   "value": "Value"
+  },
+  {
+   "candidates": [
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "body:has-text(\"jQuery.noConflict();\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "body"
+    }
+   ],
+   "class_name": null,
+   "element": {
+    "accessible_name": null,
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 778,
+     "w": 1424,
+     "x": 0,
+     "y": 0
+    },
+    "role": null,
+    "tag": "body",
+    "visible": true
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:40.437Z",
+   "event_type": "hover",
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "reveal": true,
+   "selector": "body",
+   "seq": 27,
+   "tag_name": "BODY",
+   "text_content": null,
+   "timestamp": "2026-08-13T03:46:40.441Z",
+   "url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D"
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "div.newListSelected.newListSelFocus:has-text(\"FY2024-25\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#InfoPanel1\\.Ra5\\.C1 > span > span > div"
+    }
+   ],
+   "class_name": "newListSelected  newListSelFocus",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": null,
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 24,
+     "w": 210,
+     "x": 665,
+     "y": 341
+    },
+    "role": null,
+    "tag": "div",
+    "visible": true
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:40.436Z",
+   "event_type": "click",
+   "href": null,
+   "input_type": null,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "div.newListSelected.newListSelFocus",
+   "seq": 28,
+   "tag_name": "DIV",
+   "text_content": null,
+   "timestamp": "2026-08-13T03:46:40.437Z",
+   "url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D",
+   "x": 675,
+   "y": 345
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "text",
+     "match_count": 4,
+     "value": "FY2024-25"
+    },
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "div.selectedTxt:text-is(\"FY2024-25\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#InfoPanel1\\.Ra5\\.C1 > span > span > div > div:nth-of-type(1)"
+    }
+   ],
+   "class_name": "selectedTxt",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "FY2024-25",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 24,
+     "w": 195,
+     "x": 675,
+     "y": 346
+    },
+    "role": null,
+    "tag": "div",
+    "visible": true
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:43.497Z",
+   "event_type": "click",
+   "href": null,
+   "input_type": null,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "div.selectedTxt",
+   "seq": 29,
+   "tag_name": "DIV",
+   "text_content": "FY2024-25",
+   "timestamp": "2026-08-13T03:46:43.498Z",
+   "url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D",
+   "x": 724,
+   "y": 354
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "role_name",
+     "match_count": 1,
+     "value": "link|FY2025-26"
+    },
+    {
+     "kind": "text",
+     "match_count": 3,
+     "value": "FY2025-26"
+    },
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "a.newListHover:text-is(\"FY2025-26\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#InfoPanel1\\.Ra5\\.C1 > span > span > div > div:nth-of-type(2) > ul > li:nth-of-type(4) > a"
+    }
+   ],
+   "class_name": "newListHover",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "FY2025-26",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 18,
+     "w": 208,
+     "x": 666,
+     "y": 428
+    },
+    "role": "link",
+    "tag": "a",
+    "visible": true
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:45.031Z",
+   "event_type": "click",
+   "href": "javascript:void(0);",
+   "input_type": null,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "a.newListHover",
+   "seq": 30,
+   "tag_name": "A",
+   "text_content": "FY2025-26",
+   "timestamp": "2026-08-13T03:46:45.032Z",
+   "url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D",
+   "x": 709,
+   "y": 429
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 1,
+     "value": "#CustomViewEStatementsFG\\.PERIOD"
+    },
+    {
+     "kind": "name",
+     "match_count": 1,
+     "value": "select[name=\"CustomViewEStatementsFG\\.PERIOD\"]"
+    },
+    {
+     "kind": "role_name",
+     "match_count": 1,
+     "value": "combobox|Period"
+    },
+    {
+     "kind": "label",
+     "match_count": 1,
+     "value": "Period"
+    },
+    {
+     "kind": "container_label",
+     "match_count": -1,
+     "value": "select.dropdownexpandalbe:has-text(\"FY2024-25\")"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#CustomViewEStatementsFG\\.PERIOD"
+    }
+   ],
+   "class_name": "dropdownexpandalbe",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Period",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 0,
+     "w": 0,
+     "x": 0,
+     "y": 0
+    },
+    "role": "combobox",
+    "tag": "select",
+    "visible": false
+   },
+   "element_id": "CustomViewEStatementsFG.PERIOD",
+   "event_time": "2026-08-13T03:46:45.217Z",
+   "event_type": "change",
+   "field_name": "CustomViewEStatementsFG.PERIOD",
+   "field_role": null,
+   "input_type": "select",
+   "is_redacted": false,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "#CustomViewEStatementsFG.PERIOD",
+   "seq": 31,
+   "tag_name": "SELECT",
+   "timestamp": "2026-08-13T03:46:45.217Z",
+   "url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D",
+   "value": "FY2025-26"
+  },
+  {
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 5,
+     "value": "#InfoPanel1"
+    },
+    {
+     "kind": "text",
+     "match_count": 1,
+     "value": "Please click on the icon below to download a printable copy of your e-Statement. Monthly Annual Credit Card Number Selec"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 5,
+     "value": "#InfoPanel1"
+    }
+   ],
+   "class_name": "section m_AdvSrchFlds padding_20 Padding_adjust",
+   "element": {
+    "accessible_name": "Please click on the icon below to download a printable copy of your e-Statement. Monthly Annual Credit Card Number Selec",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 344,
+     "w": 695,
+     "x": 483,
+     "y": 217
+    },
+    "role": null,
+    "tag": "div",
+    "visible": true
+   },
+   "element_id": "InfoPanel1",
+   "event_time": "2026-08-13T03:46:49.061Z",
+   "event_type": "hover",
+   "outcome": {
+    "download": true,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "reveal": true,
+   "selector": "#InfoPanel1",
+   "seq": 32,
+   "tag_name": "DIV",
+   "text_content": "Please click on the icon below to download a printable copy of your e-Statement. Monthly Annual Credit Card Number Selec",
+   "timestamp": "2026-08-13T03:46:49.061Z",
+   "url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D"
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 1,
+     "value": "#PDF_Download"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#PDF_Download"
+    }
+   ],
+   "class_name": "m_excelPDF",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Adobe - PDF Format",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 21,
+     "w": 16,
+     "x": 885,
+     "y": 343
+    },
+    "role": null,
+    "tag": "img",
+    "visible": true
+   },
+   "element_id": "PDF_Download",
+   "event_time": "2026-08-13T03:46:49.060Z",
+   "event_type": "click",
+   "href": null,
+   "input_type": null,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "#PDF_Download",
+   "seq": 33,
+   "tag_name": "IMG",
+   "text_content": null,
+   "timestamp": "2026-08-13T03:46:49.060Z",
+   "url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D",
+   "x": 886,
+   "y": 348
+  },
+  {
+   "aria_label": null,
+   "autocomplete": null,
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 1,
+     "value": "#DOWNLOAD_ESTATEMENT_PDF"
+    },
+    {
+     "kind": "name",
+     "match_count": 1,
+     "value": "input[name=\"Action\\.DOWNLOAD_ESTATEMENT_PDF\"]"
+    },
+    {
+     "kind": "role_name",
+     "match_count": 5,
+     "value": "button|Go"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#DOWNLOAD_ESTATEMENT_PDF"
+    }
+   ],
+   "class_name": "Global_note_heading m_margin",
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Go",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 16,
+     "w": 25,
+     "x": 483,
+     "y": 586
+    },
+    "role": "button",
+    "tag": "input",
+    "visible": false
+   },
+   "element_id": "DOWNLOAD_ESTATEMENT_PDF",
+   "event_time": "2026-08-13T03:46:49.101Z",
+   "event_type": "click",
+   "href": null,
+   "input_type": "submit",
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 0,
+    "settled_ms": null,
+    "to_url": null
+   },
+   "placeholder": null,
+   "role_attr": null,
+   "selector": "#DOWNLOAD_ESTATEMENT_PDF",
+   "seq": 34,
+   "tag_name": "INPUT",
+   "text_content": null,
+   "timestamp": "2026-08-13T03:46:49.101Z",
+   "url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D",
+   "x": 0,
+   "y": 0
+  },
+  {
+   "candidates": [
+    {
+     "kind": "id",
+     "match_count": 1,
+     "value": "#DOWNLOAD_ESTATEMENT_PDF"
+    },
+    {
+     "kind": "name",
+     "match_count": 1,
+     "value": "input[name=\"Action\\.DOWNLOAD_ESTATEMENT_PDF\"]"
+    },
+    {
+     "kind": "role_name",
+     "match_count": 5,
+     "value": "button|Go"
+    },
+    {
+     "kind": "css_path",
+     "match_count": 1,
+     "value": "#DOWNLOAD_ESTATEMENT_PDF"
+    }
+   ],
+   "class_name": null,
+   "data_attrs_json": null,
+   "element": {
+    "accessible_name": "Go",
+    "frame_name": "",
+    "frame_url": "",
+    "in_iframe": false,
+    "in_shadow_dom": false,
+    "occluded": false,
+    "rect": {
+     "h": 16,
+     "w": 25,
+     "x": 483,
+     "y": 586
+    },
+    "role": "button",
+    "tag": "input",
+    "visible": false
+   },
+   "element_id": null,
+   "event_time": "2026-08-13T03:46:49.107Z",
+   "event_type": "submit",
+   "field_name": "CustomViewEStatementsFG",
+   "field_role": null,
+   "input_type": "form",
+   "is_redacted": false,
+   "outcome": {
+    "download": false,
+    "navigated": false,
+    "request_count": 1,
+    "settled_ms": 1416,
+    "to_url": null
+   },
+   "selector": "form[name=\"CustomViewEStatementsFG\"]",
+   "seq": 35,
+   "tag_name": "FORM",
+   "timestamp": "2026-08-13T03:46:49.107Z",
+   "url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D",
+   "value": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=p2SK0aNgNawtEi30FjwS%2BJnkpeRm04aPR2YNw91NLao%3D"
+  }
+ ],
+ "download_events": [
+  {
+   "page_id": 0,
+   "page_url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D",
+   "suggested_filename": "CreditCardStatement.pdf",
+   "timestamp": "2026-08-13T03:46:50.523Z",
+   "url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=p2SK0aNgNawtEi30FjwS%2BJnkpeRm04aPR2YNw91NLao%3D"
+  }
+ ],
+ "url_events": [
+  {
+   "from_url": "about:blank",
+   "seq": 1,
+   "timestamp": "2026-08-13T03:44:42.469Z",
+   "to_url": "https://retailnetbanking.icici.bank.in/login-page"
+  },
+  {
+   "from_url": "https://retailnetbanking.icici.bank.in/login-page",
+   "seq": 4,
+   "timestamp": "2026-08-13T03:46:04.223Z",
+   "to_url": "https://retailnetbanking.icici.bank.in/overview"
+  },
+  {
+   "from_url": "https://retailnetbanking.icici.bank.in/overview",
+   "seq": 5,
+   "timestamp": "2026-08-13T03:46:14.493Z",
+   "to_url": "https://retailnetbanking.icici.bank.in/credit-card"
+  },
+  {
+   "from_url": "https://retailnetbanking.icici.bank.in/credit-card",
+   "seq": 12,
+   "timestamp": "2026-08-13T03:46:23.997Z",
+   "to_url": "https://infinity.icici.bank.in/corp/AuthenticationController?FORMSGROUP_ID__=AuthenticationFG&__START_TRAN_FLAG__=Y&FG_BUTTONS__=LOAD&ACTION.LOAD=Y&AuthenticationFG.LOGIN_FLAG=1&BANK_ID=ICI&__CALL_MODE__=119&UX_TOKEN=Lt46dVNS3YrfCUrXfJRBJ1+pw6a6lDMDNwm+B5VSS5vV2GwiJNbGXwphexpkeRfMLjR+s2g1OjweXQXFNBN7pWgSJqrebUyWRYPeDal7Qmp8+Sh5PuLyiy8RdqkK4+n6BmteF9qdUbCmdqa5SeSm1AVCOsjyA4T7/R6N0xrGwvGEmxeS+zRGAL+VLEn93Qjov5BCCKzu/hgiX3ho4oz6ZnKCQrNpZVcjydWkXhspcdIZbhHXsrTfFuf7/P3dfs8AtiWnSPbR1hMJNp/D70UNT85h43ulbDsDUiMfegIdh8b9HtFbpkd8+/Bqe9ngthQSdB9sf5ymaUIn31ialDTncK2tNkIsbkXYKNUnvr2toejmxmDnjryJgqXhUi7SDh9p2HUsnGJUQtDB9AZLvQVeFObbDJ1y7AYkb0KpkqtSmHfJrOtxWG1PH4C+j3mAVe4DZgAnH0xMD6KNvMMZl7MgC8njCgysuePcARUmAUXLUrtm0fE/oFHuJwNNdxpjy5SdFJZW8CXHq3G+ooi8nHEotW8L29dvzrjlBgBsAd5m4nP4ZmFTLhy29G+gOboPWFlTBLiZ6k216t9PRYdtWDs7cnXqCWkpmiiwzAa7zqZ6m95Lnf6YvbNb2EmvNIt+pxF0WPf9AkPy2VgvfB1GnQRbWERZJqxqgMja2Yqv/8F4MjvP3GGWqlWoqe7RUuiFP8jcImCmB9eAWtjLaVsJsBnxryefpntX5oDTbOTeQSF+lRU9kSP/4WPyZp9cb1ScoDryIwev5hrCyaq/hwn/pYkOp9KpzYYShH9BLhttl80j1Rfe+KvqJtwtCvYByg9z2HBNA+nf+1KH6IrSn6MrLHaExo47dQLpcxORP7CPigwhNuTIho4HzrMSf38TOJ/GWp1Z3/1ibrlsEyfs/4vsWrgKT8l/GDCpc6wbjWS3/Fk2hFSyBNFZ+RCUDgPEyAoehAmNQo2wHwrvytM4lQRAjMsj3Cz2StGDhNVAyIJpi1HCvHGIzTfuyfkBjdXMAiMNkY5f&CTA_FLAG=CCPSTM"
+  },
+  {
+   "from_url": "https://infinity.icici.bank.in/corp/AuthenticationController?FORMSGROUP_ID__=AuthenticationFG&__START_TRAN_FLAG__=Y&FG_BUTTONS__=LOAD&ACTION.LOAD=Y&AuthenticationFG.LOGIN_FLAG=1&BANK_ID=ICI&__CALL_MODE__=119&UX_TOKEN=Lt46dVNS3YrfCUrXfJRBJ1+pw6a6lDMDNwm+B5VSS5vV2GwiJNbGXwphexpkeRfMLjR+s2g1OjweXQXFNBN7pWgSJqrebUyWRYPeDal7Qmp8+Sh5PuLyiy8RdqkK4+n6BmteF9qdUbCmdqa5SeSm1AVCOsjyA4T7/R6N0xrGwvGEmxeS+zRGAL+VLEn93Qjov5BCCKzu/hgiX3ho4oz6ZnKCQrNpZVcjydWkXhspcdIZbhHXsrTfFuf7/P3dfs8AtiWnSPbR1hMJNp/D70UNT85h43ulbDsDUiMfegIdh8b9HtFbpkd8+/Bqe9ngthQSdB9sf5ymaUIn31ialDTncK2tNkIsbkXYKNUnvr2toejmxmDnjryJgqXhUi7SDh9p2HUsnGJUQtDB9AZLvQVeFObbDJ1y7AYkb0KpkqtSmHfJrOtxWG1PH4C+j3mAVe4DZgAnH0xMD6KNvMMZl7MgC8njCgysuePcARUmAUXLUrtm0fE/oFHuJwNNdxpjy5SdFJZW8CXHq3G+ooi8nHEotW8L29dvzrjlBgBsAd5m4nP4ZmFTLhy29G+gOboPWFlTBLiZ6k216t9PRYdtWDs7cnXqCWkpmiiwzAa7zqZ6m95Lnf6YvbNb2EmvNIt+pxF0WPf9AkPy2VgvfB1GnQRbWERZJqxqgMja2Yqv/8F4MjvP3GGWqlWoqe7RUuiFP8jcImCmB9eAWtjLaVsJsBnxryefpntX5oDTbOTeQSF+lRU9kSP/4WPyZp9cb1ScoDryIwev5hrCyaq/hwn/pYkOp9KpzYYShH9BLhttl80j1Rfe+KvqJtwtCvYByg9z2HBNA+nf+1KH6IrSn6MrLHaExo47dQLpcxORP7CPigwhNuTIho4HzrMSf38TOJ/GWp1Z3/1ibrlsEyfs/4vsWrgKT8l/GDCpc6wbjWS3/Fk2hFSyBNFZ+RCUDgPEyAoehAmNQo2wHwrvytM4lQRAjMsj3Cz2StGDhNVAyIJpi1HCvHGIzTfuyfkBjdXMAiMNkY5f&CTA_FLAG=CCPSTM",
+   "seq": 16,
+   "timestamp": "2026-08-13T03:46:27.894Z",
+   "to_url": "https://infinity.icici.bank.in/corp/AuthenticationController;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=UK8t%2FhDi0cpVKGV1JqwMs5nkpeRm04aPR2YNw91NLao%3D"
+  },
+  {
+   "from_url": "https://infinity.icici.bank.in/corp/AuthenticationController;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=UK8t%2FhDi0cpVKGV1JqwMs5nkpeRm04aPR2YNw91NLao%3D",
+   "seq": 24,
+   "timestamp": "2026-08-13T03:46:35.602Z",
+   "to_url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=00004pP4Jyr2Wp3da96iESmTye2:CR03n36mnzd?bwayparam=nwRPpYFAhdWzVoHXXOKRkJnkpeRm04aPR2YNw91NLao%3D"
+  }
+ ]
+}

--- a/tests/fixtures/icici_statement_operations.json
+++ b/tests/fixtures/icici_statement_operations.json
@@ -70,7 +70,7 @@
     "hover_first": null
    },
    {
-    "command": "click_element",
+    "command": "hover",
     "target": "div.width100percent:has-text(\"Monthly\")",
     "value": null,
     "hover_first": null
@@ -204,12 +204,6 @@
    {
     "command": "click_by_text",
     "target": "FY2025-26",
-    "value": null,
-    "hover_first": null
-   },
-   {
-    "command": "click_by_text",
-    "target": "Please click on the icon below to download a printable copy of your e-Statement. Monthly Annual Credit Card Number Selec",
     "value": null,
     "hover_first": null
    },

--- a/tests/fixtures/icici_statement_operations.json
+++ b/tests/fixtures/icici_statement_operations.json
@@ -1,0 +1,212 @@
+[
+ {
+  "name": "read_credit_card",
+  "kind": null,
+  "steps": [
+   {
+    "command": "click_element",
+    "target": "#subContainer4 > ul > li:nth-of-type(1) > a > div",
+    "value": null,
+    "hover_first": "#scroll-container > div > div:nth-of-type(5)"
+   },
+   {
+    "command": "get_page_summary",
+    "target": null,
+    "value": null,
+    "hover_first": null
+   }
+  ]
+ },
+ {
+  "name": "read_corp_authenticationcontroller",
+  "kind": null,
+  "steps": [
+   {
+    "command": "click_by_text",
+    "target": "Past",
+    "value": null,
+    "hover_first": "#cardStatementTrackerCard > div:nth-of-type(1)"
+   },
+   {
+    "command": "click_by_text",
+    "target": "download previous statement",
+    "value": null,
+    "hover_first": "#cardStatementTrackerCard > div:nth-of-type(2) > div"
+   },
+   {
+    "command": "get_page_summary",
+    "target": null,
+    "value": null,
+    "hover_first": null
+   }
+  ]
+ },
+ {
+  "name": "read_corp_finacle",
+  "kind": null,
+  "steps": [
+   {
+    "command": "click_element",
+    "target": "#DEH_LOGIN",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "get_page_summary",
+    "target": null,
+    "value": null,
+    "hover_first": null
+   }
+  ]
+ },
+ {
+  "name": "submit_corp_authenticationcontroller",
+  "kind": "submit",
+  "steps": [
+   {
+    "command": "click_element",
+    "target": "#DEH_LOGIN",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "get_page_summary",
+    "target": null,
+    "value": null,
+    "hover_first": null
+   }
+  ]
+ },
+ {
+  "name": "download_please_click_on_the_icon_below_to_download_a_printa",
+  "kind": "download",
+  "steps": [
+   {
+    "command": "set_checked",
+    "target": "radio",
+    "value": "Annual",
+    "hover_first": null
+   },
+   {
+    "command": "click_element",
+    "target": "#InfoPanel1\\.Ra5\\.C1 > span > span > div",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "click_element",
+    "target": "#InfoPanel1\\.Ra5\\.C1 > span > span > div > div:nth-of-type(1)",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "click_by_text",
+    "target": "FY2025-26",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "select_option",
+    "target": "#CustomViewEStatementsFG\\.PERIOD",
+    "value": "{{custom_view_e_statements_f_g_p_e_r_i_o_d}}",
+    "hover_first": null
+   },
+   {
+    "command": "select_option",
+    "target": "#FieldDropdown",
+    "value": "{{field_dropdown}}",
+    "hover_first": null
+   },
+   {
+    "command": "click_by_text",
+    "target": "Please click on the icon below to download a printable copy of your e-Statement. Monthly Annual Credit Card Number Selec",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "list_downloads",
+    "target": null,
+    "value": null,
+    "hover_first": null
+   }
+  ]
+ },
+ {
+  "name": "submit_corp_finacle",
+  "kind": "submit",
+  "steps": [
+   {
+    "command": "click_element",
+    "target": "#InfoPanel1\\.Ra5\\.C1 > span > span > div",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "click_element",
+    "target": "#InfoPanel1\\.Ra5\\.C1 > span > span > div > div:nth-of-type(1)",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "click_by_text",
+    "target": "FY2025-26",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "click_by_text",
+    "target": "Please click on the icon below to download a printable copy of your e-Statement. Monthly Annual Credit Card Number Selec",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "click_element",
+    "target": "#PDF_Download",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "click_element",
+    "target": "#DOWNLOAD_ESTATEMENT_PDF",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "select_option",
+    "target": "#CustomViewEStatementsFG\\.PERIOD",
+    "value": "{{custom_view_e_statements_f_g_p_e_r_i_o_d}}",
+    "hover_first": null
+   },
+   {
+    "command": "select_option",
+    "target": "#FieldDropdown",
+    "value": "{{field_dropdown}}",
+    "hover_first": null
+   },
+   {
+    "command": "click_element",
+    "target": "#DOWNLOAD_ESTATEMENT_PDF",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "get_page_summary",
+    "target": null,
+    "value": null,
+    "hover_first": null
+   }
+  ]
+ },
+ {
+  "name": "read_overview",
+  "kind": null,
+  "steps": [
+   {
+    "command": "get_page_summary",
+    "target": null,
+    "value": null,
+    "hover_first": null
+   }
+  ]
+ }
+]

--- a/tests/fixtures/icici_statement_operations.json
+++ b/tests/fixtures/icici_statement_operations.json
@@ -174,8 +174,8 @@
   ]
  },
  {
-  "name": "submit_corp_finacle",
-  "kind": "submit",
+  "name": "download_corp_finacle",
+  "kind": "download",
   "steps": [
    {
     "command": "click_element",
@@ -214,7 +214,7 @@
     "hover_first": null
    },
    {
-    "command": "get_page_summary",
+    "command": "list_downloads",
     "target": null,
     "value": null,
     "hover_first": null

--- a/tests/fixtures/icici_statement_operations.json
+++ b/tests/fixtures/icici_statement_operations.json
@@ -208,18 +208,6 @@
     "hover_first": null
    },
    {
-    "command": "click_element",
-    "target": "#PDF_Download",
-    "value": null,
-    "hover_first": null
-   },
-   {
-    "command": "click_element",
-    "target": "#DOWNLOAD_ESTATEMENT_PDF",
-    "value": null,
-    "hover_first": null
-   },
-   {
     "command": "select_option",
     "target": "#CustomViewEStatementsFG\\.PERIOD",
     "value": "{{custom_view_e_statements_f_g_p_e_r_i_o_d}}",
@@ -229,6 +217,12 @@
     "command": "select_option",
     "target": "#FieldDropdown",
     "value": "{{field_dropdown}}",
+    "hover_first": null
+   },
+   {
+    "command": "click_element",
+    "target": "#PDF_Download",
+    "value": null,
     "hover_first": null
    },
    {

--- a/tests/fixtures/icici_statement_operations.json
+++ b/tests/fixtures/icici_statement_operations.json
@@ -60,6 +60,60 @@
   ]
  },
  {
+  "name": "submit_corp_authenticationcontroller_2",
+  "kind": "submit",
+  "steps": [
+   {
+    "command": "click_element",
+    "target": "#DEH_LOGIN",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "click_element",
+    "target": "div.width100percent:has-text(\"Monthly\")",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "set_checked",
+    "target": "input[name=\"CustomViewEStatementsFG\\.PERIOD_TYPE\"][value=\"Y\"]",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "click_element",
+    "target": "#DUMMY1",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "select_option",
+    "target": "#CustomViewEStatementsFG\\.PERIOD",
+    "value": "{{custom_view_e_statements_f_g_p_e_r_i_o_d}}",
+    "hover_first": null
+   },
+   {
+    "command": "select_option",
+    "target": "#FieldDropdown",
+    "value": "{{field_dropdown}}",
+    "hover_first": null
+   },
+   {
+    "command": "click_element",
+    "target": "#DUMMY1",
+    "value": null,
+    "hover_first": null
+   },
+   {
+    "command": "get_page_summary",
+    "target": null,
+    "value": null,
+    "hover_first": null
+   }
+  ]
+ },
+ {
   "name": "submit_corp_authenticationcontroller",
   "kind": "submit",
   "steps": [

--- a/tests/fixtures/icici_statement_operations.json
+++ b/tests/fixtures/icici_statement_operations.json
@@ -94,12 +94,6 @@
     "hover_first": null
    },
    {
-    "command": "select_option",
-    "target": "#FieldDropdown",
-    "value": "{{field_dropdown}}",
-    "hover_first": null
-   },
-   {
     "command": "click_element",
     "target": "#DUMMY1",
     "value": null,
@@ -166,12 +160,6 @@
     "hover_first": null
    },
    {
-    "command": "select_option",
-    "target": "#FieldDropdown",
-    "value": "{{field_dropdown}}",
-    "hover_first": null
-   },
-   {
     "command": "click_by_text",
     "target": "Please click on the icon below to download a printable copy of your e-Statement. Monthly Annual Credit Card Number Selec",
     "value": null,
@@ -211,12 +199,6 @@
     "command": "select_option",
     "target": "#CustomViewEStatementsFG\\.PERIOD",
     "value": "{{custom_view_e_statements_f_g_p_e_r_i_o_d}}",
-    "hover_first": null
-   },
-   {
-    "command": "select_option",
-    "target": "#FieldDropdown",
-    "value": "{{field_dropdown}}",
     "hover_first": null
    },
    {

--- a/tests/test_amendment_verification.py
+++ b/tests/test_amendment_verification.py
@@ -1,0 +1,62 @@
+"""An amendment records what the replay proved about it, not what was hoped.
+
+Run 050970d3: the build confirmed `click_by_text "Credit Card"` worked once on
+/overview, then amended step 0 of SIX operations. Two of them ran. The other four
+were blocked long before the amended step could execute — and all six went into
+amendments.json carrying "confirmed working in live session", ready for the
+member to approve in one go.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+sys.path.insert(0, str(_ROOT / "skills" / "noui" / "scripts"))  # _bootstrap
+
+_spec = importlib.util.spec_from_file_location(
+    "_vr", _ROOT / "skills" / "noui" / "scripts" / "verify_replay.py"
+)
+vr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(vr)
+
+# The shape verify_replay's own report has: one entry per operation, one per step.
+REPORT = {
+    "operations": [
+        {"name": "read_credit_card", "steps": [{"status": "ok"}, {"status": "ok"}]},
+        {
+            "name": "read_corp_authenticationcontroller",
+            "steps": [{"status": "ok"}, {"status": "blocked"}, {"status": "blocked"}],
+        },
+        # Blocked at step 0 — the amended step is index 0, and it did not pass.
+        {"name": "download_corp_finacle", "steps": [{"status": "blocked"}]},
+    ]
+}
+
+
+def test_a_step_that_ran_cleanly_is_verified():
+    assert vr._step_ran_ok(REPORT, "read_credit_card", 0) is True
+
+
+def test_a_blocked_step_is_not_verified():
+    assert vr._step_ran_ok(REPORT, "download_corp_finacle", 0) is False
+    assert vr._step_ran_ok(REPORT, "read_corp_authenticationcontroller", 1) is False
+
+
+def test_a_step_the_replay_never_reached_is_not_verified():
+    # The operation died at step 1, so there is no result for step 2 onward.
+    # Missing must never read as passing.
+    assert vr._step_ran_ok(REPORT, "read_credit_card", 5) is False
+
+
+def test_an_operation_the_replay_never_ran_is_not_verified():
+    assert vr._step_ran_ok(REPORT, "submit_corp_authenticationcontroller", 0) is False
+
+
+def test_an_empty_report_verifies_nothing():
+    # login_required: the session died, so nothing was proved about anything.
+    assert vr._step_ran_ok({}, "read_credit_card", 0) is False
+    assert vr._step_ran_ok({"operations": []}, "read_credit_card", 0) is False

--- a/tests/test_amendments.py
+++ b/tests/test_amendments.py
@@ -1,0 +1,51 @@
+"""Steps discovered at replay live apart from the ones that were recorded.
+
+operations.json is what a human was observed doing, and the digest over it makes
+that claim checkable. When a compiled locator died at replay, the agent wrote the
+control it found INTO operations.json — destroying the provenance, getting the
+whole skill refused, and losing the discovery along with the evidence.
+
+The discovery was not worthless. It was a different KIND of evidence.
+"""
+
+from noui_core.compile.amendments import amendment_id, describe, load
+
+AMEND = {
+    "operation": "download_statement",
+    "step_index": 3,
+    "why": "the recorded css path matched nothing",
+    "replacement": {"command": "click_element", "params": {"selector": "#new-btn"}},
+}
+
+
+def test_the_id_matches_the_harness_implementation():
+    # Pinned in both repos: if they drift, an approval can never be matched to
+    # the amendment it approved, and every amended skill is refused forever.
+    assert amendment_id(AMEND) == "c9c973553b09f380"
+
+
+def test_the_id_changes_when_the_replacement_does():
+    other = dict(
+        AMEND, replacement={"command": "click_element", "params": {"selector": "#something-else"}}
+    )
+    assert amendment_id(other) != amendment_id(AMEND)
+
+
+def test_a_malformed_file_reads_as_no_amendments():
+    # An amendment nobody can interpret must never become one nobody reviewed.
+    assert load("{not json") == []
+    assert load(None) == []
+    assert load('{"amendments": "nonsense"}') == []
+
+
+def test_an_entry_without_a_replacement_is_not_an_amendment():
+    import json
+
+    assert load(json.dumps({"amendments": [{"operation": "x"}]})) == []
+
+
+def test_it_describes_an_amendment_in_one_line_a_member_can_decide_on():
+    text = describe(AMEND)
+    assert "download_statement step 3" in text
+    assert "#new-btn" in text
+    assert "matched nothing" in text

--- a/tests/test_amendments.py
+++ b/tests/test_amendments.py
@@ -162,3 +162,32 @@ def test_an_amendment_out_of_range_is_refused(tmp_path):
     )
     assert r.returncode == 1
     assert "out of range" in r.stderr
+
+
+# --- an amendment is only worth what the replay proved about it ----------------
+#
+# Run 050970d3: one control confirmed by hand on /overview, then step 0 amended
+# across six operations. Two ran; four were blocked long before reaching the
+# amended step. All six were written as "confirmed working in live session".
+
+from noui_core.compile.amendments import is_verified  # noqa: E402
+
+
+def test_an_amendment_is_unverified_until_the_replay_runs_it():
+    assert is_verified(AMEND) is False
+    assert is_verified({**AMEND, "verified": False}) is False
+    assert is_verified({**AMEND, "verified": True}) is True
+
+
+def test_describe_says_when_nothing_exercised_the_step():
+    # The member reads this line and nothing else. It must not read the same for
+    # a step that ran and a step that never happened.
+    assert "NOT EXERCISED" in describe(AMEND)
+    assert "NOT EXERCISED" not in describe({**AMEND, "verified": True})
+    assert "ran OK" in describe({**AMEND, "verified": True})
+
+
+def test_the_verified_flag_does_not_change_the_id():
+    # Ids are how an approval names what it approved. If replaying an amendment
+    # renamed it, the member's earlier decision would silently detach.
+    assert amendment_id({**AMEND, "verified": True}) == amendment_id(AMEND)

--- a/tests/test_amendments.py
+++ b/tests/test_amendments.py
@@ -49,3 +49,116 @@ def test_it_describes_an_amendment_in_one_line_a_member_can_decide_on():
     assert "download_statement step 3" in text
     assert "#new-btn" in text
     assert "matched nothing" in text
+
+
+# --- verify_replay records amendments without touching operations.json -------
+
+
+def _skill(tmp_path):
+    import json
+
+    from noui_core.compile.provenance import steps_digest
+
+    ops = [
+        {
+            "name": "dl",
+            "kind": "download",
+            "tool": "call_web_browser",
+            "steps": [
+                {"command": "click_element", "params": {"selector": "#old"}},
+                {"command": "list_downloads"},
+            ],
+        }
+    ]
+    (tmp_path / "operations.json").write_text(json.dumps({"operations": ops}))
+    (tmp_path / "manifest.json").write_text(
+        json.dumps(
+            {
+                "runtime": {"operation_style": "browser"},
+                "provenance": {"steps_sha256": steps_digest(ops), "bundle_sha256": "x"},
+            }
+        )
+    )
+    return tmp_path
+
+
+def _run_amend(tmp_path, *amend_json):
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    script = Path("skills/noui/scripts/verify_replay.py").resolve()
+    argv = [sys.executable, str(script), str(tmp_path), "--profile-slug", "none"]
+    for a in amend_json:
+        argv += ["--amend", a]
+    return subprocess.run(
+        argv,
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "PYTHONPATH": str(Path("skills/noui").resolve())},
+    )
+
+
+def test_an_amendment_never_edits_the_compiled_operations(tmp_path):
+    """THE property. Editing operations.json destroys the digest that proves the
+    rest came from a recording — which is what three builds did, losing the
+    discovery along with the evidence when the gate then refused the skill."""
+    import json
+
+    from noui_core.compile.provenance import steps_digest
+
+    d = _skill(tmp_path)
+    _run_amend(
+        d,
+        json.dumps(
+            {
+                "operation": "dl",
+                "step_index": 0,
+                "replacement": {"command": "click_element", "params": {"selector": "#new"}},
+                "why": "#old matched nothing",
+            }
+        ),
+    )
+
+    ops = json.loads((d / "operations.json").read_text())["operations"]
+    manifest = json.loads((d / "manifest.json").read_text())
+    assert ops[0]["steps"][0]["params"]["selector"] == "#old"
+    assert steps_digest(ops) == manifest["provenance"]["steps_sha256"]
+    assert len(json.loads((d / "amendments.json").read_text())["amendments"]) == 1
+
+
+def test_an_amendment_naming_an_unknown_operation_is_refused(tmp_path):
+    import json
+
+    d = _skill(tmp_path)
+    r = _run_amend(
+        d,
+        json.dumps(
+            {
+                "operation": "nope",
+                "step_index": 0,
+                "replacement": {"command": "click_element", "params": {"selector": "#x"}},
+            }
+        ),
+    )
+    assert r.returncode == 1
+    assert "No operation named" in r.stderr
+    assert not (d / "amendments.json").exists()
+
+
+def test_an_amendment_out_of_range_is_refused(tmp_path):
+    import json
+
+    d = _skill(tmp_path)
+    r = _run_amend(
+        d,
+        json.dumps(
+            {
+                "operation": "dl",
+                "step_index": 9,
+                "replacement": {"command": "click_element", "params": {"selector": "#x"}},
+            }
+        ),
+    )
+    assert r.returncode == 1
+    assert "out of range" in r.stderr

--- a/tests/test_approval_waiver.py
+++ b/tests/test_approval_waiver.py
@@ -1,0 +1,146 @@
+"""A waiver has to name what it waives, and name all of it.
+
+Run 050970d3: the replay reached 3 of 7 goals. The failures were the statement
+download — the entire thing the member had asked for. `--force` was one flag
+that covered all of it, so the build reached for it, drafted the member's
+approval sentence, and asked them to paste it back.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+sys.path.insert(0, str(_ROOT / "skills" / "noui" / "scripts"))  # _bootstrap
+
+_spec = importlib.util.spec_from_file_location(
+    "_va", _ROOT / "skills" / "noui" / "scripts" / "verify_approve.py"
+)
+va = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(va)
+
+REPORT = {
+    "fingerprint": "abc123",
+    "all_goals_reached": False,
+    "operations": [
+        {"name": "read_overview", "goal_reached": True, "steps": [{"status": "ok"}]},
+        {
+            "name": "download_monthly_statement",
+            "goal_reached": False,
+            "steps": [
+                {"command": "click_by_text", "status": "ok"},
+                {"command": "click_by_text", "status": "blocked", "error": "nothing matches"},
+            ],
+        },
+        {
+            "name": "download_annual_statement",
+            "goal_reached": False,
+            "steps": [{"command": "click_element", "status": "blocked", "error": "no match"}],
+        },
+    ],
+}
+
+
+def _skill(tmp_path, report=None):
+    d = tmp_path / "icici"
+    d.mkdir()
+    (d / "replay_report.json").write_text(json.dumps(report or REPORT), encoding="utf-8")
+    return d
+
+
+def _run(monkeypatch, skill_dir, *flags):
+    monkeypatch.setattr(sys, "argv", ["verify_approve.py", str(skill_dir), *flags])
+    return va.main()
+
+
+def _approval(skill_dir):
+    return json.loads((skill_dir / "replay_approval.json").read_text(encoding="utf-8"))
+
+
+def test_force_is_gone_and_says_what_replaced_it(tmp_path, monkeypatch, capsys):
+    d = _skill(tmp_path)
+    assert _run(monkeypatch, d, "--force") == 1
+    err = capsys.readouterr().err
+    assert "--accept-failing" in err
+    assert not (d / "replay_approval.json").exists()
+
+
+def test_an_unnamed_failure_refuses_and_lists_the_flags(tmp_path, monkeypatch, capsys):
+    d = _skill(tmp_path)
+    assert _run(monkeypatch, d) == 1
+    err = capsys.readouterr().err
+    # The message must be usable as-is: the build should not have to work out
+    # the operation names itself, that is how the convenient ones get named and
+    # the rest get quietly dropped.
+    assert "--accept-failing download_monthly_statement" in err
+    assert "--accept-failing download_annual_statement" in err
+
+
+def test_naming_only_some_failures_is_refused(tmp_path, monkeypatch, capsys):
+    d = _skill(tmp_path)
+    code = _run(monkeypatch, d, "--accept-failing", "download_monthly_statement")
+    assert code == 1
+    assert "download_annual_statement" in capsys.readouterr().err
+    assert not (d / "replay_approval.json").exists()
+
+
+def test_naming_an_operation_that_passed_is_refused(tmp_path, monkeypatch, capsys):
+    # A list carried over from an earlier replay: it names something that is now
+    # green, which means it was not written about THIS run.
+    d = _skill(tmp_path)
+    code = _run(
+        monkeypatch,
+        d,
+        "--accept-failing",
+        "read_overview",
+        "--accept-failing",
+        "download_monthly_statement",
+        "--accept-failing",
+        "download_annual_statement",
+    )
+    assert code == 1
+    assert "read_overview" in capsys.readouterr().err
+
+
+def test_naming_an_operation_that_does_not_exist_is_refused(tmp_path, monkeypatch, capsys):
+    d = _skill(tmp_path)
+    code = _run(monkeypatch, d, "--accept-failing", "download_quarterly")
+    assert code == 1
+    assert "download_quarterly" in capsys.readouterr().err
+
+
+def test_naming_every_failure_approves_and_records_why(tmp_path, monkeypatch):
+    d = _skill(tmp_path)
+    code = _run(
+        monkeypatch,
+        d,
+        "--accept-failing",
+        "download_monthly_statement",
+        "--accept-failing",
+        "download_annual_statement",
+    )
+    assert code == 0
+    rec = _approval(d)
+    assert rec["installable"] is True
+    waived = {a["operation"]: a for a in rec["accepted_failing"]}
+    assert set(waived) == {"download_monthly_statement", "download_annual_statement"}
+    # Built from the report, not from what the caller said about it — the member
+    # sees the actual error, not a summary written by whoever wanted the waiver.
+    assert waived["download_monthly_statement"]["blocked"] == [
+        {"command": "click_by_text", "error": "nothing matches"}
+    ]
+
+
+def test_an_all_green_replay_needs_no_waiver(tmp_path, monkeypatch):
+    report = {
+        "fingerprint": "abc123",
+        "all_goals_reached": True,
+        "operations": [{"name": "read_overview", "goal_reached": True, "steps": []}],
+    }
+    d = _skill(tmp_path, report)
+    assert _run(monkeypatch, d) == 0
+    assert "accepted_failing" not in _approval(d)

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -1352,3 +1352,69 @@ def test_an_ordinary_button_still_compiles_to_a_click():
         }
     )
     assert step["command"] == "click_element"
+
+
+def test_a_recorded_hover_compiles_to_a_hover_step():
+    """The menu that opens on hover must be opened at replay too.
+
+    ICICI's top nav reveals its items on hover: hover "Cards", click "Credit
+    Cards". With no hover step the compiled path never opens the menu, and the
+    click targets something that does not exist yet.
+    """
+    from noui_core.compile.browser_skill import _step_for_click
+
+    step = _step_for_click(
+        {
+            "event_type": "hover",
+            "text": "Cards",
+            "locator": {
+                "value": "#nav-cards",
+                "kind": "css",
+                "is_css": True,
+                "confidence": "high",
+                "match_count": 1,
+            },
+        }
+    )
+    assert step["command"] == "hover"
+    assert step["params"]["selector"] == "#nav-cards"
+
+
+def test_a_hover_with_only_a_text_locator_is_not_compiled():
+    # There is no hover-by-text at runtime, and guessing one would hover the
+    # wrong thing — worse than leaving the gesture out.
+    from noui_core.compile.browser_skill import _step_for_click
+
+    step = _step_for_click(
+        {
+            "event_type": "hover",
+            "text": "Cards",
+            "locator": {
+                "value": "Cards",
+                "kind": "text",
+                "is_css": False,
+                "confidence": "medium",
+                "match_count": 1,
+            },
+        }
+    )
+    assert step is None
+
+
+def test_a_hover_inside_a_frame_keeps_its_frame():
+    from noui_core.compile.browser_skill import _step_for_click
+
+    step = _step_for_click(
+        {
+            "event_type": "hover",
+            "locator": {
+                "value": "#menu",
+                "kind": "css",
+                "is_css": True,
+                "confidence": "high",
+                "match_count": 1,
+            },
+            "element": {"in_iframe": True, "frame_url": "https://finacle.test/x"},
+        }
+    )
+    assert step["params"]["frame_url"] == "https://finacle.test/x"

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -1145,8 +1145,13 @@ def test_a_click_inside_an_iframe_carries_the_frame_to_the_step():
 
     step = _step_for_click(
         {
-            "locator": {"value": "#PDF_Download", "kind": "css", "is_css": True,
-                        "confidence": "high", "match_count": 1},
+            "locator": {
+                "value": "#PDF_Download",
+                "kind": "css",
+                "is_css": True,
+                "confidence": "high",
+                "match_count": 1,
+            },
             "element": {
                 "in_iframe": True,
                 "frame_url": "https://finacle.bank.test/statements?tok=abc",
@@ -1164,8 +1169,13 @@ def test_a_top_level_click_names_no_frame():
 
     step = _step_for_click(
         {
-            "locator": {"value": "#nav", "kind": "css", "is_css": True,
-                        "confidence": "high", "match_count": 1},
+            "locator": {
+                "value": "#nav",
+                "kind": "css",
+                "is_css": True,
+                "confidence": "high",
+                "match_count": 1,
+            },
             "element": {"in_iframe": False},
         }
     )

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -579,7 +579,11 @@ def test_unnumbered_bundle_still_uses_timestamps():
 # visible text alone.
 
 _RICH_EVENTS = [
-    {"from_url": f"{_H}/login-page", "to_url": f"{_H}/overview", "timestamp": "2026-08-07T10:00:00Z"},
+    {
+        "from_url": f"{_H}/login-page",
+        "to_url": f"{_H}/overview",
+        "timestamp": "2026-08-07T10:00:00Z",
+    },
     {
         "from_url": f"{_H}/overview",
         "to_url": f"{_H}/credit-card",
@@ -689,7 +693,9 @@ def test_an_icon_button_is_compiled_instead_of_dropped():
     # accordions, so the page they lead to became unreachable and was dropped.
     icon = _rich_click(
         text_content="",
-        candidates=[{"kind": "aria_label", "value": 'button[aria-label="Open menu"]', "match_count": 1}],
+        candidates=[
+            {"kind": "aria_label", "value": 'button[aria-label="Open menu"]', "match_count": 1}
+        ],
     )
     pages = derive_browser_pages(_RICH_EVENTS, [icon], login_url=LOGIN)
 

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -1418,3 +1418,80 @@ def test_a_hover_inside_a_frame_keeps_its_frame():
         }
     )
     assert step["params"]["frame_url"] == "https://finacle.test/x"
+
+
+def test_a_dropdown_opener_is_addressed_by_selector_not_its_value():
+    """The opener's label is the widget's VALUE, not a control name.
+
+    ICICI's year dropdown displays "FY2024-25"; you click that to open it, then
+    click the year you want. At replay the displayed value differs — next year,
+    or on another account — so click_by_text("FY2024-25") matches nothing.
+    """
+    from noui_core.compile.browser_skill import _step_for_click
+
+    step = _step_for_click(
+        {
+            "is_opener": True,
+            "text": "FY2024-25",
+            "locator": {
+                "value": "FY2024-25",
+                "kind": "text",
+                "is_css": False,
+                "confidence": "medium",
+                "match_count": 1,
+            },
+            "candidates": [
+                {"kind": "text", "value": "FY2024-25", "match_count": 1},
+                {"kind": "css_path", "value": "#InfoPanel1 > span > div", "match_count": 1},
+            ],
+        }
+    )
+    assert step["command"] == "click_element"
+    assert step["params"]["selector"] == "#InfoPanel1 > span > div"
+
+
+def test_an_ordinary_nav_item_keeps_its_text_locator():
+    """THE GUARD. "Credit Cards" has the same shape as the dropdown opener —
+    a div with no role, distinguished only by its text — and recovering that
+    text locator is what this session was for. Only an OPENER may lose it."""
+    from noui_core.compile.browser_skill import _step_for_click
+
+    step = _step_for_click(
+        {
+            "text": "Credit Cards",
+            "locator": {
+                "value": "Credit Cards",
+                "kind": "text",
+                "is_css": False,
+                "confidence": "high",
+                "match_count": 1,
+            },
+            "candidates": [
+                {"kind": "text", "value": "Credit Cards", "match_count": 1},
+                {"kind": "css_path", "value": "#scroll-container > div", "match_count": 1},
+            ],
+        }
+    )
+    assert step["command"] == "click_by_text"
+    assert step["params"]["text"] == "Credit Cards"
+
+
+def test_an_opener_with_no_stable_selector_keeps_what_it_has():
+    # Better a text locator that may drift than no step at all.
+    from noui_core.compile.browser_skill import _step_for_click
+
+    step = _step_for_click(
+        {
+            "is_opener": True,
+            "text": "FY2024-25",
+            "locator": {
+                "value": "FY2024-25",
+                "kind": "text",
+                "is_css": False,
+                "confidence": "medium",
+                "match_count": 1,
+            },
+            "candidates": [{"kind": "text", "value": "FY2024-25", "match_count": 1}],
+        }
+    )
+    assert step["command"] == "click_by_text"

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -1023,3 +1023,111 @@ def test_skill_md_tells_the_agent_what_it_can_vary():
     assert "accepts:" in md
     assert "from_date" in md
     assert "{{placeholders}}" in md
+
+
+# --- multi-origin apps --------------------------------------------------------
+#
+# ICICI serves its portal from retailnetbanking.icici.bank.in and its statement
+# DOWNLOAD from infinity.icici.bank.in. Keeping only the login origin discarded
+# the e-Statements page entirely — the one that actually produces the PDF — so
+# the compiled skill had no way to reach the file, and the agent had to
+# rediscover the whole route by trial and error at run time.
+
+_INFINITY = "https://infinity.icici.bank.in"
+
+_MULTI_ORIGIN_EVENTS = [
+    {
+        "from_url": f"{_H}/login-page",
+        "to_url": f"{_H}/overview",
+        "timestamp": "2026-08-07T10:00:00Z",
+    },
+    {
+        "from_url": f"{_H}/overview",
+        "to_url": f"{_H}/credit-card",
+        "timestamp": "2026-08-07T10:00:05Z",
+    },
+    # The human clicked "Download Previous Statement" and landed on the bank's
+    # OTHER host. This is the hop that used to be thrown away.
+    {
+        "from_url": f"{_H}/credit-card",
+        "to_url": f"{_INFINITY}/corp/AuthenticationController",
+        "timestamp": "2026-08-07T10:00:12Z",
+    },
+    # Third-party telemetry: never reached by a human navigation, still dropped.
+    {
+        "from_url": f"{_H}/credit-card",
+        "to_url": "https://rum.dynatrace.com/beacon",
+        "timestamp": "2026-08-07T10:00:13Z",
+    },
+]
+
+
+def _hop_click(text, url, **over):
+    base = {
+        "event_type": "click",
+        "text_content": text,
+        "url": url,
+        "timestamp": "2026-08-07T10:00:11.000Z",
+        "event_time": "2026-08-07T10:00:11.000Z",
+        "candidates": [{"kind": "id", "value": "#dl-prev", "match_count": 1}],
+    }
+    base.update(over)
+    return base
+
+
+def test_a_page_on_the_apps_other_host_is_kept():
+    clicks = [
+        _rich_click(),
+        _hop_click("Download Previous Statement", f"{_H}/credit-card"),
+        # The human then worked ON that host — picked Annual, pressed download.
+        _hop_click("Annual", f"{_INFINITY}/corp/AuthenticationController"),
+    ]
+    pages = derive_browser_pages(_MULTI_ORIGIN_EVENTS, clicks, login_url=LOGIN)
+
+    urls = [p["url"] for p in pages]
+    assert f"{_INFINITY}/corp/AuthenticationController" in urls
+
+
+def test_third_party_telemetry_is_still_dropped():
+    # The filter exists for a reason — this is the noise that poisoned the
+    # HAR-replay compile. It is never reached by a human navigation.
+    clicks = [
+        _rich_click(),
+        _hop_click("Download Previous Statement", f"{_H}/credit-card"),
+        _hop_click("Annual", f"{_INFINITY}/corp/AuthenticationController"),
+    ]
+    pages = derive_browser_pages(_MULTI_ORIGIN_EVENTS, clicks, login_url=LOGIN)
+
+    assert all("dynatrace" not in p["url"] for p in pages)
+
+
+def test_a_download_on_the_other_host_becomes_an_operation():
+    # The end of the real ICICI path: the PDF is produced on the second host.
+    dl = _terminal_click(url=f"{_INFINITY}/corp/AuthenticationController", seq=20)
+    clicks = [
+        _rich_click(),
+        _hop_click("Download Previous Statement", f"{_H}/credit-card"),
+        _hop_click("Annual", f"{_INFINITY}/corp/AuthenticationController", seq=15),
+        dl,
+    ]
+    pages = derive_browser_pages(_MULTI_ORIGIN_EVENTS, clicks, login_url=LOGIN)
+    ops = [o for o in _ops(pages, clicks)["operations"] if o.get("kind") == "download"]
+
+    assert len(ops) == 1
+
+
+def test_origins_are_grown_in_order_not_matched_by_domain():
+    # A registrable-domain heuristic is guesswork: bank.in is a public suffix, so
+    # "share the last two labels" would make every Indian bank the same app. An
+    # unreached sibling host must NOT be treated as part of this app.
+    from noui_core.compile.browser_skill import app_origins_from  # noqa: PLC0415
+
+    clicks = [
+        _rich_click(),
+        _hop_click("Download Previous Statement", f"{_H}/credit-card"),
+        _hop_click("Annual", f"{_INFINITY}/corp/AuthenticationController"),
+    ]
+    origins = app_origins_from(_MULTI_ORIGIN_EVENTS, LOGIN, clicks)
+    assert _INFINITY in origins
+    assert "https://someotherbank.bank.in" not in origins
+    assert "https://rum.dynatrace.com" not in origins

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -933,3 +933,93 @@ def test_skill_md_names_the_operations_that_produce_a_result():
 
     assert "Operations that produce a result" in md
     assert "download_statement" in md
+
+
+def test_a_download_operation_accepts_the_period_the_human_typed():
+    # THE ICICI failure: asked for "last year", the operation had nothing to
+    # vary, so the agent hunted the page for a period selector instead.
+    period = {
+        "event_type": "input",
+        "tag_name": "INPUT",
+        "input_type": "text",
+        "field_name": "fromDate",
+        "value": "2026-01-01",
+        "url": f"{_H}/credit-card",
+        "timestamp": "2026-08-07T10:00:10.000Z",
+        "event_time": "2026-08-07T10:00:10.000Z",
+        "seq": 5,
+        "candidates": [{"kind": "id", "value": "#from-date", "match_count": 1}],
+    }
+    clicks = [_rich_click(), period, _terminal_click(seq=9)]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+    dl = [o for o in _ops(pages, clicks)["operations"] if o.get("kind") == "download"][0]
+
+    assert dl["parameters"][0]["name"] == "from_date"
+    assert dl["parameters"][0]["default"] == "2026-01-01"
+    # The fill lands between reaching the page and the download click.
+    fills = [s for s in dl["steps"] if s["command"] == "type_text"]
+    assert fills[0]["params"]["text"] == "{{from_date}}"
+    assert dl["steps"].index(fills[0]) < dl["steps"].index(dl["steps"][-2])
+
+
+def test_inputs_from_another_page_do_not_leak_into_an_operation():
+    other = {
+        "event_type": "input",
+        "tag_name": "INPUT",
+        "field_name": "search",
+        "value": "groceries",
+        "url": f"{_H}/overview",
+        "seq": 4,
+        "timestamp": "2026-08-07T10:00:09.000Z",
+    }
+    clicks = [_rich_click(), other, _terminal_click(seq=9)]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+    dl = [o for o in _ops(pages, clicks)["operations"] if o.get("kind") == "download"][0]
+
+    assert dl["parameters"] == []
+
+
+def test_values_entered_after_the_action_are_not_parameters_of_it():
+    late = {
+        "event_type": "input",
+        "tag_name": "INPUT",
+        "field_name": "feedback",
+        "value": "great",
+        "url": f"{_H}/credit-card",
+        "seq": 20,
+        "timestamp": "2026-08-07T10:00:40.000Z",
+    }
+    clicks = [_rich_click(), _terminal_click(seq=9), late]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+    dl = [o for o in _ops(pages, clicks)["operations"] if o.get("kind") == "download"][0]
+
+    assert dl["parameters"] == []
+
+
+def test_skill_md_tells_the_agent_what_it_can_vary():
+    period = {
+        "event_type": "input",
+        "tag_name": "INPUT",
+        "field_name": "fromDate",
+        "value": "2026-01-01",
+        "url": f"{_H}/credit-card",
+        "seq": 5,
+        "timestamp": "2026-08-07T10:00:10.000Z",
+        "candidates": [{"kind": "id", "value": "#from-date", "match_count": 1}],
+    }
+    clicks = [_rich_click(), period, _terminal_click(seq=9)]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+    from noui_core.compile.browser_skill import derive_terminal_operations  # noqa: PLC0415
+
+    md = render_browser_skill_md(
+        skill_id="icici-cc-statement",
+        app_name="ICICI",
+        workflow_name="Credit card statement",
+        pages=pages,
+        profile_slug="icici-cc-statement",
+        terminal_ops=derive_terminal_operations(pages, clicks, login_url=LOGIN),
+    )
+
+    assert "accepts:" in md
+    assert "from_date" in md
+    assert "{{placeholders}}" in md

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -984,6 +984,56 @@ def test_a_legacy_submit_without_an_outcome_emits_no_terminal_operation():
     assert all("kind" not in o for o in _ops(pages, clicks)["operations"])
 
 
+def test_a_flaky_download_submit_compiles_as_a_download_not_a_submit():
+    # ICICI's PDF server is slow, so the download click fired a `submit` event but
+    # outcome.download never landed inside the recorder's window. The control still
+    # plainly downloads (#DOWNLOAD_ESTATEMENT_PDF), so it must compile as a
+    # DOWNLOAD -- judged by a FRESH file (goal_reached + the download baseline),
+    # not by a visibility-gated click a not-yet-rendered PDF panel blocks. As a
+    # `submit` the op failed on that blocked step; as a download it is judged by
+    # the file that actually arrived.
+    flaky = _terminal_click(
+        event_type="submit",
+        text_content="",
+        candidates=[{"kind": "id", "value": "#DOWNLOAD_ESTATEMENT_PDF", "match_count": 1}],
+        outcome={
+            "navigated": False,
+            "to_url": None,
+            "request_count": 3,
+            "settled_ms": 500,
+            "download": False,
+        },
+    )
+    clicks = [_rich_click(), flaky]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+    ops = [o for o in _ops(pages, clicks)["operations"] if o.get("kind") == "download"]
+    assert len(ops) == 1
+    # It ends by naming the file, so the goal is a fresh download, not a click.
+    assert ops[0]["steps"][-1] == {"command": "list_downloads"}
+
+
+def test_a_submit_without_download_words_stays_a_submit():
+    # The upgrade is targeted: a submit whose control says nothing about
+    # downloading (a search) is still a submit, judged by its steps.
+    submit = _terminal_click(
+        event_type="submit",
+        text_content="Search transactions",
+        candidates=[{"kind": "id", "value": "#search", "match_count": 1}],
+        outcome={
+            "navigated": False,
+            "to_url": None,
+            "request_count": 2,
+            "settled_ms": 400,
+            "download": False,
+        },
+    )
+    clicks = [_rich_click(), submit]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+    ops = _ops(pages, clicks)["operations"]
+    assert any(o.get("kind") == "submit" for o in ops)
+    assert not any(o.get("kind") == "download" for o in ops)
+
+
 def test_skill_md_names_the_operations_that_produce_a_result():
     clicks = [_rich_click(), _terminal_click()]
     pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -1250,3 +1250,65 @@ def test_a_later_screens_clicks_do_not_leak_into_the_download():
     ]
     ops = derive_terminal_operations(pages, clicks, login_url="https://bank.test/login")
     assert ops[0]["lead"] == []
+
+
+def test_a_radio_compiles_to_set_checked_not_a_click():
+    """ICICI's Monthly / Annual period is a styled radio.
+
+    Portals draw these as images or spans over a hidden input, so a click lands
+    on the decoration and the input never changes — a replay that "clicked
+    Annual" was still asking for the monthly statement. set_checked drives the
+    control and verifies the state changed, which a click cannot promise.
+    """
+    from noui_core.compile.browser_skill import _step_for_click
+
+    step = _step_for_click(
+        {
+            "locator": {
+                "value": "#annual",
+                "kind": "css",
+                "is_css": True,
+                "confidence": "high",
+                "match_count": 1,
+            },
+            "element": {"role": "radio", "tag": "input"},
+        }
+    )
+    assert step["command"] == "set_checked"
+    assert step["params"] == {"selector": "#annual", "checked": True}
+
+
+def test_a_radio_inside_a_frame_keeps_its_frame():
+    from noui_core.compile.browser_skill import _step_for_click
+
+    step = _step_for_click(
+        {
+            "locator": {
+                "value": "#annual",
+                "kind": "css",
+                "is_css": True,
+                "confidence": "high",
+                "match_count": 1,
+            },
+            "element": {"role": "radio", "in_iframe": True, "frame_url": "https://finacle.test/x"},
+        }
+    )
+    assert step["params"]["frame_url"] == "https://finacle.test/x"
+
+
+def test_an_ordinary_button_still_compiles_to_a_click():
+    from noui_core.compile.browser_skill import _step_for_click
+
+    step = _step_for_click(
+        {
+            "locator": {
+                "value": "#go",
+                "kind": "css",
+                "is_css": True,
+                "confidence": "high",
+                "match_count": 1,
+            },
+            "element": {"role": "button"},
+        }
+    )
+    assert step["command"] == "click_element"

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -784,7 +784,8 @@ def test_recordings_without_candidates_still_compile_the_old_way():
     from noui_core.compile.browser_skill import _behaviour
 
     assert _behaviour(steps[0]) == {
-        "command": "click_by_text", "params": {"text": "Credit Cards"},
+        "command": "click_by_text",
+        "params": {"text": "Credit Cards"},
     }
     assert steps[-1] == {"command": "get_page_summary"}
 

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -568,3 +568,209 @@ def test_unnumbered_bundle_still_uses_timestamps():
     )
     by_name = {p["name"]: p for p in pages}
     assert [c["text"] for c in by_name["read_accounts"]["nav"]] == ["Banking", "Accounts"]
+
+
+# --- schema_version >= 4/5 recordings: candidates + outcomes -------------------
+#
+# The recorder no longer guesses a single selector. It emits several candidates
+# with match counts, and what happened after each click. These pin that the
+# compiler actually USES them — previously `selector` was captured on every nav
+# click and then silently discarded, so every step compiled to click_by_text on
+# visible text alone.
+
+_RICH_EVENTS = [
+    {"from_url": f"{_H}/login-page", "to_url": f"{_H}/overview", "timestamp": "2026-08-07T10:00:00Z"},
+    {
+        "from_url": f"{_H}/overview",
+        "to_url": f"{_H}/credit-card",
+        "timestamp": "2026-08-07T10:00:05Z",
+    },
+]
+
+
+def _rich_click(**over):
+    base = {
+        "event_type": "click",
+        "text_content": "Credit Cards",
+        "selector": "div.submenu-text",
+        "url": f"{_H}/overview",
+        "timestamp": "2026-08-07T10:00:04.900Z",
+        "event_time": "2026-08-07T10:00:04.900Z",
+        "candidates": [
+            {"kind": "testid", "value": '[data-testid="nav-cards"]', "match_count": 1},
+            {"kind": "text", "value": "Credit Cards", "match_count": 1},
+        ],
+        "outcome": {
+            "navigated": True,
+            "to_url": f"{_H}/credit-card",
+            "request_count": 3,
+            "settled_ms": 420,
+            "download": False,
+        },
+    }
+    base.update(over)
+    return base
+
+
+def _ops(pages):
+    return json.loads(render_browser_operations_json(pages, profile_slug="icici-bank"))
+
+
+def test_step_uses_the_unique_candidate_instead_of_visible_text():
+    pages = derive_browser_pages(_RICH_EVENTS, [_rich_click()], login_url=LOGIN)
+    steps = _ops(pages)["operations"][1]["steps"]
+
+    assert steps[0]["command"] == "click_element"
+    assert steps[0]["params"]["selector"] == '[data-testid="nav-cards"]'
+    assert steps[0]["locator"]["confidence"] == "unique"
+
+
+def test_text_steps_are_exact_so_they_cannot_widen_back_into_ambiguity():
+    # The recorder established the text matched ONE control. A substring match
+    # would reintroduce exactly the ambiguity that made HSBCnet misclick.
+    click = _rich_click(
+        candidates=[{"kind": "text", "value": "Statements", "match_count": 1}],
+    )
+    pages = derive_browser_pages(_RICH_EVENTS, [click], login_url=LOGIN)
+    steps = _ops(pages)["operations"][1]["steps"]
+
+    assert steps[0]["command"] == "click_by_text"
+    assert steps[0]["params"] == {"text": "Statements", "exact": True}
+
+
+def test_step_carries_the_observed_postcondition():
+    # A linear script cannot tell it has gone wrong; it keeps clicking. The URL
+    # the recorder OBSERVED after this click is checkable in one step.
+    pages = derive_browser_pages(_RICH_EVENTS, [_rich_click()], login_url=LOGIN)
+    step = _ops(pages)["operations"][1]["steps"][0]
+
+    assert step["expect"]["url"] == f"{_H}/credit-card"
+    # A recorded settle is one sample from one network, so it is doubled for
+    # headroom — but never below a second, which is not a wait worth having on a
+    # bank SPA. 420ms doubles to 840 and lands on the floor.
+    assert step["expect"]["settle_ms"] == 1000
+
+
+def test_a_slow_observed_settle_is_doubled_rather_than_floored():
+    click = _rich_click(
+        outcome={
+            "navigated": True,
+            "to_url": f"{_H}/credit-card",
+            "request_count": 2,
+            "settled_ms": 2600,
+            "download": False,
+        }
+    )
+    pages = derive_browser_pages(_RICH_EVENTS, [click], login_url=LOGIN)
+    step = _ops(pages)["operations"][1]["steps"][0]
+
+    assert step["expect"]["settle_ms"] == 5200
+
+
+def test_a_click_that_downloaded_records_it_as_the_success_condition():
+    click = _rich_click(
+        outcome={
+            "navigated": False,
+            "to_url": None,
+            "request_count": 1,
+            "settled_ms": None,
+            "download": True,
+        }
+    )
+    pages = derive_browser_pages(_RICH_EVENTS, [click], login_url=LOGIN)
+    step = _ops(pages)["operations"][1]["steps"][0]
+
+    assert step["expect"] == {"download": True}
+
+
+def test_an_icon_button_is_compiled_instead_of_dropped():
+    # A click with no visible text used to be discarded outright, which threw away
+    # every icon control — the hamburger and the chevrons that open a bank nav's
+    # accordions, so the page they lead to became unreachable and was dropped.
+    icon = _rich_click(
+        text_content="",
+        candidates=[{"kind": "aria_label", "value": 'button[aria-label="Open menu"]', "match_count": 1}],
+    )
+    pages = derive_browser_pages(_RICH_EVENTS, [icon], login_url=LOGIN)
+
+    assert [p["name"] for p in pages] == ["read_overview", "read_credit_card"]
+    step = _ops(pages)["operations"][1]["steps"][0]
+    assert step["params"]["selector"] == 'button[aria-label="Open menu"]'
+
+
+def test_ambiguous_locators_are_surfaced_rather_than_hidden():
+    from noui_core.compile.browser_skill import ambiguous_steps  # noqa: PLC0415
+
+    click = _rich_click(
+        candidates=[{"kind": "text", "value": "Credit Cards", "match_count": 4}],
+    )
+    pages = derive_browser_pages(_RICH_EVENTS, [click], login_url=LOGIN)
+    flagged = ambiguous_steps(pages)
+
+    assert len(flagged) == 1
+    assert flagged[0]["page"] == "read_credit_card"
+    assert flagged[0]["locator"]["match_count"] == 4
+
+
+def test_recordings_without_candidates_still_compile_the_old_way():
+    # Every recording made before schema_version 4 has no candidates. Those must
+    # keep compiling exactly as they did, not start failing.
+    legacy = {
+        "event_type": "click",
+        "text_content": "Credit Cards",
+        "selector": "div.submenu-text",
+        "url": f"{_H}/overview",
+        "timestamp": "2026-08-07T10:00:04.900Z",
+    }
+    pages = derive_browser_pages(_RICH_EVENTS, [legacy], login_url=LOGIN)
+    steps = _ops(pages)["operations"][1]["steps"]
+
+    assert steps[0] == {"command": "click_by_text", "params": {"text": "Credit Cards"}}
+    assert steps[-1] == {"command": "get_page_summary"}
+
+
+def test_skill_md_tells_the_agent_to_stop_when_an_expectation_fails():
+    # With an LLM runtime the prose IS the enforcement for `expect` — nothing
+    # else reads it.
+    pages = derive_browser_pages(_RICH_EVENTS, [_rich_click()], login_url=LOGIN)
+    md = render_browser_skill_md(
+        skill_id="icici-bank",
+        app_name="ICICI",
+        workflow_name="Credit card",
+        pages=pages,
+        profile_slug="icici-bank",
+    )
+    assert "stop and report it" in md
+    assert "settle_ms" in md
+    assert "Known ambiguous steps" not in md  # nothing ambiguous in this recording
+
+
+def test_skill_md_names_the_ambiguous_steps():
+    click = _rich_click(candidates=[{"kind": "text", "value": "Credit Cards", "match_count": 4}])
+    pages = derive_browser_pages(_RICH_EVENTS, [click], login_url=LOGIN)
+    md = render_browser_skill_md(
+        skill_id="icici-bank",
+        app_name="ICICI",
+        workflow_name="Credit card",
+        pages=pages,
+        profile_slug="icici-bank",
+    )
+    assert "Known ambiguous steps" in md
+    assert "matched 4 elements" in md
+
+
+def test_skill_md_describes_an_icon_click_without_an_empty_quote():
+    icon = _rich_click(
+        text_content="",
+        candidates=[{"kind": "aria_label", "value": 'button[aria-label="Menu"]', "match_count": 1}],
+    )
+    pages = derive_browser_pages(_RICH_EVENTS, [icon], login_url=LOGIN)
+    md = render_browser_skill_md(
+        skill_id="icici-bank",
+        app_name="ICICI",
+        workflow_name="Credit card",
+        pages=pages,
+        profile_slug="icici-bank",
+    )
+    assert 'click ""' not in md
+    assert "aria_label" in md

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -616,8 +616,14 @@ def _rich_click(**over):
     return base
 
 
-def _ops(pages):
-    return json.loads(render_browser_operations_json(pages, profile_slug="icici-bank"))
+def _ops(pages, clicks=None):
+    """operations.json — pass the click list to include terminal operations."""
+    from noui_core.compile.browser_skill import derive_terminal_operations  # noqa: PLC0415
+
+    terminal = derive_terminal_operations(pages, clicks or [], login_url=LOGIN)
+    return json.loads(
+        render_browser_operations_json(pages, profile_slug="icici-bank", terminal_ops=terminal)
+    )
 
 
 def test_step_uses_the_unique_candidate_instead_of_visible_text():
@@ -780,3 +786,150 @@ def test_skill_md_describes_an_icon_click_without_an_empty_quote():
     )
     assert 'click ""' not in md
     assert "aria_label" in md
+
+
+# --- terminal operations ------------------------------------------------------
+#
+# An operation used to mean "a page the human visited", so anything whose result
+# is not a new URL could not become an operation at all. On ICICI the compiler
+# produced two read operations and the statement download had to be hand-written
+# afterwards — not reproducible, not verifiable. Downloads are one KIND of
+# terminal outcome here, not a special case.
+
+
+def _terminal_click(**over):
+    base = {
+        "event_type": "click",
+        "text_content": "Download statement",
+        "url": f"{_H}/credit-card",
+        "timestamp": "2026-08-07T10:00:20.000Z",
+        "event_time": "2026-08-07T10:00:20.000Z",
+        "candidates": [{"kind": "testid", "value": '[data-testid="stmt-dl"]', "match_count": 1}],
+        "outcome": {
+            "navigated": False,
+            "to_url": None,
+            "request_count": 1,
+            "settled_ms": 300,
+            "download": True,
+        },
+    }
+    base.update(over)
+    return base
+
+
+def test_a_download_becomes_a_real_operation():
+    # The gap that forced a hand-written operation on ICICI.
+    clicks = [_rich_click(), _terminal_click()]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+    ops = _ops(pages, clicks)["operations"]
+
+    dl = [o for o in ops if o.get("kind") == "download"]
+    assert len(dl) == 1
+    assert dl[0]["name"] == "download_statement"
+
+
+def test_the_download_operation_reaches_the_page_first():
+    # A step that cannot be reached is worse than a missing one: the operation
+    # replays the same click chain the read operation for that page uses.
+    clicks = [_rich_click(), _terminal_click()]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+    dl = [o for o in _ops(pages, clicks)["operations"] if o.get("kind") == "download"][0]
+
+    # nav click to the credit-card page, then the download control itself.
+    assert dl["steps"][0]["params"]["selector"] == '[data-testid="nav-cards"]'
+    assert dl["steps"][1]["params"]["selector"] == '[data-testid="stmt-dl"]'
+
+
+def test_the_download_operation_ends_by_naming_the_artifact():
+    # The file IS the result, so it closes with list_downloads rather than
+    # reading whatever page it left behind.
+    clicks = [_rich_click(), _terminal_click()]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+    dl = [o for o in _ops(pages, clicks)["operations"] if o.get("kind") == "download"][0]
+
+    assert dl["steps"][-1] == {"command": "list_downloads"}
+    assert dl["steps"][1]["expect"]["download"] is True
+
+
+def test_a_form_submission_becomes_an_operation_too():
+    # Not download-specific: any goal that finishes without a new URL.
+    submit = _terminal_click(
+        event_type="submit",
+        text_content="Search transactions",
+        outcome={
+            "navigated": False,
+            "to_url": None,
+            "request_count": 2,
+            "settled_ms": 500,
+            "download": False,
+        },
+    )
+    clicks = [_rich_click(), submit]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+    ops = [o for o in _ops(pages, clicks)["operations"] if o.get("kind") == "submit"]
+
+    assert len(ops) == 1
+    # A submission leaves a page worth reading, unlike a download.
+    assert ops[0]["steps"][-1] == {"command": "get_page_summary"}
+
+
+def test_an_ordinary_click_does_not_become_an_operation():
+    # "Fired some XHRs" describes half the clicks on a bank portal — filters,
+    # toggles, accordions. Emitting one each would bury the two the user wants.
+    noisy = _terminal_click(
+        text_content="Filter",
+        outcome={
+            "navigated": False,
+            "to_url": None,
+            "request_count": 3,
+            "settled_ms": 200,
+            "download": False,
+        },
+    )
+    clicks = [_rich_click(), noisy]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+    ops = _ops(pages, clicks)["operations"]
+
+    assert all("kind" not in o for o in ops)
+
+
+def test_a_terminal_click_on_an_unreachable_page_is_dropped():
+    # Its page was never resolved, so the skill has no way to get there.
+    orphan = _terminal_click(url=f"{_H}/some-page-never-visited")
+    clicks = [_rich_click(), orphan]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+
+    assert all("kind" not in o for o in _ops(pages, clicks)["operations"])
+
+
+def test_recordings_without_outcomes_emit_no_terminal_operations():
+    # Everything captured before schema_version 5 — must compile as it did.
+    legacy = {
+        "event_type": "click",
+        "text_content": "Download statement",
+        "url": f"{_H}/credit-card",
+        "timestamp": "2026-08-07T10:00:20.000Z",
+    }
+    clicks = [_rich_click(), legacy]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+
+    assert all("kind" not in o for o in _ops(pages, clicks)["operations"])
+
+
+def test_skill_md_names_the_operations_that_produce_a_result():
+    clicks = [_rich_click(), _terminal_click()]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+    from noui_core.compile.browser_skill import derive_terminal_operations  # noqa: PLC0415
+
+    terminal = derive_terminal_operations(pages, clicks, login_url=LOGIN)
+    md = render_browser_skill_md(
+        skill_id="icici-cc-statement",
+        app_name="ICICI",
+        workflow_name="Credit card statement",
+        pages=pages,
+        profile_slug="icici-cc-statement",
+        terminal_ops=terminal,
+    )
+
+    assert "Operations that produce a result" in md
+    assert "download_statement" in md

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -1131,3 +1131,43 @@ def test_origins_are_grown_in_order_not_matched_by_domain():
     assert _INFINITY in origins
     assert "https://someotherbank.bank.in" not in origins
     assert "https://rum.dynatrace.com" not in origins
+
+
+def test_a_click_inside_an_iframe_carries_the_frame_to_the_step():
+    """A recorded in-frame click must remain executable.
+
+    The recorder runs in every frame, so the click was always captured. Without
+    the frame on the step the runtime drives the top-level page, the control is
+    not there, and a navigation the human completed becomes one the skill cannot
+    reproduce — the ICICI/Finacle statement download.
+    """
+    from noui_core.compile.browser_skill import _step_for_click
+
+    step = _step_for_click(
+        {
+            "locator": {"value": "#PDF_Download", "kind": "css", "is_css": True,
+                        "confidence": "high", "match_count": 1},
+            "element": {
+                "in_iframe": True,
+                "frame_url": "https://finacle.bank.test/statements?tok=abc",
+                "frame_name": "finacleFrame",
+            },
+        }
+    )
+    assert step["params"]["frame_url"] == "https://finacle.bank.test/statements?tok=abc"
+    assert step["params"]["frame_name"] == "finacleFrame"
+
+
+def test_a_top_level_click_names_no_frame():
+    # Adding an empty frame to every step would make each one look embedded.
+    from noui_core.compile.browser_skill import _step_for_click
+
+    step = _step_for_click(
+        {
+            "locator": {"value": "#nav", "kind": "css", "is_css": True,
+                        "confidence": "high", "match_count": 1},
+            "element": {"in_iframe": False},
+        }
+    )
+    assert "frame_url" not in step["params"]
+    assert "frame_name" not in step["params"]

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -777,7 +777,15 @@ def test_recordings_without_candidates_still_compile_the_old_way():
     pages = derive_browser_pages(_RICH_EVENTS, [legacy], login_url=LOGIN)
     steps = _ops(pages)["operations"][1]["steps"]
 
-    assert steps[0] == {"command": "click_by_text", "params": {"text": "Credit Cards"}}
+    # Compared on what the step DOES. Underscore keys are compile-time
+    # provenance (which interaction, and the page it ran on) — they never change
+    # behaviour, and `_behaviour` is what the compiler itself uses to decide
+    # whether two steps are the same action.
+    from noui_core.compile.browser_skill import _behaviour
+
+    assert _behaviour(steps[0]) == {
+        "command": "click_by_text", "params": {"text": "Credit Cards"},
+    }
     assert steps[-1] == {"command": "get_page_summary"}
 
 

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -965,6 +965,25 @@ def test_recordings_without_outcomes_emit_no_terminal_operations():
     assert all("kind" not in o for o in _ops(pages, clicks)["operations"])
 
 
+def test_a_legacy_submit_without_an_outcome_emits_no_terminal_operation():
+    # The backward-compat hole the download branch didn't have: `event_type ==
+    # "submit"` predates schema 5 (login_assets reads it for login detection), so
+    # gating the terminal on event_type alone made a pre-schema-5 non-login submit
+    # (a "Save Note" form) compile a brand-new operation, breaking "older captures
+    # compile exactly as they did". A submit with no outcome must stay inert.
+    legacy_submit = {
+        "event_type": "submit",
+        "text_content": "Save Note",
+        "url": f"{_H}/credit-card",
+        "timestamp": "2026-08-07T10:00:20.000Z",
+        "event_time": "2026-08-07T10:00:20.000Z",
+    }
+    clicks = [_rich_click(), legacy_submit]
+    pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)
+
+    assert all("kind" not in o for o in _ops(pages, clicks)["operations"])
+
+
 def test_skill_md_names_the_operations_that_produce_a_result():
     clicks = [_rich_click(), _terminal_click()]
     pages = derive_browser_pages(_RICH_EVENTS, clicks, login_url=LOGIN)

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -1181,3 +1181,72 @@ def test_a_top_level_click_names_no_frame():
     )
     assert "frame_url" not in step["params"]
     assert "frame_name" not in step["params"]
+
+
+def test_a_download_keeps_the_clicks_that_decide_what_is_downloaded():
+    """The tab and the period are part of the download, not scenery.
+
+    Only the terminal click was compiled, so a statement download became "click
+    Download" alone — losing the "Past Statements" tab and the "Annual" period.
+    At replay that click landed on whatever the page happened to show, which is
+    how a run ended up hunting a control that was one tab away.
+    """
+    from noui_core.compile.browser_skill import derive_terminal_operations
+
+    page_url = "https://bank.test/statements"
+    pages = [{"name": "read_statements", "url": page_url, "nav": [], "_from_key": None}]
+    clicks = [
+        {
+            "seq": 1,
+            "url": page_url,
+            "event_type": "click",
+            "text_content": "Past Statements",
+            "candidates": [{"kind": "text", "value": "Past Statements", "match_count": 1}],
+        },
+        {
+            "seq": 2,
+            "url": page_url,
+            "event_type": "click",
+            "text_content": "Annual",
+            "candidates": [{"kind": "text", "value": "Annual", "match_count": 1}],
+        },
+        {
+            "seq": 3,
+            "url": page_url,
+            "event_type": "click",
+            "text_content": "Download",
+            "candidates": [{"kind": "text", "value": "Download", "match_count": 1}],
+            "outcome": {"download": True},
+        },
+    ]
+    ops = derive_terminal_operations(pages, clicks, login_url="https://bank.test/login")
+    assert len(ops) == 1
+    lead = [str(s.get("params", {}).get("text") or "") for s in ops[0]["lead"]]
+    assert lead == ["Past Statements", "Annual"]
+
+
+def test_a_later_screens_clicks_do_not_leak_into_the_download():
+    from noui_core.compile.browser_skill import derive_terminal_operations
+
+    page_url = "https://bank.test/statements"
+    pages = [{"name": "read_statements", "url": page_url, "nav": [], "_from_key": None}]
+    clicks = [
+        {
+            "seq": 1,
+            "url": page_url,
+            "event_type": "click",
+            "text_content": "Download",
+            "candidates": [{"kind": "text", "value": "Download", "match_count": 1}],
+            "outcome": {"download": True},
+        },
+        # After the file: the human closing a dialog is not part of the download.
+        {
+            "seq": 2,
+            "url": page_url,
+            "event_type": "click",
+            "text_content": "Close",
+            "candidates": [{"kind": "text", "value": "Close", "match_count": 1}],
+        },
+    ]
+    ops = derive_terminal_operations(pages, clicks, login_url="https://bank.test/login")
+    assert ops[0]["lead"] == []

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -1495,3 +1495,59 @@ def test_an_opener_with_no_stable_selector_keeps_what_it_has():
         }
     )
     assert step["command"] == "click_by_text"
+
+
+def test_a_click_and_the_submit_it_fires_are_one_step():
+    """ICICI recorded a click and a submit on #DOWNLOAD_ESTATEMENT_PDF four
+    milliseconds apart — one press of one button. The download was attributed to
+    the submit, making it the terminal step, while the click became a lead-in, so
+    a replay would have asked the portal for the file twice."""
+    from noui_core.compile.browser_skill import _collapse_repeats
+
+    steps = _collapse_repeats(
+        [
+            {"command": "click_element", "params": {"selector": "#DOWNLOAD_ESTATEMENT_PDF"}},
+            {
+                "command": "click_element",
+                "params": {"selector": "#DOWNLOAD_ESTATEMENT_PDF"},
+                "expect": {"download": True},
+            },
+        ]
+    )
+    assert len(steps) == 1
+    # the richer of the two survives, so the expectation is not lost
+    assert steps[0].get("expect") == {"download": True}
+
+
+def test_the_same_control_used_again_later_survives():
+    # A paging control or a retry is a real second action.
+    from noui_core.compile.browser_skill import _collapse_repeats
+
+    steps = _collapse_repeats(
+        [
+            {"command": "click_element", "params": {"selector": "#next"}},
+            {"command": "get_page_summary"},
+            {"command": "click_element", "params": {"selector": "#next"}},
+        ]
+    )
+    assert len(steps) == 3
+
+
+def test_a_click_that_resolved_to_the_document_is_not_a_step():
+    from noui_core.compile.browser_skill import _step_for_click
+
+    assert (
+        _step_for_click(
+            {
+                "text": "",
+                "locator": {
+                    "value": "body",
+                    "kind": "css",
+                    "is_css": True,
+                    "confidence": "low",
+                    "match_count": 1,
+                },
+            }
+        )
+        is None
+    )

--- a/tests/test_browser_skill.py
+++ b/tests/test_browser_skill.py
@@ -80,7 +80,11 @@ LOGIN = f"{_H}/login-page"
 
 def test_derive_pages_keeps_only_readable_app_pages():
     pages = derive_browser_pages(ICICI_EVENTS, ICICI_CLICKS, login_url=LOGIN)
-    assert [p["name"] for p in pages] == ["read_overview", "read_credit_card"]
+    # read_pay is kept now rather than dropped: its driving click could not be
+    # recovered, and discarding such pages is what cost an entire bank workflow.
+    # It carries nav_partial and must prove arrival before it reads anything.
+    assert [p["name"] for p in pages] == ["read_overview", "read_credit_card", "read_pay"]
+    assert next(p for p in pages if p["name"] == "read_pay")["nav_partial"] is True
     assert pages[1]["url"] == "https://retailnetbanking.icici.bank.in/credit-card"
 
 
@@ -278,7 +282,11 @@ def test_generate_browser_skill_writes_installable_dir(tmp_path):
     assert manifest["runtime"]["operation_style"] == "browser"
     assert manifest["runtime"]["type"] == "agent-harness-skill"
     assert manifest["auth"]["execution_strategy"] == "harness_call_web_browser"
-    assert [o["name"] for o in manifest["operations"]] == ["read_overview", "read_credit_card"]
+    assert [o["name"] for o in manifest["operations"]] == [
+        "read_overview",
+        "read_credit_card",
+        "read_pay",
+    ]
     assert all(o["tool"] == "call_web_browser" for o in manifest["operations"])
 
 
@@ -338,7 +346,7 @@ def test_compile_workflow_bundle_browser_driven(tmp_path):
     )
     m = res["skill"]
     assert m["runtime"]["operation_style"] == "browser"
-    assert [o["name"] for o in m["operations"]] == ["read_overview", "read_credit_card"]
+    assert [o["name"] for o in m["operations"]] == ["read_overview", "read_credit_card", "read_pay"]
     assert all(o["tool"] == "call_web_browser" for o in m["operations"])
 
 
@@ -419,11 +427,20 @@ def test_multi_hop_page_gets_the_whole_chain_from_the_landing_page():
     assert [c["text"] for c in by_name["read_statements"]["nav"]] == ["Accounts", "Statements"]
 
 
-def test_page_whose_driving_click_is_untextual_is_dropped_not_read_as_landing():
-    """`nav = [] or None` made an unreachable page look like the landing page: its
-    recipe became a bare get_page_summary, so the operation claimed to read
-    /accounts and actually returned the landing DOM. Icon/SVG nav buttons (no
-    text) are common in bank portals, so this was silently wrong data."""
+def test_a_page_whose_driving_click_is_untextual_is_kept_and_must_prove_arrival():
+    """Icon/SVG nav buttons carry no text, and bank portals are full of them.
+
+    Dropping the page avoided a worse bug -- `nav = [] or None` made it look like
+    the LANDING page, so the recipe became a bare get_page_summary and the
+    operation claimed to read /accounts while returning the landing DOM. But
+    dropping cost the whole workflow: an ICICI recording captured 15 clicks
+    through to the statement download, one unlabelled hop on the Finacle host
+    made the chain unresolvable, and the compile emitted a single overview
+    operation. Three re-recordings could not fix data that was already correct.
+
+    So keep the page with what was resolved, mark it partial, and make it prove
+    it arrived -- which is the honest failure the drop was protecting against.
+    """
     pages = derive_browser_pages(
         [
             _url_ev(f"{_B}/login", f"{_B}/home", "2026-01-01T00:00:01+00:00"),
@@ -432,7 +449,30 @@ def test_page_whose_driving_click_is_untextual_is_dropped_not_read_as_landing():
         [_click(f"{_B}/home", "", "2026-01-01T00:00:04+00:00")],  # icon button
         login_url=f"{_B}/login",
     )
-    assert [p["name"] for p in pages] == ["read_home"]
+    assert [p["name"] for p in pages] == ["read_home", "read_accounts"]
+
+    accounts = next(p for p in pages if p["name"] == "read_accounts")
+    assert accounts["nav_partial"] is True
+
+    # It must never be mistaken for the landing page: the recipe asserts the url.
+    from noui_core.compile.browser_skill import _steps_for_page
+
+    steps = _steps_for_page(accounts)
+    checks = [s for s in steps if s.get("expect", {}).get("url")]
+    assert checks and checks[0]["expect"]["url"] == accounts["url"]
+
+
+def test_a_fully_resolved_page_carries_no_partial_marker():
+    pages = derive_browser_pages(
+        [
+            _url_ev(f"{_B}/login", f"{_B}/home", "2026-01-01T00:00:01+00:00"),
+            _url_ev(f"{_B}/home", f"{_B}/accounts", "2026-01-01T00:00:05+00:00"),
+        ],
+        [_click(f"{_B}/home", "Accounts", "2026-01-01T00:00:04+00:00")],
+        login_url=f"{_B}/login",
+    )
+    accounts = next(p for p in pages if p["name"] == "read_accounts")
+    assert "nav_partial" not in accounts
 
 
 def test_hash_router_screens_are_separate_pages():

--- a/tests/test_bundle_classification.py
+++ b/tests/test_bundle_classification.py
@@ -268,3 +268,40 @@ class TestValidateBundleIsShapeOnly:
     def test_non_dict_rejected(self):
         with pytest.raises(ValueError, match="JSON object"):
             validate_bundle([])  # type: ignore[arg-type]
+
+
+# --- capture-downgrade warning -----------------------------------------------
+#
+# Tabby gates its workflow-only capture (locator candidates, element state,
+# interaction outcomes, downloads, popups) on the pod's recording mode. A pooled
+# spare boots as a login recording and adopts its real mode at bind. If that
+# regresses the recording still succeeds and still compiles — just from far
+# poorer evidence — and the skill misbehaves in a way that looks like a bad
+# recording rather than a bug. This makes it say so.
+
+from noui_core.capture.recording import warn_if_capture_was_downgraded  # noqa: E402
+
+
+def test_warns_when_a_workflow_capture_has_no_workflow_shaped_capture(capsys):
+    bundle = {"schema_version": 5, "har": {"log": {"entries": []}}}
+    warn_if_capture_was_downgraded(bundle, "workflow")
+    assert "recording_mode=workflow" in capsys.readouterr().out
+
+
+def test_silent_when_the_pod_knew_it_was_a_workflow_recording(capsys):
+    bundle = {"schema_version": 5, "download_events": [], "har": {"log": {"entries": []}}}
+    warn_if_capture_was_downgraded(bundle, "workflow")
+    assert capsys.readouterr().out == ""
+
+
+def test_silent_for_a_login_capture(capsys):
+    bundle = {"schema_version": 5, "har": {"log": {"entries": []}}}
+    warn_if_capture_was_downgraded(bundle, "login")
+    assert capsys.readouterr().out == ""
+
+
+def test_silent_for_recordings_made_before_rich_capture_existed(capsys):
+    # Nothing to expect from them, so warning would be pure noise.
+    warn_if_capture_was_downgraded({"schema_version": 2}, "workflow")
+    warn_if_capture_was_downgraded({}, "workflow")
+    assert capsys.readouterr().out == ""

--- a/tests/test_capture_record_default_mode.py
+++ b/tests/test_capture_record_default_mode.py
@@ -136,3 +136,35 @@ class TestTemplateReuseCheck:
         assert rc == 0
         find.assert_not_called()
         prov.assert_called_once()
+
+
+class TestEvidenceIsAlwaysRequested:
+    """Locator evidence must be captured before anyone knows it is needed.
+
+    Whether a skill has to be browser-driven is decided at COMPILE time, from the
+    HAR. Tabby gates rich capture (locator candidates, element evidence) on the
+    browser_driven flag, so leaving it off until the kind was known meant an
+    ICICI capture came back with 718 HAR entries, auto-detected as browser-driven
+    — and not one click interaction to compile steps from. The recording had to
+    be done again.
+    """
+
+    def test_a_combined_capture_always_asks_for_evidence(self, run):
+        rc, _, prov = run("--url", "https://app.test/login")
+        assert rc == 0
+        assert prov.call_args.args[0] == "login"  # HAR stays whole for the template
+        assert prov.call_args.kwargs["browser_driven"] is True
+
+    def test_an_explicit_browser_driven_capture_still_asks(self, run):
+        rc, _, prov = run("--url", "https://app.test/login", "--browser-driven")
+        assert rc == 0
+        assert prov.call_args.kwargs["browser_driven"] is True
+
+    def test_a_workflow_capture_is_left_alone(self, run):
+        # Workflow mode already captures evidence (Tabby keys it off the mode),
+        # and forcing the flag here WOULD reduce the HAR — which is the flag's
+        # other meaning, and not something to switch on by accident.
+        rc, _, prov = run("--url", "https://app.test/x", "--profile", "acme")
+        assert rc == 0
+        assert prov.call_args.args[0] == "workflow"
+        assert prov.call_args.kwargs["browser_driven"] is False

--- a/tests/test_capture_record_default_mode.py
+++ b/tests/test_capture_record_default_mode.py
@@ -47,6 +47,8 @@ def run(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(cr.recording, "resolve_agent_token", lambda: "test-token")
 
     def _run(*argv: str):
+        if not any(a == "--kind" for a in argv) and "--browser-driven" not in argv:
+            argv = ("--kind", "auto", *argv)
         monkeypatch.setattr(sys, "argv", ["capture_record.py", *argv])
         with patch.object(
             cr.recording, "provision_live_link", return_value=dict(_PROVISIONED)

--- a/tests/test_combined_import.py
+++ b/tests/test_combined_import.py
@@ -28,6 +28,10 @@ def _merged_bundle(with_login: bool = True) -> dict:
                 "field_role": "password" if with_login else None,
                 "tag_name": "input",
             },
+            # Something the human did AFTER signing in. Without it the workflow
+            # half is empty, which the splitter now refuses -- and a combined
+            # capture whose workflow half is empty is not a combined capture.
+            {"timestamp": T[5], "field_role": None, "tag_name": "a"},
         ],
         # with_login=False means a capture recorded against an ALREADY
         # authenticated profile, so its timeline never passes through a sign-in

--- a/tests/test_combined_import.py
+++ b/tests/test_combined_import.py
@@ -29,18 +29,33 @@ def _merged_bundle(with_login: bool = True) -> dict:
                 "tag_name": "input",
             },
         ],
-        "url_events": [
-            {
-                "timestamp": T[0],
-                "from_url": "about:blank",
-                "to_url": "https://app.example.com/login",
-            },
-            {
-                "timestamp": T[4],
-                "from_url": "https://app.example.com/login",
-                "to_url": "https://app.example.com/dash",
-            },
-        ],
+        # with_login=False means a capture recorded against an ALREADY
+        # authenticated profile, so its timeline never passes through a sign-in
+        # page. Merely dropping the credential field roles is not that: a login
+        # that types nothing is exactly how ICICI's QR sign-in looks, and the
+        # splitter now recognises it by the exit from the sign-in page.
+        "url_events": (
+            [
+                {
+                    "timestamp": T[0],
+                    "from_url": "about:blank",
+                    "to_url": "https://app.example.com/login",
+                },
+                {
+                    "timestamp": T[4],
+                    "from_url": "https://app.example.com/login",
+                    "to_url": "https://app.example.com/dash",
+                },
+            ]
+            if with_login
+            else [
+                {
+                    "timestamp": T[0],
+                    "from_url": "about:blank",
+                    "to_url": "https://app.example.com/dash",
+                },
+            ]
+        ),
         "har": {
             "log": {
                 "entries": [

--- a/tests/test_compile_is_stable.py
+++ b/tests/test_compile_is_stable.py
@@ -1,0 +1,126 @@
+"""The compiler's output for a real recording, pinned.
+
+Every unit test in this suite checks a function in isolation. None of them looks
+at the artifact a replay actually runs, which is why a compiler change could pass
+1028 tests and still silently gut a skill:
+
+  9f4fba3 restored a dropped "Past" click -- and displaced the Annual radio's
+  set_checked into a different operation, where it stopped being emitted at all.
+  The suite stayed green. It was found by a human watching a replay click the
+  wrong tab, hours later.
+
+So this file pins the whole output for one fixed bundle. Any change to the
+compiler that alters the operations fails here with a diff. That is the point:
+accepting a change becomes a deliberate, visible act -- regenerate the golden,
+and the diff sits in the review where someone can see what behaviour moved --
+rather than something that happens quietly while the assertions still pass.
+
+Regenerate deliberately, never reflexively:
+
+    python tests/test_compile_is_stable.py --update
+
+and read the diff before committing it.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+from noui_core.compile.browser_skill import generate_browser_skill
+
+FIXTURES = Path(__file__).parent / "fixtures"
+BUNDLE = FIXTURES / "icici_statement_bundle.json"
+GOLDEN = FIXTURES / "icici_statement_operations.json"
+LOGIN_URL = "https://retailnetbanking.icici.bank.in/login-page"
+
+
+def _compile(bundle: dict) -> list[dict]:
+    """The operations a replay would actually run, reduced to what matters.
+
+    Drives generate_browser_skill -- the one entry point compile_workflow uses --
+    and reads the operations.json it writes. Calling the internals instead
+    (derive_browser_pages + derive_terminal_operations) looks equivalent and is
+    not: the assembly on top is where set_checked and select_option land, so a
+    harness built on the fragments reported them missing from a skill that
+    plainly contained them.
+
+    Selectors and values are kept -- they are the thing that breaks -- while
+    volatile provenance (seq stamps, jsessionid-bearing urls) is dropped, so the
+    golden does not churn on every re-record.
+    """
+    with tempfile.TemporaryDirectory() as out:
+        generate_browser_skill(
+            app_slug="icici-fixture",
+            app_name="ICICI Fixture",
+            workflow_name="statement",
+            profile_slug="icici-fixture",
+            url_events=bundle.get("url_events") or [],
+            click_events=bundle.get("click_events") or [],
+            login_url=LOGIN_URL,
+            output_dir=out,
+            bundle=bundle,
+        )
+        written = json.loads((Path(out) / "operations.json").read_text())
+    ops = written if isinstance(written, list) else written.get("operations", [])
+
+    shaped: list[dict] = []
+    for op in ops:
+        steps = []
+        for step in op.get("segment_steps") or op.get("steps") or []:
+            params = step.get("params") or {}
+            steps.append(
+                {
+                    "command": step.get("command"),
+                    # The three that decide whether a step does the right thing.
+                    "target": params.get("selector") or params.get("text") or params.get("role"),
+                    "value": params.get("value") or params.get("name"),
+                    "hover_first": params.get("hover_first"),
+                }
+            )
+        shaped.append({"name": op.get("name"), "kind": op.get("kind"), "steps": steps})
+    return shaped
+
+
+def _load_bundle() -> dict:
+    return json.loads(BUNDLE.read_text())
+
+
+def test_the_compiled_operations_have_not_changed():
+    actual = _compile(_load_bundle())
+    expected = json.loads(GOLDEN.read_text())
+    if actual != expected:  # pragma: no cover - only on a real regression
+        raise AssertionError(
+            "The compiler now produces different operations for the same recording.\n"
+            "If that is intended, run `python tests/test_compile_is_stable.py --update`\n"
+            "and put the diff in the review. If it is not, something regressed.\n\n"
+            f"expected: {json.dumps(expected, indent=1)}\n\n"
+            f"actual:   {json.dumps(actual, indent=1)}"
+        )
+
+
+def test_the_download_operation_still_selects_the_period_and_downloads():
+    """The specific behaviour that broke, named so a regression says what it cost.
+
+    A golden diff tells you something moved. This says which capability went
+    missing -- the Annual radio and the period, without which the skill downloads
+    a monthly statement and every check still passes, because a monthly statement
+    is still a statement.
+    """
+    ops = _compile(_load_bundle())
+    download = [o for o in ops if o["kind"] == "download"]
+    assert download, "no download operation compiled at all"
+    commands = [s["command"] for o in download for s in o["steps"]]
+    assert "set_checked" in commands, "the statement-period radio is not set"
+    assert "select_option" in commands, "the period dropdown is not chosen"
+    assert "list_downloads" in commands, "nothing confirms a file arrived"
+
+
+if __name__ == "__main__":  # pragma: no cover - maintenance entry point
+    if "--update" in sys.argv:
+        GOLDEN.write_text(json.dumps(_compile(_load_bundle()), indent=1) + "\n")
+        print(f"wrote {GOLDEN}")
+    else:
+        print(__doc__)

--- a/tests/test_declared_kind_survives.py
+++ b/tests/test_declared_kind_survives.py
@@ -1,0 +1,37 @@
+"""The skill KIND travels with the recording, not with a command line.
+
+capture_record took --browser-driven, provisioned with it, and never wrote it
+down — so capture_import had to be told again. Forget it there, which is easily
+done since nothing in the recording says so, and an app that must be DRIVEN
+compiles to replayed API calls: an ICICI capture asked for as a "BROWSER BASED"
+skill shipped as two Finacle POSTs.
+"""
+
+from noui_core.capture import ledger
+
+
+def test_the_ledger_remembers_a_browser_driven_recording(tmp_path, monkeypatch):
+    monkeypatch.setenv("NOUI_WORKBENCH_DIR", str(tmp_path))
+    from noui_core.config import settings
+
+    monkeypatch.setattr(settings, "workbench_dir", str(tmp_path))
+
+    ledger.record("sess-1", declared_mode="login", browser_driven=True)
+    assert ledger.declared_browser_driven("sess-1") is True
+
+
+def test_an_ordinary_recording_is_not_marked_browser_driven(tmp_path, monkeypatch):
+    from noui_core.config import settings
+
+    monkeypatch.setattr(settings, "workbench_dir", str(tmp_path))
+
+    ledger.record("sess-2", declared_mode="workflow")
+    assert ledger.declared_browser_driven("sess-2") is False
+
+
+def test_an_unknown_session_is_not_browser_driven(tmp_path, monkeypatch):
+    from noui_core.config import settings
+
+    monkeypatch.setattr(settings, "workbench_dir", str(tmp_path))
+
+    assert ledger.declared_browser_driven("never-recorded") is False

--- a/tests/test_declared_kind_survives.py
+++ b/tests/test_declared_kind_survives.py
@@ -35,3 +35,20 @@ def test_an_unknown_session_is_not_browser_driven(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "workbench_dir", str(tmp_path))
 
     assert ledger.declared_browser_driven("never-recorded") is False
+
+
+def test_the_platform_can_declare_the_kind_by_environment(monkeypatch):
+    """The member's words become an environment fact the agent cannot forget.
+
+    Passing --browser-driven survived only if the agent typed it.
+    NOUI_BROWSER_DRIVEN lets the platform state the kind once, from the member's
+    own request, so the recording is provisioned correctly whether or not anyone
+    remembers the flag.
+    """
+    import os
+
+    monkeypatch.setenv("NOUI_BROWSER_DRIVEN", "1")
+    assert os.environ.get("NOUI_BROWSER_DRIVEN", "").strip().lower() in ("1", "true", "yes")
+
+    monkeypatch.setenv("NOUI_BROWSER_DRIVEN", "")
+    assert os.environ.get("NOUI_BROWSER_DRIVEN", "").strip().lower() not in ("1", "true", "yes")

--- a/tests/test_declared_kind_survives.py
+++ b/tests/test_declared_kind_survives.py
@@ -35,20 +35,3 @@ def test_an_unknown_session_is_not_browser_driven(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "workbench_dir", str(tmp_path))
 
     assert ledger.declared_browser_driven("never-recorded") is False
-
-
-def test_the_platform_can_declare_the_kind_by_environment(monkeypatch):
-    """The member's words become an environment fact the agent cannot forget.
-
-    Passing --browser-driven survived only if the agent typed it.
-    NOUI_BROWSER_DRIVEN lets the platform state the kind once, from the member's
-    own request, so the recording is provisioned correctly whether or not anyone
-    remembers the flag.
-    """
-    import os
-
-    monkeypatch.setenv("NOUI_BROWSER_DRIVEN", "1")
-    assert os.environ.get("NOUI_BROWSER_DRIVEN", "").strip().lower() in ("1", "true", "yes")
-
-    monkeypatch.setenv("NOUI_BROWSER_DRIVEN", "")
-    assert os.environ.get("NOUI_BROWSER_DRIVEN", "").strip().lower() not in ("1", "true", "yes")

--- a/tests/test_fold_candidates.py
+++ b/tests/test_fold_candidates.py
@@ -75,3 +75,63 @@ def test_the_suffix_never_eats_into_the_prefix():
     assert f["prefix"] + f["suffix"] <= min(len(a["steps"]), len(b["steps"]))
     assert f["branches"][0] == []
     assert [s["params"]["selector"] for s in f["branches"][1]] == ["#extra"]
+
+
+# --- applying a fold the member has named --------------------------------------
+#
+# The names come from a person. "corp_finacle" is the page the annual statement
+# happened to be served from; a caller choosing between monthly and annual can
+# make nothing of it.
+
+from noui_core.compile.browser_skill import apply_fold  # noqa: E402
+from noui_core.verify.replay import substitute_parameters  # noqa: E402
+
+
+def _folded():
+    ops = [_op("monthly", [_s("#HDisplay23")]), _op("annual", [_s("#Annual")])]
+    fold = fold_candidates(ops)[0]
+    return apply_fold(
+        ops, fold, name="download_statement", param="timeframe",
+        values=["monthly", "annual"],
+    )
+
+
+def test_the_pair_becomes_one_named_operation():
+    out = _folded()
+    assert [o["name"] for o in out] == ["download_statement"]
+    assert out[0]["parameters"][-1] == {
+        "name": "timeframe",
+        "default": "monthly",
+        "allowed": ["monthly", "annual"],
+        "description": "Which variant to run: monthly, annual.",
+    }
+
+
+def test_each_variant_replays_its_own_steps():
+    op = _folded()[0]
+    def targets(values):
+        return [
+            (s.get("params") or {}).get("selector")
+            for s in substitute_parameters(op, values)
+        ]
+    # The shared journey runs for both; only the middle differs.
+    assert targets({"timeframe": "monthly"}) == ["#nav", "#cards", "#past", "#stmt", "#HDisplay23", None]
+    assert targets({"timeframe": "annual"}) == ["#nav", "#cards", "#past", "#stmt", "#Annual", None]
+
+
+def test_the_default_variant_is_the_first_named():
+    op = _folded()[0]
+    sels = [(s.get("params") or {}).get("selector") for s in substitute_parameters(op)]
+    assert "#HDisplay23" in sels and "#Annual" not in sels
+
+
+def test_only_the_divergent_steps_carry_a_condition():
+    op = _folded()[0]
+    conditioned = [s for s in op["steps"] if s.get("when")]
+    assert len(conditioned) == 2, "the shared prefix and ending must run for every variant"
+
+
+def test_a_fold_naming_missing_operations_changes_nothing():
+    ops = [_op("monthly", [_s("#a")]), _op("annual", [_s("#b")])]
+    bad = {"operations": ["monthly", "gone"], "prefix": 4, "suffix": 1, "branches": [[], []]}
+    assert apply_fold(ops, bad, name="x", param="p", values=["a", "b"]) == ops

--- a/tests/test_fold_candidates.py
+++ b/tests/test_fold_candidates.py
@@ -170,3 +170,41 @@ def test_the_landing_page_starts_from_nothing():
          "nav": None, "_from_key": None},
     ])
     assert pages[0]["starts_from"] is None
+
+
+def test_a_terminal_operation_drops_the_journey_from_its_segment():
+    # A download repeats four clicks the previous operation already made. Its
+    # segment is what happens ON the statement page: the lead-in, the fills, and
+    # the download itself.
+    from noui_core.compile import browser_skill as bs
+
+    op = {
+        "name": "download_statement",
+        "kind": "download",
+        "nav": [
+            {"text": "Cards", "outcome": {"to_url": "https://x.test/credit-card"}},
+            {"text": "Past", "outcome": {"to_url": "https://x.test/stmt"}},
+        ],
+        "lead": [{"command": "click_by_text", "params": {"text": "Annual"}}],
+        "parameters": [],
+        "terminal": {"command": "click_element", "params": {"selector": "#DL"}},
+    }
+    full = bs._steps_for_terminal(op)
+    seg = bs._terminal_segment(op)
+    # The segment is the full recipe minus exactly the two journey clicks --
+    # and it keeps the tail (list_downloads) that confirms the download landed,
+    # which a hand-mirrored version dropped.
+    assert len(full) == len(seg) + 2, "the journey is what the segment drops"
+    assert full[2:] == seg
+    assert seg[0]["params"]["text"] == "Annual"
+    assert seg[-1]["command"] == "list_downloads"
+    assert bs._terminal_starts_from(op) == "https://x.test/stmt"
+
+
+def test_a_terminal_with_no_journey_starts_from_the_landing_page():
+    from noui_core.compile import browser_skill as bs
+
+    op = {"nav": [], "lead": [], "parameters": [],
+          "terminal": {"command": "click_element", "params": {"selector": "#DL"}}}
+    assert bs._terminal_starts_from(op) is None
+    assert bs._terminal_segment(op) == bs._steps_for_terminal(op)

--- a/tests/test_fold_candidates.py
+++ b/tests/test_fold_candidates.py
@@ -369,3 +369,48 @@ def test_a_unique_selector_is_still_preferred():
         ],
     })
     assert step["params"]["selector"] == "#annual"
+
+
+def test_a_completed_download_ends_the_previous_variant():
+    """The human downloaded the MONTHLY statement, then switched to Annual and
+    downloaded again.
+
+    The clicks between the fork and the annual terminal therefore include the
+    monthly download that ENDED the previous variant. Handed to the annual
+    branch it fired a monthly download first, left the form busy — the bank
+    answered "the system is considering your first request" — and the annual
+    steps had nothing to act on.
+    """
+    from noui_core.compile.browser_skill import _after_last_terminal
+
+    steps = [
+        {"command": "click_element", "params": {"selector": "#PDF_Download"},
+         "expect": {"download": True}},
+        {"command": "set_checked", "params": {"role": "radio", "name": "Annual"}},
+        {"command": "click_element", "params": {"selector": "#GO"}},
+    ]
+    kept = [(s.get("params") or {}).get("selector") or (s.get("params") or {}).get("name")
+            for s in _after_last_terminal(steps)]
+    assert kept == ["Annual", "#GO"]
+
+
+def test_steps_with_no_terminal_are_left_alone():
+    from noui_core.compile.browser_skill import _after_last_terminal
+
+    steps = [{"command": "click_by_text", "params": {"text": "Past"}},
+             {"command": "click_element", "params": {"selector": "#x"}}]
+    assert _after_last_terminal(steps) == steps
+
+
+def test_only_the_last_terminal_bounds_it():
+    # Two completed downloads before the fork: everything up to the later one
+    # belongs to variants already finished.
+    from noui_core.compile.browser_skill import _after_last_terminal
+
+    steps = [
+        {"command": "click_element", "params": {"selector": "#a"}, "expect": {"download": True}},
+        {"command": "click_element", "params": {"selector": "#b"}},
+        {"command": "list_downloads", "params": {}},
+        {"command": "click_element", "params": {"selector": "#keep"}},
+    ]
+    assert [(s.get("params") or {}).get("selector") for s in _after_last_terminal(steps)] == ["#keep"]

--- a/tests/test_fold_candidates.py
+++ b/tests/test_fold_candidates.py
@@ -230,3 +230,33 @@ def test_a_terminal_starts_from_its_own_page_not_the_last_stamped_hop():
         "terminal": {"command": "click_element", "params": {"selector": "#DL"}},
     }
     assert bs._terminal_starts_from(op) == "https://infinity.icici.bank.in/corp/AuthenticationController"
+
+
+def test_the_segment_is_folded_too_not_just_the_full_steps():
+    """A segmented replay runs segment_steps. Leaving it as operation A's copy
+    meant `timeframe=annual` ran the monthly branch — the skill offered a choice
+    it could not honour, which is worse than not folding at all.
+    """
+    from noui_core.compile.browser_skill import apply_fold, fold_candidates
+    from noui_core.verify.replay import substitute_parameters
+
+    ops = [
+        {**_op("monthly", [_s("#HDisplay23")]),
+         "segment_steps": [_s("#HDisplay23"), _s("#DL")], "starts_from": "https://x/p"},
+        {**_op("annual", [_s("#Annual"), _s("#GO")]),
+         "segment_steps": [_s("#Annual"), _s("#GO"), _s("#DL")], "starts_from": "https://x/p"},
+    ]
+    fold = fold_candidates(ops)[0]
+    out = apply_fold(ops, fold, name="download_statement", param="timeframe",
+                     values=["monthly", "annual"])[0]
+
+    def seg(tf):
+        return [
+            (s.get("params") or {}).get("selector")
+            for s in substitute_parameters({**out, "steps": out["segment_steps"]},
+                                           {"timeframe": tf})
+        ]
+
+    assert seg("monthly") == ["#HDisplay23", "#DL"]
+    assert seg("annual") == ["#Annual", "#GO", "#DL"]
+    assert "#Annual" not in seg("monthly"), "branches must not leak into each other"

--- a/tests/test_fold_candidates.py
+++ b/tests/test_fold_candidates.py
@@ -1,0 +1,77 @@
+"""Operations that are one workflow with a choice in the middle.
+
+ICICI's monthly and annual statements share four steps to reach the download
+page, then diverge: annual clicks a radio and picks a financial year, monthly
+does not. The compiler emits them as two operations, each replaying the whole
+journey from the landing page — which is why every operation needs the browser
+returned to the entry page before it runs.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+
+from noui_core.compile.browser_skill import fold_candidates  # noqa: E402
+
+
+def _s(t):
+    return {"command": "click_element", "params": {"selector": t}}
+
+
+PREFIX = [_s("#nav"), _s("#cards"), _s("#past"), _s("#stmt")]
+TAIL = [{"command": "list_downloads", "params": {}}]
+
+
+def _op(name, mid, kind="download"):
+    return {"name": name, "kind": kind, "steps": PREFIX + mid + TAIL}
+
+
+def test_a_shared_prefix_and_ending_is_foldable():
+    ops = [_op("monthly", [_s("#HDisplay23")]), _op("annual", [_s("#Annual")])]
+    got = fold_candidates(ops)
+    assert len(got) == 1
+    assert got[0]["operations"] == ["monthly", "annual"]
+    assert got[0]["prefix"] == 4
+    assert got[0]["suffix"] == 1
+    assert [b[0]["params"]["selector"] for b in got[0]["branches"]] == ["#HDisplay23", "#Annual"]
+
+
+def test_a_short_overlap_is_not_a_fold():
+    # Any two operations on one site open with the same nav click. Folding on
+    # that would merge workflows with nothing to do with each other.
+    a = {"name": "a", "kind": "download", "steps": [_s("#nav"), _s("#x")] + TAIL}
+    b = {"name": "b", "kind": "download", "steps": [_s("#nav"), _s("#y")] + TAIL}
+    assert fold_candidates([a, b]) == []
+
+
+def test_operations_of_different_kinds_are_never_folded():
+    ops = [_op("read_it", [_s("#a")], kind="read"), _op("download_it", [_s("#b")])]
+    assert fold_candidates(ops) == []
+
+
+def test_no_shared_ending_means_they_do_different_things():
+    a = {"name": "a", "kind": "download", "steps": PREFIX + [_s("#x")]}
+    b = {"name": "b", "kind": "download", "steps": PREFIX + [_s("#y")]}
+    assert fold_candidates([a, b]) == []
+
+
+def test_identical_operations_are_not_a_fold():
+    ops = [_op("a", [_s("#same")]), _op("b", [_s("#same")])]
+    assert fold_candidates(ops) == []
+
+
+def test_the_suffix_never_eats_into_the_prefix():
+    # Two operations that are prefix + tail, differing only in length, must not
+    # report overlapping regions — the branches would come out negative-length.
+    a = _op("a", [])
+    b = _op("b", [_s("#extra")])
+    got = fold_candidates([a, b])
+    assert len(got) == 1
+    f = got[0]
+    assert f["prefix"] + f["suffix"] <= min(len(a["steps"]), len(b["steps"]))
+    assert f["branches"][0] == []
+    assert [s["params"]["selector"] for s in f["branches"][1]] == ["#extra"]

--- a/tests/test_fold_candidates.py
+++ b/tests/test_fold_candidates.py
@@ -467,3 +467,56 @@ def test_provenance_never_makes_two_identical_actions_differ():
     b = [{"command": "click_element", "params": {"selector": "#D"}, "_seq": 39}]
     assert _common_prefix_len(a, b) == 1
     assert _common_suffix_len(a, b, 0) == 1
+
+
+def _pair():
+    """The monthly/annual pair, shaped like the real fold."""
+    to_fork = [_s("#nav"), _s("#past"), _s("#stmt")]
+    monthly = {**_op("monthly", [_s("#DL")]),
+               "steps": to_fork + [_s("#DL")] + TAIL,
+               "segment_steps": [_s("#DL")] + TAIL}
+    annual = {**_op("annual", [_s("#DL")]),
+              "steps": to_fork + [_s("#Annual"), _s("#GO")] + [_s("#year"), _s("#DL")] + TAIL,
+              "segment_steps": [_s("#year"), _s("#DL")] + TAIL}
+    return monthly, annual
+
+def test_each_variant_starts_where_its_own_work_happens():
+    """A folded operation's variants need not share a page.
+
+    ICICI produces the monthly statement on /corp/AuthenticationController;
+    choosing Annual navigates to /corp/Finacle. The folded operation inherited
+    the monthly page as its single precondition, so the annual variant's guard
+    refused it while standing on exactly the page it was supposed to run on.
+    """
+    from noui_core.compile.browser_skill import apply_fold, fold_candidates
+
+    monthly, annual = _pair()
+    monthly["starts_from"] = "https://p.test/corp/AuthenticationController"
+    annual["starts_from"] = "https://p.test/corp/Finacle"
+
+    fold = fold_candidates([monthly, annual])[0]
+    out = apply_fold([monthly, annual], fold, name="download_statement",
+                     param="timeframe", values=["monthly", "annual"])
+    op = [o for o in out if o["name"] == "download_statement"][0]
+
+    assert op["starts_from_by"] == {
+        "param": "timeframe",
+        "by": {
+            "monthly": "https://p.test/corp/AuthenticationController",
+            "annual": "https://p.test/corp/Finacle",
+        },
+    }
+
+
+def test_variants_that_share_a_page_carry_no_override():
+    """Nothing changes for a fold whose variants begin in the same place."""
+    from noui_core.compile.browser_skill import apply_fold, fold_candidates
+
+    monthly, annual = _pair()
+    monthly["starts_from"] = annual["starts_from"] = "https://p.test/same"
+
+    fold = fold_candidates([monthly, annual])[0]
+    out = apply_fold([monthly, annual], fold, name="d", param="timeframe",
+                     values=["monthly", "annual"])
+    op = [o for o in out if o["name"] == "d"][0]
+    assert "starts_from_by" not in op

--- a/tests/test_fold_candidates.py
+++ b/tests/test_fold_candidates.py
@@ -294,3 +294,43 @@ def test_a_recorded_expectation_is_not_overwritten():
           if (s.get("params") or {}).get("selector") == "#DL"][0]
     assert dl["expect"]["url"] == "https://x/observed", "what was observed wins"
     assert dl["expect"]["download"] is True
+
+
+def test_a_branch_keeps_the_journey_only_it_takes():
+    """A step can both navigate and belong to one branch.
+
+    ICICI's annual statement is selected by a radio and a GO press — and that
+    submit navigates, so both were classified as journey and stripped from the
+    segment. Nothing else performed them: the monthly branch diverges before,
+    and no operation sits between. So timeframe=annual ran the MONTHLY steps on
+    the monthly page and returned a monthly statement, with every check green.
+    """
+    from noui_core.compile.browser_skill import apply_fold, fold_candidates
+    from noui_core.verify.replay import substitute_parameters
+
+    to_fork = [_s("#nav"), _s("#past"), _s("#stmt")]
+    monthly = {**_op("monthly", [_s("#DL")]),
+               "steps": to_fork + [_s("#DL")] + TAIL,
+               "segment_steps": [_s("#DL")] + TAIL, "starts_from": "https://x/fork"}
+    annual = {**_op("annual", [_s("#DL")]),
+              # its journey continues past the fork: radio, then GO (navigates)
+              "steps": to_fork + [_s("#Annual"), _s("#GO")] + [_s("#year"), _s("#DL")] + TAIL,
+              "segment_steps": [_s("#year"), _s("#DL")] + TAIL,
+              "starts_from": "https://x/after-go"}
+
+    fold = fold_candidates([monthly, annual])[0]
+    out = apply_fold([monthly, annual], fold, name="download_statement",
+                     param="timeframe", values=["monthly", "annual"])[0]
+
+    def seg(tf):
+        return [
+            (s.get("params") or {}).get("selector")
+            for s in substitute_parameters({**out, "steps": out["segment_steps"]},
+                                           {"timeframe": tf})
+        ]
+
+    assert "#Annual" in seg("annual"), "the branch must select itself"
+    assert "#GO" in seg("annual")
+    assert "#Annual" not in seg("monthly")
+    # The way to the fork stays out of both — the operation before walks it.
+    assert "#past" not in seg("annual") and "#past" not in seg("monthly")

--- a/tests/test_fold_candidates.py
+++ b/tests/test_fold_candidates.py
@@ -135,3 +135,38 @@ def test_a_fold_naming_missing_operations_changes_nothing():
     ops = [_op("monthly", [_s("#a")]), _op("annual", [_s("#b")])]
     bad = {"operations": ["monthly", "gone"], "prefix": 4, "suffix": 1, "branches": [[], []]}
     assert apply_fold(ops, bad, name="x", param="p", values=["a", "b"]) == ops
+
+
+# --- segments: the hop, not the whole journey ----------------------------------
+#
+# `steps` repeats the full chain from the landing page into every operation, so
+# replaying operation 2 demands being back somewhere the recording left once and
+# never returned to. `segment_steps` is only the hop from `starts_from`.
+
+
+def test_the_compiler_emits_the_hop_alongside_the_journey():
+    from noui_core.compile import browser_skill as bs
+
+    pages = bs._resolve_nav_chains([
+        {"name": "read_overview", "url": "https://x.test/overview",
+         "nav": None, "_from_key": None},
+        {"name": "read_cc", "url": "https://x.test/credit-card",
+         "nav": [{"text": "Cards"}], "_from_key": bs._page_key("https://x.test/overview")},
+        {"name": "read_stmt", "url": "https://x.test/stmt",
+         "nav": [{"text": "Past"}], "_from_key": bs._page_key("https://x.test/credit-card")},
+    ])
+    stmt = [p for p in pages if p["name"] == "read_stmt"][0]
+    assert [c["text"] for c in stmt["nav"]] == ["Cards", "Past"]   # the journey
+    assert [c["text"] for c in stmt["segment"]] == ["Past"]        # the hop
+    assert stmt["starts_from"] == "https://x.test/credit-card"
+
+
+def test_the_landing_page_starts_from_nothing():
+    # A fresh session is already there, so there is no hop to record.
+    from noui_core.compile import browser_skill as bs
+
+    pages = bs._resolve_nav_chains([
+        {"name": "read_overview", "url": "https://x.test/overview",
+         "nav": None, "_from_key": None},
+    ])
+    assert pages[0]["starts_from"] is None

--- a/tests/test_fold_candidates.py
+++ b/tests/test_fold_candidates.py
@@ -198,7 +198,7 @@ def test_a_terminal_operation_drops_the_journey_from_its_segment():
     assert full[2:] == seg
     assert seg[0]["params"]["text"] == "Annual"
     assert seg[-1]["command"] == "list_downloads"
-    assert bs._terminal_starts_from(op) == "https://x.test/stmt"
+    assert bs._terminal_starts_from(dict(op, url="https://x.test/stmt")) == "https://x.test/stmt"
 
 
 def test_a_terminal_with_no_journey_starts_from_the_landing_page():
@@ -208,3 +208,25 @@ def test_a_terminal_with_no_journey_starts_from_the_landing_page():
           "terminal": {"command": "click_element", "params": {"selector": "#DL"}}}
     assert bs._terminal_starts_from(op) is None
     assert bs._terminal_segment(op) == bs._steps_for_terminal(op)
+
+
+def test_a_terminal_starts_from_its_own_page_not_the_last_stamped_hop():
+    """download_statement came out starting from /credit-card while it runs on
+    the statement portal, so its starts_from guard refused it every time.
+
+    A cross-origin hop completes after the click returns, so it is never stamped
+    as that click's outcome — and walking the nav chain for one fell back to the
+    last hop that WAS stamped. The operation already carries the page it acts on.
+    """
+    from noui_core.compile import browser_skill as bs
+
+    op = {
+        "url": "https://infinity.icici.bank.in/corp/AuthenticationController",
+        "nav": [
+            {"text": "Cards", "outcome": {"to_url": "https://retailnetbanking.icici.bank.in/credit-card"}},
+            {"text": "Past", "outcome": {"navigated": False, "to_url": None}},
+        ],
+        "lead": [], "parameters": [],
+        "terminal": {"command": "click_element", "params": {"selector": "#DL"}},
+    }
+    assert bs._terminal_starts_from(op) == "https://infinity.icici.bank.in/corp/AuthenticationController"

--- a/tests/test_fold_candidates.py
+++ b/tests/test_fold_candidates.py
@@ -260,3 +260,37 @@ def test_the_segment_is_folded_too_not_just_the_full_steps():
     assert seg("monthly") == ["#HDisplay23", "#DL"]
     assert seg("annual") == ["#Annual", "#GO", "#DL"]
     assert "#Annual" not in seg("monthly"), "branches must not leak into each other"
+
+
+def test_the_terminal_asserts_the_page_it_was_recorded_on():
+    """ICICI's annual and monthly statement pages are identically designed.
+
+    #PDF_Download and #DOWNLOAD_ESTATEMENT_PDF exist on both, so the monthly
+    steps ran on the annual page and returned a MONTHLY statement with every
+    check green — selector checks cannot tell the pages apart. Their URLs can.
+    """
+    from noui_core.compile import browser_skill as bs
+
+    op = {
+        "url": "https://infinity.icici.bank.in/corp/Finacle",
+        "work_url": "https://infinity.icici.bank.in/corp/Finacle",
+        "nav": [], "lead": [], "parameters": [],
+        "terminal": {"command": "click_element", "params": {"selector": "#DL"}},
+    }
+    steps = bs._steps_for_terminal(op)
+    dl = [s for s in steps if (s.get("params") or {}).get("selector") == "#DL"][0]
+    assert dl["expect"]["url"] == "https://infinity.icici.bank.in/corp/Finacle"
+
+
+def test_a_recorded_expectation_is_not_overwritten():
+    from noui_core.compile import browser_skill as bs
+
+    op = {
+        "url": "https://x/page", "nav": [], "lead": [], "parameters": [],
+        "terminal": {"command": "click_element", "params": {"selector": "#DL"},
+                     "expect": {"url": "https://x/observed", "download": True}},
+    }
+    dl = [s for s in bs._steps_for_terminal(op)
+          if (s.get("params") or {}).get("selector") == "#DL"][0]
+    assert dl["expect"]["url"] == "https://x/observed", "what was observed wins"
+    assert dl["expect"]["download"] is True

--- a/tests/test_fold_candidates.py
+++ b/tests/test_fold_candidates.py
@@ -414,3 +414,56 @@ def test_only_the_last_terminal_bounds_it():
         {"command": "click_element", "params": {"selector": "#keep"}},
     ]
     assert [(s.get("params") or {}).get("selector") for s in _after_last_terminal(steps)] == ["#keep"]
+
+
+def test_a_terminal_the_steps_cannot_show_still_bounds_the_branch():
+    """The real ICICI boundary is invisible in the steps.
+
+    The monthly download was reported against the `submit` that the download
+    click triggered, and a submit is not a replayable step — so no step in the
+    annual journey carries `expect.download`, and comparing the steps finds
+    nothing. Recorded order is the only witness: `_seq` says when each step
+    happened, the monthly operation says when it finished, and everything at or
+    before that moment was its work.
+    """
+    from noui_core.compile.browser_skill import _after_last_terminal
+
+    steps = [
+        {"command": "click_element", "params": {"selector": "#PDF_Download"}, "_seq": 20},
+        {"command": "set_checked", "params": {"role": "radio", "name": "Annual"}, "_seq": 23},
+        {"command": "click_element", "params": {"selector": "#DUMMY1"}, "_seq": 24},
+    ]
+    kept = [(s.get("params") or {}).get("selector") or (s.get("params") or {}).get("name")
+            for s in _after_last_terminal(steps, boundary_seq=22)]
+    assert kept == ["Annual", "#DUMMY1"]
+
+
+def test_a_terminal_that_has_not_happened_yet_bounds_nothing():
+    """Applied backwards this rule deletes the earlier branch entirely.
+
+    The monthly branch must not be trimmed by the annual download that comes
+    after it: every one of its steps precedes that moment, so the whole branch
+    would vanish and the operation would report success having done nothing.
+    """
+    from noui_core.compile.browser_skill import _preceding_terminal
+
+    assert _preceding_terminal(22, 40) is None      # monthly bounded by annual: no
+    assert _preceding_terminal(40, 22) == 22        # annual bounded by monthly: yes
+    assert _preceding_terminal(22, 22) is None      # one operation is not its own boundary
+    assert _preceding_terminal(None, 22) is None
+    assert _preceding_terminal(40, None) is None
+
+
+def test_provenance_never_makes_two_identical_actions_differ():
+    """`_seq` records where a step came from, not what it does.
+
+    Monthly and annual both end by clicking Download, from different clicks. If
+    the recorded moment counted as part of the step, that shared ending would
+    stop being recognised as shared and be duplicated into both branches.
+    """
+    from noui_core.compile.browser_skill import _common_prefix_len, _common_suffix_len
+
+    a = [{"command": "click_element", "params": {"selector": "#D"}, "_seq": 21}]
+    b = [{"command": "click_element", "params": {"selector": "#D"}, "_seq": 39}]
+    assert _common_prefix_len(a, b) == 1
+    assert _common_suffix_len(a, b, 0) == 1

--- a/tests/test_fold_candidates.py
+++ b/tests/test_fold_candidates.py
@@ -334,3 +334,38 @@ def test_a_branch_keeps_the_journey_only_it_takes():
     assert "#Annual" not in seg("monthly")
     # The way to the fork stays out of both — the operation before walks it.
     assert "#past" not in seg("annual") and "#past" not in seg("monthly")
+
+
+def test_a_radio_with_no_unique_selector_is_set_by_role_and_name():
+    """ICICI's Monthly and Annual radios share an id AND a name.
+
+    No selector picks one of them, so the step fell back to clicking the label
+    text: it reported success while the form stayed on Monthly, and the replay
+    downloaded a monthly statement while asking for the annual one. The only
+    unique handle the recorder captured was `role_name: radio|Annual`.
+    """
+    from noui_core.compile.browser_skill import _step_for_click
+
+    step = _step_for_click({
+        "element": {"role": "radio"},
+        "candidates": [
+            {"kind": "id", "value": "#PERIOD_TYPE", "match_count": 2},
+            {"kind": "name", "value": 'input[name="PERIOD_TYPE"]', "match_count": 2},
+            {"kind": "role_name", "value": "radio|Annual", "match_count": 1},
+        ],
+    })
+    assert step["command"] == "set_checked"
+    assert step["params"] == {"role": "radio", "name": "Annual", "checked": True}
+
+
+def test_a_unique_selector_is_still_preferred():
+    from noui_core.compile.browser_skill import _step_for_click
+
+    step = _step_for_click({
+        "element": {"role": "radio"},
+        "candidates": [
+            {"kind": "id", "value": "#annual", "match_count": 1},
+            {"kind": "role_name", "value": "radio|Annual", "match_count": 1},
+        ],
+    })
+    assert step["params"]["selector"] == "#annual"

--- a/tests/test_fold_candidates.py
+++ b/tests/test_fold_candidates.py
@@ -91,7 +91,10 @@ def _folded():
     ops = [_op("monthly", [_s("#HDisplay23")]), _op("annual", [_s("#Annual")])]
     fold = fold_candidates(ops)[0]
     return apply_fold(
-        ops, fold, name="download_statement", param="timeframe",
+        ops,
+        fold,
+        name="download_statement",
+        param="timeframe",
         values=["monthly", "annual"],
     )
 
@@ -109,13 +112,19 @@ def test_the_pair_becomes_one_named_operation():
 
 def test_each_variant_replays_its_own_steps():
     op = _folded()[0]
+
     def targets(values):
-        return [
-            (s.get("params") or {}).get("selector")
-            for s in substitute_parameters(op, values)
-        ]
+        return [(s.get("params") or {}).get("selector") for s in substitute_parameters(op, values)]
+
     # The shared journey runs for both; only the middle differs.
-    assert targets({"timeframe": "monthly"}) == ["#nav", "#cards", "#past", "#stmt", "#HDisplay23", None]
+    assert targets({"timeframe": "monthly"}) == [
+        "#nav",
+        "#cards",
+        "#past",
+        "#stmt",
+        "#HDisplay23",
+        None,
+    ]
     assert targets({"timeframe": "annual"}) == ["#nav", "#cards", "#past", "#stmt", "#Annual", None]
 
 
@@ -147,17 +156,31 @@ def test_a_fold_naming_missing_operations_changes_nothing():
 def test_the_compiler_emits_the_hop_alongside_the_journey():
     from noui_core.compile import browser_skill as bs
 
-    pages = bs._resolve_nav_chains([
-        {"name": "read_overview", "url": "https://x.test/overview",
-         "nav": None, "_from_key": None},
-        {"name": "read_cc", "url": "https://x.test/credit-card",
-         "nav": [{"text": "Cards"}], "_from_key": bs._page_key("https://x.test/overview")},
-        {"name": "read_stmt", "url": "https://x.test/stmt",
-         "nav": [{"text": "Past"}], "_from_key": bs._page_key("https://x.test/credit-card")},
-    ])
+    pages = bs._resolve_nav_chains(
+        [
+            {
+                "name": "read_overview",
+                "url": "https://x.test/overview",
+                "nav": None,
+                "_from_key": None,
+            },
+            {
+                "name": "read_cc",
+                "url": "https://x.test/credit-card",
+                "nav": [{"text": "Cards"}],
+                "_from_key": bs._page_key("https://x.test/overview"),
+            },
+            {
+                "name": "read_stmt",
+                "url": "https://x.test/stmt",
+                "nav": [{"text": "Past"}],
+                "_from_key": bs._page_key("https://x.test/credit-card"),
+            },
+        ]
+    )
     stmt = [p for p in pages if p["name"] == "read_stmt"][0]
-    assert [c["text"] for c in stmt["nav"]] == ["Cards", "Past"]   # the journey
-    assert [c["text"] for c in stmt["segment"]] == ["Past"]        # the hop
+    assert [c["text"] for c in stmt["nav"]] == ["Cards", "Past"]  # the journey
+    assert [c["text"] for c in stmt["segment"]] == ["Past"]  # the hop
     assert stmt["starts_from"] == "https://x.test/credit-card"
 
 
@@ -165,10 +188,16 @@ def test_the_landing_page_starts_from_nothing():
     # A fresh session is already there, so there is no hop to record.
     from noui_core.compile import browser_skill as bs
 
-    pages = bs._resolve_nav_chains([
-        {"name": "read_overview", "url": "https://x.test/overview",
-         "nav": None, "_from_key": None},
-    ])
+    pages = bs._resolve_nav_chains(
+        [
+            {
+                "name": "read_overview",
+                "url": "https://x.test/overview",
+                "nav": None,
+                "_from_key": None,
+            },
+        ]
+    )
     assert pages[0]["starts_from"] is None
 
 
@@ -204,8 +233,12 @@ def test_a_terminal_operation_drops_the_journey_from_its_segment():
 def test_a_terminal_with_no_journey_starts_from_the_landing_page():
     from noui_core.compile import browser_skill as bs
 
-    op = {"nav": [], "lead": [], "parameters": [],
-          "terminal": {"command": "click_element", "params": {"selector": "#DL"}}}
+    op = {
+        "nav": [],
+        "lead": [],
+        "parameters": [],
+        "terminal": {"command": "click_element", "params": {"selector": "#DL"}},
+    }
     assert bs._terminal_starts_from(op) is None
     assert bs._terminal_segment(op) == bs._steps_for_terminal(op)
 
@@ -223,13 +256,20 @@ def test_a_terminal_starts_from_its_own_page_not_the_last_stamped_hop():
     op = {
         "url": "https://infinity.icici.bank.in/corp/AuthenticationController",
         "nav": [
-            {"text": "Cards", "outcome": {"to_url": "https://retailnetbanking.icici.bank.in/credit-card"}},
+            {
+                "text": "Cards",
+                "outcome": {"to_url": "https://retailnetbanking.icici.bank.in/credit-card"},
+            },
             {"text": "Past", "outcome": {"navigated": False, "to_url": None}},
         ],
-        "lead": [], "parameters": [],
+        "lead": [],
+        "parameters": [],
         "terminal": {"command": "click_element", "params": {"selector": "#DL"}},
     }
-    assert bs._terminal_starts_from(op) == "https://infinity.icici.bank.in/corp/AuthenticationController"
+    assert (
+        bs._terminal_starts_from(op)
+        == "https://infinity.icici.bank.in/corp/AuthenticationController"
+    )
 
 
 def test_the_segment_is_folded_too_not_just_the_full_steps():
@@ -241,20 +281,28 @@ def test_the_segment_is_folded_too_not_just_the_full_steps():
     from noui_core.verify.replay import substitute_parameters
 
     ops = [
-        {**_op("monthly", [_s("#HDisplay23")]),
-         "segment_steps": [_s("#HDisplay23"), _s("#DL")], "starts_from": "https://x/p"},
-        {**_op("annual", [_s("#Annual"), _s("#GO")]),
-         "segment_steps": [_s("#Annual"), _s("#GO"), _s("#DL")], "starts_from": "https://x/p"},
+        {
+            **_op("monthly", [_s("#HDisplay23")]),
+            "segment_steps": [_s("#HDisplay23"), _s("#DL")],
+            "starts_from": "https://x/p",
+        },
+        {
+            **_op("annual", [_s("#Annual"), _s("#GO")]),
+            "segment_steps": [_s("#Annual"), _s("#GO"), _s("#DL")],
+            "starts_from": "https://x/p",
+        },
     ]
     fold = fold_candidates(ops)[0]
-    out = apply_fold(ops, fold, name="download_statement", param="timeframe",
-                     values=["monthly", "annual"])[0]
+    out = apply_fold(
+        ops, fold, name="download_statement", param="timeframe", values=["monthly", "annual"]
+    )[0]
 
     def seg(tf):
         return [
             (s.get("params") or {}).get("selector")
-            for s in substitute_parameters({**out, "steps": out["segment_steps"]},
-                                           {"timeframe": tf})
+            for s in substitute_parameters(
+                {**out, "steps": out["segment_steps"]}, {"timeframe": tf}
+            )
         ]
 
     assert seg("monthly") == ["#HDisplay23", "#DL"]
@@ -274,7 +322,9 @@ def test_the_terminal_asserts_the_page_it_was_recorded_on():
     op = {
         "url": "https://infinity.icici.bank.in/corp/Finacle",
         "work_url": "https://infinity.icici.bank.in/corp/Finacle",
-        "nav": [], "lead": [], "parameters": [],
+        "nav": [],
+        "lead": [],
+        "parameters": [],
         "terminal": {"command": "click_element", "params": {"selector": "#DL"}},
     }
     steps = bs._steps_for_terminal(op)
@@ -286,12 +336,19 @@ def test_a_recorded_expectation_is_not_overwritten():
     from noui_core.compile import browser_skill as bs
 
     op = {
-        "url": "https://x/page", "nav": [], "lead": [], "parameters": [],
-        "terminal": {"command": "click_element", "params": {"selector": "#DL"},
-                     "expect": {"url": "https://x/observed", "download": True}},
+        "url": "https://x/page",
+        "nav": [],
+        "lead": [],
+        "parameters": [],
+        "terminal": {
+            "command": "click_element",
+            "params": {"selector": "#DL"},
+            "expect": {"url": "https://x/observed", "download": True},
+        },
     }
-    dl = [s for s in bs._steps_for_terminal(op)
-          if (s.get("params") or {}).get("selector") == "#DL"][0]
+    dl = [
+        s for s in bs._steps_for_terminal(op) if (s.get("params") or {}).get("selector") == "#DL"
+    ][0]
     assert dl["expect"]["url"] == "https://x/observed", "what was observed wins"
     assert dl["expect"]["download"] is True
 
@@ -309,24 +366,35 @@ def test_a_branch_keeps_the_journey_only_it_takes():
     from noui_core.verify.replay import substitute_parameters
 
     to_fork = [_s("#nav"), _s("#past"), _s("#stmt")]
-    monthly = {**_op("monthly", [_s("#DL")]),
-               "steps": to_fork + [_s("#DL")] + TAIL,
-               "segment_steps": [_s("#DL")] + TAIL, "starts_from": "https://x/fork"}
-    annual = {**_op("annual", [_s("#DL")]),
-              # its journey continues past the fork: radio, then GO (navigates)
-              "steps": to_fork + [_s("#Annual"), _s("#GO")] + [_s("#year"), _s("#DL")] + TAIL,
-              "segment_steps": [_s("#year"), _s("#DL")] + TAIL,
-              "starts_from": "https://x/after-go"}
+    monthly = {
+        **_op("monthly", [_s("#DL")]),
+        "steps": to_fork + [_s("#DL")] + TAIL,
+        "segment_steps": [_s("#DL")] + TAIL,
+        "starts_from": "https://x/fork",
+    }
+    annual = {
+        **_op("annual", [_s("#DL")]),
+        # its journey continues past the fork: radio, then GO (navigates)
+        "steps": to_fork + [_s("#Annual"), _s("#GO")] + [_s("#year"), _s("#DL")] + TAIL,
+        "segment_steps": [_s("#year"), _s("#DL")] + TAIL,
+        "starts_from": "https://x/after-go",
+    }
 
     fold = fold_candidates([monthly, annual])[0]
-    out = apply_fold([monthly, annual], fold, name="download_statement",
-                     param="timeframe", values=["monthly", "annual"])[0]
+    out = apply_fold(
+        [monthly, annual],
+        fold,
+        name="download_statement",
+        param="timeframe",
+        values=["monthly", "annual"],
+    )[0]
 
     def seg(tf):
         return [
             (s.get("params") or {}).get("selector")
-            for s in substitute_parameters({**out, "steps": out["segment_steps"]},
-                                           {"timeframe": tf})
+            for s in substitute_parameters(
+                {**out, "steps": out["segment_steps"]}, {"timeframe": tf}
+            )
         ]
 
     assert "#Annual" in seg("annual"), "the branch must select itself"
@@ -346,14 +414,16 @@ def test_a_radio_with_no_unique_selector_is_set_by_role_and_name():
     """
     from noui_core.compile.browser_skill import _step_for_click
 
-    step = _step_for_click({
-        "element": {"role": "radio"},
-        "candidates": [
-            {"kind": "id", "value": "#PERIOD_TYPE", "match_count": 2},
-            {"kind": "name", "value": 'input[name="PERIOD_TYPE"]', "match_count": 2},
-            {"kind": "role_name", "value": "radio|Annual", "match_count": 1},
-        ],
-    })
+    step = _step_for_click(
+        {
+            "element": {"role": "radio"},
+            "candidates": [
+                {"kind": "id", "value": "#PERIOD_TYPE", "match_count": 2},
+                {"kind": "name", "value": 'input[name="PERIOD_TYPE"]', "match_count": 2},
+                {"kind": "role_name", "value": "radio|Annual", "match_count": 1},
+            ],
+        }
+    )
     assert step["command"] == "set_checked"
     assert step["params"] == {"role": "radio", "name": "Annual", "checked": True}
 
@@ -361,13 +431,15 @@ def test_a_radio_with_no_unique_selector_is_set_by_role_and_name():
 def test_a_unique_selector_is_still_preferred():
     from noui_core.compile.browser_skill import _step_for_click
 
-    step = _step_for_click({
-        "element": {"role": "radio"},
-        "candidates": [
-            {"kind": "id", "value": "#annual", "match_count": 1},
-            {"kind": "role_name", "value": "radio|Annual", "match_count": 1},
-        ],
-    })
+    step = _step_for_click(
+        {
+            "element": {"role": "radio"},
+            "candidates": [
+                {"kind": "id", "value": "#annual", "match_count": 1},
+                {"kind": "role_name", "value": "radio|Annual", "match_count": 1},
+            ],
+        }
+    )
     assert step["params"]["selector"] == "#annual"
 
 
@@ -384,21 +456,28 @@ def test_a_completed_download_ends_the_previous_variant():
     from noui_core.compile.browser_skill import _after_last_terminal
 
     steps = [
-        {"command": "click_element", "params": {"selector": "#PDF_Download"},
-         "expect": {"download": True}},
+        {
+            "command": "click_element",
+            "params": {"selector": "#PDF_Download"},
+            "expect": {"download": True},
+        },
         {"command": "set_checked", "params": {"role": "radio", "name": "Annual"}},
         {"command": "click_element", "params": {"selector": "#GO"}},
     ]
-    kept = [(s.get("params") or {}).get("selector") or (s.get("params") or {}).get("name")
-            for s in _after_last_terminal(steps)]
+    kept = [
+        (s.get("params") or {}).get("selector") or (s.get("params") or {}).get("name")
+        for s in _after_last_terminal(steps)
+    ]
     assert kept == ["Annual", "#GO"]
 
 
 def test_steps_with_no_terminal_are_left_alone():
     from noui_core.compile.browser_skill import _after_last_terminal
 
-    steps = [{"command": "click_by_text", "params": {"text": "Past"}},
-             {"command": "click_element", "params": {"selector": "#x"}}]
+    steps = [
+        {"command": "click_by_text", "params": {"text": "Past"}},
+        {"command": "click_element", "params": {"selector": "#x"}},
+    ]
     assert _after_last_terminal(steps) == steps
 
 
@@ -413,7 +492,9 @@ def test_only_the_last_terminal_bounds_it():
         {"command": "list_downloads", "params": {}},
         {"command": "click_element", "params": {"selector": "#keep"}},
     ]
-    assert [(s.get("params") or {}).get("selector") for s in _after_last_terminal(steps)] == ["#keep"]
+    assert [(s.get("params") or {}).get("selector") for s in _after_last_terminal(steps)] == [
+        "#keep"
+    ]
 
 
 def test_a_terminal_the_steps_cannot_show_still_bounds_the_branch():
@@ -433,8 +514,10 @@ def test_a_terminal_the_steps_cannot_show_still_bounds_the_branch():
         {"command": "set_checked", "params": {"role": "radio", "name": "Annual"}, "_seq": 23},
         {"command": "click_element", "params": {"selector": "#DUMMY1"}, "_seq": 24},
     ]
-    kept = [(s.get("params") or {}).get("selector") or (s.get("params") or {}).get("name")
-            for s in _after_last_terminal(steps, boundary_seq=22)]
+    kept = [
+        (s.get("params") or {}).get("selector") or (s.get("params") or {}).get("name")
+        for s in _after_last_terminal(steps, boundary_seq=22)
+    ]
     assert kept == ["Annual", "#DUMMY1"]
 
 
@@ -447,9 +530,9 @@ def test_a_terminal_that_has_not_happened_yet_bounds_nothing():
     """
     from noui_core.compile.browser_skill import _preceding_terminal
 
-    assert _preceding_terminal(22, 40) is None      # monthly bounded by annual: no
-    assert _preceding_terminal(40, 22) == 22        # annual bounded by monthly: yes
-    assert _preceding_terminal(22, 22) is None      # one operation is not its own boundary
+    assert _preceding_terminal(22, 40) is None  # monthly bounded by annual: no
+    assert _preceding_terminal(40, 22) == 22  # annual bounded by monthly: yes
+    assert _preceding_terminal(22, 22) is None  # one operation is not its own boundary
     assert _preceding_terminal(None, 22) is None
     assert _preceding_terminal(40, None) is None
 
@@ -472,13 +555,18 @@ def test_provenance_never_makes_two_identical_actions_differ():
 def _pair():
     """The monthly/annual pair, shaped like the real fold."""
     to_fork = [_s("#nav"), _s("#past"), _s("#stmt")]
-    monthly = {**_op("monthly", [_s("#DL")]),
-               "steps": to_fork + [_s("#DL")] + TAIL,
-               "segment_steps": [_s("#DL")] + TAIL}
-    annual = {**_op("annual", [_s("#DL")]),
-              "steps": to_fork + [_s("#Annual"), _s("#GO")] + [_s("#year"), _s("#DL")] + TAIL,
-              "segment_steps": [_s("#year"), _s("#DL")] + TAIL}
+    monthly = {
+        **_op("monthly", [_s("#DL")]),
+        "steps": to_fork + [_s("#DL")] + TAIL,
+        "segment_steps": [_s("#DL")] + TAIL,
+    }
+    annual = {
+        **_op("annual", [_s("#DL")]),
+        "steps": to_fork + [_s("#Annual"), _s("#GO")] + [_s("#year"), _s("#DL")] + TAIL,
+        "segment_steps": [_s("#year"), _s("#DL")] + TAIL,
+    }
     return monthly, annual
+
 
 def test_each_variant_starts_where_its_own_work_happens():
     """A folded operation's variants need not share a page.
@@ -495,8 +583,13 @@ def test_each_variant_starts_where_its_own_work_happens():
     annual["starts_from"] = "https://p.test/corp/Finacle"
 
     fold = fold_candidates([monthly, annual])[0]
-    out = apply_fold([monthly, annual], fold, name="download_statement",
-                     param="timeframe", values=["monthly", "annual"])
+    out = apply_fold(
+        [monthly, annual],
+        fold,
+        name="download_statement",
+        param="timeframe",
+        values=["monthly", "annual"],
+    )
     op = [o for o in out if o["name"] == "download_statement"][0]
 
     assert op["starts_from_by"] == {
@@ -516,7 +609,8 @@ def test_variants_that_share_a_page_carry_no_override():
     monthly["starts_from"] = annual["starts_from"] = "https://p.test/same"
 
     fold = fold_candidates([monthly, annual])[0]
-    out = apply_fold([monthly, annual], fold, name="d", param="timeframe",
-                     values=["monthly", "annual"])
+    out = apply_fold(
+        [monthly, annual], fold, name="d", param="timeframe", values=["monthly", "annual"]
+    )
     op = [o for o in out if o["name"] == "d"][0]
     assert "starts_from_by" not in op

--- a/tests/test_hover_click_gesture.py
+++ b/tests/test_hover_click_gesture.py
@@ -42,7 +42,10 @@ def test_the_pair_becomes_one_step():
     }
     # The click's expectation describes where the gesture lands; the hover's
     # described opening a menu and is not the postcondition.
-    assert out[0]["expect"] == {"url": "https://x/credit-card"}
+    # Plus the hover's own measurement of how long its menu takes to appear —
+    # the click never measured that, and without it the step fell back to the
+    # runtime's 3s floor.
+    assert out[0]["expect"] == {"url": "https://x/credit-card", "settle_ms": 4322}
 
 
 def test_a_hover_before_something_else_is_left_alone():
@@ -127,3 +130,34 @@ def test_scoping_a_recorded_control_inside_another_keeps_its_provenance():
     assert _is_observed_scoped_inside_observed("#nav a.invented", seen) is False
     assert _is_observed_scoped_inside_observed("#other a.item", seen) is False
     assert _is_observed_scoped_inside_observed("a.item", seen) is False
+
+
+def test_the_merged_step_keeps_the_hovers_measurement_of_the_menu():
+    """How long the menu takes was measured on the HOVER, not on the click.
+
+    Folding threw it away with the rest of the hover's expectation, so the
+    merged step carried no settle and fell back to the runtime's 3s floor —
+    while ICICI's nav measured 2161ms and renders its submenu right around
+    there. That is the coin flip.
+    """
+    from noui_core.compile.browser_skill import _fold_hover_into_click
+
+    out = _fold_hover_into_click([
+        {"command": "hover", "params": {"selector": "#nav"},
+         "expect": {"settle_ms": 4322}},
+        {"command": "click_element", "params": {"selector": "#cards"},
+         "expect": {"url": "https://x.test/credit-card"}},
+    ])
+    assert out[0]["expect"] == {"url": "https://x.test/credit-card", "settle_ms": 4322}
+
+
+def test_the_clicks_own_measurement_wins_when_it_has_one():
+    """What the click observed is about where it landed — the better answer."""
+    from noui_core.compile.browser_skill import _fold_hover_into_click
+
+    out = _fold_hover_into_click([
+        {"command": "hover", "params": {"selector": "#nav"}, "expect": {"settle_ms": 4322}},
+        {"command": "click_element", "params": {"selector": "#cards"},
+         "expect": {"settle_ms": 900}},
+    ])
+    assert out[0]["expect"]["settle_ms"] == 900

--- a/tests/test_hover_click_gesture.py
+++ b/tests/test_hover_click_gesture.py
@@ -22,12 +22,17 @@ ITEM = "a.sub-menu-list-item-link"
 
 
 def test_the_pair_becomes_one_step():
-    out = _fold_hover_into_click([
-        {"command": "hover", "params": {"selector": NAV}, "expect": {"settle_ms": 4322}},
-        {"command": "click_element", "params": {"selector": ITEM},
-         "expect": {"url": "https://x/credit-card"}},
-        {"command": "get_page_summary", "params": {}},
-    ])
+    out = _fold_hover_into_click(
+        [
+            {"command": "hover", "params": {"selector": NAV}, "expect": {"settle_ms": 4322}},
+            {
+                "command": "click_element",
+                "params": {"selector": ITEM},
+                "expect": {"url": "https://x/credit-card"},
+            },
+            {"command": "get_page_summary", "params": {}},
+        ]
+    )
     assert [s["command"] for s in out] == ["click_element", "get_page_summary"]
     # The click is addressed INSIDE what the hover revealed. `a.sub-menu-list-
     # item-link` is a class every submenu item in this nav carries, so unscoped
@@ -83,10 +88,12 @@ def test_a_selector_that_already_names_one_node_is_left_alone():
     """An id addresses one node by definition; scoping it would only add risk."""
     from noui_core.compile.browser_skill import _fold_hover_into_click
 
-    out = _fold_hover_into_click([
-        {"command": "hover", "params": {"selector": "#nav"}},
-        {"command": "click_element", "params": {"selector": "#cards"}},
-    ])
+    out = _fold_hover_into_click(
+        [
+            {"command": "hover", "params": {"selector": "#nav"}},
+            {"command": "click_element", "params": {"selector": "#cards"}},
+        ]
+    )
     assert out[0]["params"] == {"selector": "#cards", "hover_first": "#nav"}
 
 
@@ -95,10 +102,12 @@ def test_a_recorded_path_is_left_alone_too():
     from noui_core.compile.browser_skill import _fold_hover_into_click
 
     path = "#scroll-container > div > div:nth-of-type(2) > a"
-    out = _fold_hover_into_click([
-        {"command": "hover", "params": {"selector": "#nav"}},
-        {"command": "click_element", "params": {"selector": path}},
-    ])
+    out = _fold_hover_into_click(
+        [
+            {"command": "hover", "params": {"selector": "#nav"}},
+            {"command": "click_element", "params": {"selector": path}},
+        ]
+    )
     assert out[0]["params"]["selector"] == path
     assert "fallbacks" not in out[0]["params"]
 
@@ -106,11 +115,15 @@ def test_a_recorded_path_is_left_alone_too():
 def test_an_existing_fallback_is_kept_behind_the_unscoped_one():
     from noui_core.compile.browser_skill import _fold_hover_into_click
 
-    out = _fold_hover_into_click([
-        {"command": "hover", "params": {"selector": "#nav"}},
-        {"command": "click_element",
-         "params": {"selector": "a.item", "fallbacks": [{"text": "Credit Cards"}]}},
-    ])
+    out = _fold_hover_into_click(
+        [
+            {"command": "hover", "params": {"selector": "#nav"}},
+            {
+                "command": "click_element",
+                "params": {"selector": "a.item", "fallbacks": [{"text": "Credit Cards"}]},
+            },
+        ]
+    )
     assert out[0]["params"]["selector"] == "#nav a.item"
     assert out[0]["params"]["fallbacks"] == [{"selector": "a.item"}, {"text": "Credit Cards"}]
 
@@ -142,12 +155,16 @@ def test_the_merged_step_keeps_the_hovers_measurement_of_the_menu():
     """
     from noui_core.compile.browser_skill import _fold_hover_into_click
 
-    out = _fold_hover_into_click([
-        {"command": "hover", "params": {"selector": "#nav"},
-         "expect": {"settle_ms": 4322}},
-        {"command": "click_element", "params": {"selector": "#cards"},
-         "expect": {"url": "https://x.test/credit-card"}},
-    ])
+    out = _fold_hover_into_click(
+        [
+            {"command": "hover", "params": {"selector": "#nav"}, "expect": {"settle_ms": 4322}},
+            {
+                "command": "click_element",
+                "params": {"selector": "#cards"},
+                "expect": {"url": "https://x.test/credit-card"},
+            },
+        ]
+    )
     assert out[0]["expect"] == {"url": "https://x.test/credit-card", "settle_ms": 4322}
 
 
@@ -155,9 +172,14 @@ def test_the_clicks_own_measurement_wins_when_it_has_one():
     """What the click observed is about where it landed — the better answer."""
     from noui_core.compile.browser_skill import _fold_hover_into_click
 
-    out = _fold_hover_into_click([
-        {"command": "hover", "params": {"selector": "#nav"}, "expect": {"settle_ms": 4322}},
-        {"command": "click_element", "params": {"selector": "#cards"},
-         "expect": {"settle_ms": 900}},
-    ])
+    out = _fold_hover_into_click(
+        [
+            {"command": "hover", "params": {"selector": "#nav"}, "expect": {"settle_ms": 4322}},
+            {
+                "command": "click_element",
+                "params": {"selector": "#cards"},
+                "expect": {"settle_ms": 900},
+            },
+        ]
+    )
     assert out[0]["expect"]["settle_ms"] == 900

--- a/tests/test_hover_click_gesture.py
+++ b/tests/test_hover_click_gesture.py
@@ -59,11 +59,36 @@ def test_the_pair_becomes_one_step():
 
 
 def test_a_hover_before_something_else_is_left_alone():
+    """Something that is not a click at all: there is no gesture to merge into."""
+    steps = [
+        {"command": "hover", "_reveal": True, "params": {"selector": NAV}},
+        {"command": "get_page_summary"},
+    ]
+    assert [s["command"] for s in _fold_hover_into_click(steps)] == ["hover", "get_page_summary"]
+
+
+def test_a_click_by_text_folds_just_like_a_click_element():
+    """The CLICK's command was never the point -- only the hover must be css-addressable.
+
+    Restricting the fold to click_element was accidental. Before evidence was
+    gathered from the clicked element a nav item had no text candidate, so it
+    always compiled to click_element and the restriction never bit; once it
+    gained one and compiled to click_by_text, the pair stopped folding.
+
+    That matters because the two cannot be separate steps. Measured on ICICI:
+    the flyout is display:none, goes to block while the pointer rests on the
+    box, and is back to none within 500ms of it leaving -- so the menu shuts
+    between two round trips. Hovering the box and clicking the revealed item as
+    ONE gesture navigates.
+    """
     steps = [
         {"command": "hover", "_reveal": True, "params": {"selector": NAV}},
         {"command": "click_by_text", "params": {"text": "Credit Cards"}},
     ]
-    assert [s["command"] for s in _fold_hover_into_click(steps)] == ["hover", "click_by_text"]
+    folded = _fold_hover_into_click(steps)
+    assert [s["command"] for s in folded] == ["click_by_text"]
+    assert folded[0]["params"]["hover_first"] == NAV
+    assert folded[0]["params"]["text"] == "Credit Cards"
 
 
 def test_a_hover_the_pointer_merely_crossed_is_not_folded():

--- a/tests/test_hover_click_gesture.py
+++ b/tests/test_hover_click_gesture.py
@@ -24,7 +24,12 @@ ITEM = "a.sub-menu-list-item-link"
 def test_the_pair_becomes_one_step():
     out = _fold_hover_into_click(
         [
-            {"command": "hover", "params": {"selector": NAV}, "expect": {"settle_ms": 4322}},
+            {
+                "command": "hover",
+                "_reveal": True,
+                "params": {"selector": NAV},
+                "expect": {"settle_ms": 4322},
+            },
             {
                 "command": "click_element",
                 "params": {"selector": ITEM},
@@ -55,14 +60,32 @@ def test_the_pair_becomes_one_step():
 
 def test_a_hover_before_something_else_is_left_alone():
     steps = [
-        {"command": "hover", "params": {"selector": NAV}},
+        {"command": "hover", "_reveal": True, "params": {"selector": NAV}},
         {"command": "click_by_text", "params": {"text": "Credit Cards"}},
     ]
     assert [s["command"] for s in _fold_hover_into_click(steps)] == ["hover", "click_by_text"]
 
 
+def test_a_hover_the_pointer_merely_crossed_is_not_folded():
+    """Only a hover the RECORDER marked as a reveal may be folded.
+
+    An incidental hover is also hover-immediately-then-click: the pointer crosses
+    one nav box on its way to another. An ICICI capture held both pairs, and
+    folding on adjacency alone produced a gesture that hovered Deposits and
+    clicked Cards -- so the menu never opened and the whole replay died on step
+    one. Position cannot tell them apart; only `_reveal` can.
+    """
+    steps = [
+        {"command": "hover", "params": {"selector": "#deposits"}},
+        {"command": "click_element", "params": {"selector": "#cards"}},
+    ]
+    folded = _fold_hover_into_click(steps)
+    assert [s["command"] for s in folded] == ["hover", "click_element"]
+    assert "hover_first" not in (folded[1].get("params") or {})
+
+
 def test_a_trailing_hover_survives():
-    steps = [{"command": "hover", "params": {"selector": NAV}}]
+    steps = [{"command": "hover", "_reveal": True, "params": {"selector": NAV}}]
     assert _fold_hover_into_click(steps) == steps
 
 
@@ -73,9 +96,9 @@ def test_an_ordinary_click_is_untouched():
 
 def test_consecutive_pairs_both_fold():
     steps = [
-        {"command": "hover", "params": {"selector": "#a"}},
+        {"command": "hover", "_reveal": True, "params": {"selector": "#a"}},
         {"command": "click_element", "params": {"selector": "#b"}},
-        {"command": "hover", "params": {"selector": "#c"}},
+        {"command": "hover", "_reveal": True, "params": {"selector": "#c"}},
         {"command": "click_element", "params": {"selector": "#d"}},
     ]
     out = _fold_hover_into_click(steps)
@@ -90,7 +113,7 @@ def test_a_selector_that_already_names_one_node_is_left_alone():
 
     out = _fold_hover_into_click(
         [
-            {"command": "hover", "params": {"selector": "#nav"}},
+            {"command": "hover", "_reveal": True, "params": {"selector": "#nav"}},
             {"command": "click_element", "params": {"selector": "#cards"}},
         ]
     )
@@ -104,7 +127,7 @@ def test_a_recorded_path_is_left_alone_too():
     path = "#scroll-container > div > div:nth-of-type(2) > a"
     out = _fold_hover_into_click(
         [
-            {"command": "hover", "params": {"selector": "#nav"}},
+            {"command": "hover", "_reveal": True, "params": {"selector": "#nav"}},
             {"command": "click_element", "params": {"selector": path}},
         ]
     )
@@ -117,7 +140,7 @@ def test_an_existing_fallback_is_kept_behind_the_unscoped_one():
 
     out = _fold_hover_into_click(
         [
-            {"command": "hover", "params": {"selector": "#nav"}},
+            {"command": "hover", "_reveal": True, "params": {"selector": "#nav"}},
             {
                 "command": "click_element",
                 "params": {"selector": "a.item", "fallbacks": [{"text": "Credit Cards"}]},
@@ -157,7 +180,12 @@ def test_the_merged_step_keeps_the_hovers_measurement_of_the_menu():
 
     out = _fold_hover_into_click(
         [
-            {"command": "hover", "params": {"selector": "#nav"}, "expect": {"settle_ms": 4322}},
+            {
+                "command": "hover",
+                "_reveal": True,
+                "params": {"selector": "#nav"},
+                "expect": {"settle_ms": 4322},
+            },
             {
                 "command": "click_element",
                 "params": {"selector": "#cards"},
@@ -174,7 +202,12 @@ def test_the_clicks_own_measurement_wins_when_it_has_one():
 
     out = _fold_hover_into_click(
         [
-            {"command": "hover", "params": {"selector": "#nav"}, "expect": {"settle_ms": 4322}},
+            {
+                "command": "hover",
+                "_reveal": True,
+                "params": {"selector": "#nav"},
+                "expect": {"settle_ms": 4322},
+            },
             {
                 "command": "click_element",
                 "params": {"selector": "#cards"},

--- a/tests/test_hover_click_gesture.py
+++ b/tests/test_hover_click_gesture.py
@@ -1,0 +1,66 @@
+"""A hover and the click it enables are one gesture, so they are one step.
+
+As two steps they are two round trips to the worker, and a menu that only exists
+while the pointer rests on its trigger cannot survive the gap. Measured on ICICI:
+hover returned ok, and the submenu was not visible on any later call — checked at
+1s, 2s, 3s and 4s. The click was racing the menu closing, which looked like
+slowness and got "fixed" twice by waiting longer — the opposite of the cure.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+
+from noui_core.compile.browser_skill import _fold_hover_into_click  # noqa: E402
+
+NAV = "#scroll-container > div > div:nth-of-type(5)"
+ITEM = "a.sub-menu-list-item-link"
+
+
+def test_the_pair_becomes_one_step():
+    out = _fold_hover_into_click([
+        {"command": "hover", "params": {"selector": NAV}, "expect": {"settle_ms": 4322}},
+        {"command": "click_element", "params": {"selector": ITEM},
+         "expect": {"url": "https://x/credit-card"}},
+        {"command": "get_page_summary", "params": {}},
+    ])
+    assert [s["command"] for s in out] == ["click_element", "get_page_summary"]
+    assert out[0]["params"] == {"selector": ITEM, "hover_first": NAV}
+    # The click's expectation describes where the gesture lands; the hover's
+    # described opening a menu and is not the postcondition.
+    assert out[0]["expect"] == {"url": "https://x/credit-card"}
+
+
+def test_a_hover_before_something_else_is_left_alone():
+    steps = [
+        {"command": "hover", "params": {"selector": NAV}},
+        {"command": "click_by_text", "params": {"text": "Credit Cards"}},
+    ]
+    assert [s["command"] for s in _fold_hover_into_click(steps)] == ["hover", "click_by_text"]
+
+
+def test_a_trailing_hover_survives():
+    steps = [{"command": "hover", "params": {"selector": NAV}}]
+    assert _fold_hover_into_click(steps) == steps
+
+
+def test_an_ordinary_click_is_untouched():
+    steps = [{"command": "click_element", "params": {"selector": "#DL"}}]
+    assert _fold_hover_into_click(steps) == steps
+
+
+def test_consecutive_pairs_both_fold():
+    steps = [
+        {"command": "hover", "params": {"selector": "#a"}},
+        {"command": "click_element", "params": {"selector": "#b"}},
+        {"command": "hover", "params": {"selector": "#c"}},
+        {"command": "click_element", "params": {"selector": "#d"}},
+    ]
+    out = _fold_hover_into_click(steps)
+    assert len(out) == 2
+    assert out[0]["params"]["hover_first"] == "#a"
+    assert out[1]["params"]["hover_first"] == "#c"

--- a/tests/test_hover_click_gesture.py
+++ b/tests/test_hover_click_gesture.py
@@ -29,7 +29,17 @@ def test_the_pair_becomes_one_step():
         {"command": "get_page_summary", "params": {}},
     ])
     assert [s["command"] for s in out] == ["click_element", "get_page_summary"]
-    assert out[0]["params"] == {"selector": ITEM, "hover_first": NAV}
+    # The click is addressed INSIDE what the hover revealed. `a.sub-menu-list-
+    # item-link` is a class every submenu item in this nav carries, so unscoped
+    # it resolved whichever match came first in the document — and when that one
+    # sat in a menu that was not open, the step failed "on the page but not
+    # visible" on about half of all runs. The bare selector stays as a fallback
+    # for a menu rendered in an overlay rather than inside its trigger.
+    assert out[0]["params"] == {
+        "selector": f"{NAV} {ITEM}",
+        "hover_first": NAV,
+        "fallbacks": [{"selector": ITEM}],
+    }
     # The click's expectation describes where the gesture lands; the hover's
     # described opening a menu and is not the postcondition.
     assert out[0]["expect"] == {"url": "https://x/credit-card"}
@@ -64,3 +74,56 @@ def test_consecutive_pairs_both_fold():
     assert len(out) == 2
     assert out[0]["params"]["hover_first"] == "#a"
     assert out[1]["params"]["hover_first"] == "#c"
+
+
+def test_a_selector_that_already_names_one_node_is_left_alone():
+    """An id addresses one node by definition; scoping it would only add risk."""
+    from noui_core.compile.browser_skill import _fold_hover_into_click
+
+    out = _fold_hover_into_click([
+        {"command": "hover", "params": {"selector": "#nav"}},
+        {"command": "click_element", "params": {"selector": "#cards"}},
+    ])
+    assert out[0]["params"] == {"selector": "#cards", "hover_first": "#nav"}
+
+
+def test_a_recorded_path_is_left_alone_too():
+    """A css_path is a walk down the tree, not a style shared by many nodes."""
+    from noui_core.compile.browser_skill import _fold_hover_into_click
+
+    path = "#scroll-container > div > div:nth-of-type(2) > a"
+    out = _fold_hover_into_click([
+        {"command": "hover", "params": {"selector": "#nav"}},
+        {"command": "click_element", "params": {"selector": path}},
+    ])
+    assert out[0]["params"]["selector"] == path
+    assert "fallbacks" not in out[0]["params"]
+
+
+def test_an_existing_fallback_is_kept_behind_the_unscoped_one():
+    from noui_core.compile.browser_skill import _fold_hover_into_click
+
+    out = _fold_hover_into_click([
+        {"command": "hover", "params": {"selector": "#nav"}},
+        {"command": "click_element",
+         "params": {"selector": "a.item", "fallbacks": [{"text": "Credit Cards"}]}},
+    ])
+    assert out[0]["params"]["selector"] == "#nav a.item"
+    assert out[0]["params"]["fallbacks"] == [{"selector": "a.item"}, {"text": "Credit Cards"}]
+
+
+def test_scoping_a_recorded_control_inside_another_keeps_its_provenance():
+    """The gate must not read the compiler's own output as a hand edit.
+
+    Scoping composes two selectors the recording DID see, and the result can
+    only match fewer nodes than the half on its right — so nothing was invented.
+    """
+    from noui_core.compile.provenance import _is_observed_scoped_inside_observed
+
+    seen = {"#nav", "a.item"}
+    assert _is_observed_scoped_inside_observed("#nav a.item", seen) is True
+    # Neither half invented, and nothing looser: a control nobody saw stays
+    # unobserved however it is combined.
+    assert _is_observed_scoped_inside_observed("#nav a.invented", seen) is False
+    assert _is_observed_scoped_inside_observed("#other a.item", seen) is False
+    assert _is_observed_scoped_inside_observed("a.item", seen) is False

--- a/tests/test_install_gate.py
+++ b/tests/test_install_gate.py
@@ -238,10 +238,25 @@ def test_approving_a_replay_that_missed_its_goal_is_refused(tmp_path):
     assert "download_statement" in out
 
 
-def test_a_deliberate_override_is_possible_and_explicit(tmp_path):
+def test_a_deliberate_override_has_to_name_what_it_gives_up(tmp_path):
+    """`--force` waved through everything at once, so it got used that way.
+
+    Run 050970d3: 3 of 7 goals reached, the failures being the statement
+    download the member had asked for, and the build went straight to --force
+    with an approval sentence it had written itself. The override still exists
+    -- a member can decide to ship without an operation -- but it names the
+    operation, so the decision is about something.
+    """
     d = make_skill(tmp_path)
-    _report(d, all_goals_reached=False)
-    code, _ = _run_approve(d, "--force")
+    _report(
+        d,
+        all_goals_reached=False,
+        operations=[{"name": "download_statement", "goal_reached": False, "steps": []}],
+    )
+    assert _run_approve(d, "--force")[0] == 1
+    assert not (d / "replay_approval.json").exists()
+
+    code, _ = _run_approve(d, "--accept-failing", "download_statement")
     assert code == 0
     assert (d / "replay_approval.json").exists()
 

--- a/tests/test_install_gate.py
+++ b/tests/test_install_gate.py
@@ -167,3 +167,88 @@ def test_the_digest_ignores_descriptions_but_not_steps():
         }
     ]
     assert operations_fingerprint(restepped) != _SHARED_FINGERPRINT
+
+
+# --- the approve CLI's refusals -----------------------------------------------
+#
+# The approval file is the record of a HUMAN decision. These pin the cases where
+# recording one would be a lie: a replay that never ran, and a replay that ran
+# and did not do what the skill exists for.
+
+
+def _report(skill_dir: Path, **over) -> Path:
+    import json as _json
+
+    base = {
+        "operations": [{"name": "download_statement", "goal_reached": True, "steps": []}],
+        "all_goals_reached": True,
+        "installable": False,
+        "fingerprint": "abc",
+    }
+    base.update(over)
+    path = skill_dir / "replay_report.json"
+    path.write_text(_json.dumps(base), encoding="utf-8")
+    return path
+
+
+def _run_approve(skill_dir: Path, *args) -> tuple[int, str]:
+    import subprocess
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(_ROOT / "skills" / "noui" / "scripts" / "verify_approve.py"),
+            str(skill_dir),
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def test_approving_without_a_replay_is_refused(tmp_path):
+    d = make_skill(tmp_path)
+    code, out = _run_approve(d)
+    assert code == 1
+    assert "Replay the draft first" in out
+
+
+def test_approving_a_replay_that_never_ran_is_refused(tmp_path):
+    # login_required means the plan was not found wanting — it was never tried.
+    d = make_skill(tmp_path)
+    _report(d, status="login_required", all_goals_reached=False)
+    code, out = _run_approve(d)
+    assert code == 1
+    assert "never ran" in out
+
+
+def test_approving_a_replay_that_missed_its_goal_is_refused(tmp_path):
+    # An operation that did not do what it exists for is not something to wave
+    # through; the fix is to amend and replay again.
+    d = make_skill(tmp_path)
+    _report(
+        d,
+        all_goals_reached=False,
+        operations=[{"name": "download_statement", "goal_reached": False, "steps": []}],
+    )
+    code, out = _run_approve(d)
+    assert code == 1
+    assert "did not reach every goal" in out
+    assert "download_statement" in out
+
+
+def test_a_deliberate_override_is_possible_and_explicit(tmp_path):
+    d = make_skill(tmp_path)
+    _report(d, all_goals_reached=False)
+    code, _ = _run_approve(d, "--force")
+    assert code == 0
+    assert (d / "replay_approval.json").exists()
+
+
+def test_approving_a_good_replay_records_it(tmp_path):
+    d = make_skill(tmp_path)
+    _report(d)
+    code, out = _run_approve(d)
+    assert code == 0
+    assert "may now be installed" in out

--- a/tests/test_install_gate.py
+++ b/tests/test_install_gate.py
@@ -121,3 +121,49 @@ def test_a_corrupt_approval_reads_as_absent(tmp_path):
 
 def test_is_browser_skill_reads_the_manifest_then_the_operations(tmp_path):
     assert is_browser_skill(make_skill(tmp_path)) is True
+
+
+# --- shared fingerprint vector ------------------------------------------------
+#
+# The harness recomputes this digest to check an approval covers the plan being
+# installed, because noui is installed in the sandbox and not in the worker.
+# Two implementations, one pinned vector: if either drifts, its own test fails
+# rather than the gate silently accepting an approval for different steps.
+#
+# The twin lives in adoptai-workflows:
+# tests/agent_harness/test_web_browser_dispatch.py
+
+_SHARED_FINGERPRINT_OPS = [
+    {
+        "name": "download_statement",
+        "kind": "download",
+        "tool": "call_web_browser",
+        "description": "ignored — descriptions are excluded from the digest",
+        "steps": [{"command": "click_element", "params": {"selector": "#dl"}}],
+        "parameters": [{"name": "from_date", "default": "2026-01-01", "type": "date"}],
+    }
+]
+_SHARED_FINGERPRINT = "69656c931cee13bcfee67e2e6fab4db0"
+
+
+def test_the_fingerprint_matches_the_harness_implementation():
+    from noui_core.verify.replay import operations_fingerprint  # noqa: PLC0415
+
+    assert operations_fingerprint(_SHARED_FINGERPRINT_OPS) == _SHARED_FINGERPRINT
+
+
+def test_the_digest_ignores_descriptions_but_not_steps():
+    # Pins the two properties the twin depends on: renaming is free, changing
+    # behaviour is not.
+    from noui_core.verify.replay import operations_fingerprint  # noqa: PLC0415
+
+    reworded = [{**_SHARED_FINGERPRINT_OPS[0], "description": "completely different"}]
+    assert operations_fingerprint(reworded) == _SHARED_FINGERPRINT
+
+    restepped = [
+        {
+            **_SHARED_FINGERPRINT_OPS[0],
+            "steps": [{"command": "click_element", "params": {"selector": "#other"}}],
+        }
+    ]
+    assert operations_fingerprint(restepped) != _SHARED_FINGERPRINT

--- a/tests/test_install_gate.py
+++ b/tests/test_install_gate.py
@@ -62,6 +62,37 @@ def test_a_browser_skill_with_an_approval_installs(tmp_path):
     check_installable(d)  # does not raise
 
 
+def test_an_unapproved_amendment_refuses_install(tmp_path):
+    # Parity with the harness gate: a step discovered at replay must be approved
+    # by name, so an approval of the skill as a whole cannot wave it through.
+    d = make_skill(tmp_path)
+    write_approval(d, approved_report([BROWSER_OP]))
+    (d / "amendments.json").write_text(
+        json.dumps(
+            {
+                "amendments": [
+                    {
+                        "operation": "download_statement",
+                        "step_index": 0,
+                        "replacement": {"command": "click_element", "params": {"selector": "#new"}},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(NotApprovedError, match="discovered at replay"):
+        check_installable(d)
+
+
+def test_no_amendments_file_is_a_no_op(tmp_path):
+    # The whole record->replay->approve->install path carries no amendments; the
+    # amendment check must never turn a clean skill away.
+    d = make_skill(tmp_path)
+    write_approval(d, approved_report([BROWSER_OP]))
+    check_installable(d)  # does not raise
+
+
 def test_an_approval_does_not_survive_a_change_to_the_steps(tmp_path):
     # "The human's confirmation takes precedence" only means something if
     # amending the plan invalidates the confirmation.

--- a/tests/test_install_gate.py
+++ b/tests/test_install_gate.py
@@ -1,0 +1,123 @@
+"""Tests for the gate that stops an unverified browser skill being installed.
+
+Without a gate, replay is a report — produced, glanced at, and skipped whenever
+it is inconvenient. These pin that the installer actually refuses, and that an
+approval cannot be stretched to cover a plan it was not given for.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+
+from noui_core.verify.gate import (  # noqa: E402
+    NotApprovedError,
+    check_installable,
+    is_browser_skill,
+    read_approval,
+    write_approval,
+)
+from noui_core.verify.replay import approve, build_report  # noqa: E402
+
+BROWSER_OP = {
+    "name": "download_statement",
+    "kind": "download",
+    "tool": "call_web_browser",
+    "description": "Download the statement",
+    "steps": [{"command": "click_element", "params": {"selector": "#dl"}}],
+}
+
+
+def make_skill(tmp_path: Path, ops=None, style="browser") -> Path:
+    d = tmp_path / "skill"
+    d.mkdir()
+    (d / "operations.json").write_text(
+        json.dumps({"schema_version": "1", "operations": ops or [BROWSER_OP]}), encoding="utf-8"
+    )
+    (d / "manifest.json").write_text(
+        json.dumps({"runtime": {"operation_style": style}}), encoding="utf-8"
+    )
+    return d
+
+
+def approved_report(ops) -> dict:
+    return approve(build_report(ops, [[{"status": "ok", "command": "click_element"}]]))
+
+
+def test_a_browser_skill_with_no_approval_is_refused(tmp_path):
+    # The whole point: never run against the live app, never installed.
+    with pytest.raises(NotApprovedError, match="never been run"):
+        check_installable(make_skill(tmp_path))
+
+
+def test_a_browser_skill_with_an_approval_installs(tmp_path):
+    d = make_skill(tmp_path)
+    write_approval(d, approved_report([BROWSER_OP]))
+    check_installable(d)  # does not raise
+
+
+def test_an_approval_does_not_survive_a_change_to_the_steps(tmp_path):
+    # "The human's confirmation takes precedence" only means something if
+    # amending the plan invalidates the confirmation.
+    d = make_skill(tmp_path)
+    write_approval(d, approved_report([BROWSER_OP]))
+
+    changed = {
+        **BROWSER_OP,
+        "steps": [{"command": "click_element", "params": {"selector": "#other"}}],
+    }
+    (d / "operations.json").write_text(json.dumps({"operations": [changed]}), encoding="utf-8")
+
+    with pytest.raises(NotApprovedError, match="changed since it was approved"):
+        check_installable(d)
+
+
+def test_renaming_or_rewording_does_not_cost_a_fresh_replay(tmp_path):
+    # A gate that fires on a typo fix is a gate people learn to bypass.
+    d = make_skill(tmp_path)
+    write_approval(d, approved_report([BROWSER_OP]))
+
+    reworded = {**BROWSER_OP, "description": "Fetch the annual statement PDF"}
+    (d / "operations.json").write_text(json.dumps({"operations": [reworded]}), encoding="utf-8")
+
+    check_installable(d)  # behaviour is unchanged, so the approval still holds
+
+
+def test_an_unapproved_report_cannot_be_recorded_as_an_approval(tmp_path):
+    # Otherwise the file becomes a rubber stamp written by the code that made the
+    # report, and the human is out of the loop entirely.
+    d = make_skill(tmp_path)
+    with pytest.raises(ValueError, match="never approved"):
+        write_approval(d, build_report([BROWSER_OP], [[{"status": "ok"}]]))
+
+
+def test_a_har_replay_skill_is_not_gated(tmp_path):
+    # Those are verified by their existing test loop; replaying one means firing
+    # recorded requests, a different risk profile.
+    api_op = {"name": "list_txns", "tool": "call_web_api", "steps": []}
+    check_installable(make_skill(tmp_path, ops=[api_op], style="api"))
+
+
+def test_operations_calling_the_browser_are_gated_whatever_the_manifest_says(tmp_path):
+    # A manifest can be wrong or hand-edited; what the operations DO cannot.
+    with pytest.raises(NotApprovedError):
+        check_installable(make_skill(tmp_path, style="api"))
+
+
+def test_a_corrupt_approval_reads_as_absent(tmp_path):
+    d = make_skill(tmp_path)
+    (d / "replay_approval.json").write_text("{not json", encoding="utf-8")
+
+    assert read_approval(d) is None
+    with pytest.raises(NotApprovedError):
+        check_installable(d)
+
+
+def test_is_browser_skill_reads_the_manifest_then_the_operations(tmp_path):
+    assert is_browser_skill(make_skill(tmp_path)) is True

--- a/tests/test_kind_is_reported.py
+++ b/tests/test_kind_is_reported.py
@@ -1,0 +1,47 @@
+"""The compiled KIND is always stated, and confirmed when nobody chose it.
+
+Reporting spoke only when browser mode was auto-selected, so choosing REPLAY was
+silent — an ICICI capture asked for as a browser skill compiled to two Finacle
+POSTs with nothing anywhere saying a decision had been taken. A default is fine;
+a default nobody is told about is not.
+"""
+
+import capture_import as ci
+
+
+def _run(capsys, det, declared=False, skill_id="icici-bank-cc-statement"):
+    ci._report_kind({"browser_detection": det}, {"skill_id": skill_id}, declared=declared)
+    return capsys.readouterr().err
+
+
+def test_replay_says_so_instead_of_saying_nothing(capsys):
+    out = _run(capsys, {"unreplayable": False, "reasons": []})
+    assert "KIND: replay" in out
+    assert "fire the recorded requests rather than drive the page" in out
+
+
+def test_an_undetected_kind_asks_for_confirmation(capsys):
+    out = _run(capsys, {"unreplayable": False})
+    assert "CONFIRM THE KIND WITH THE MEMBER BEFORE INSTALLING" in out
+    assert "--browser-driven" in out
+
+
+def test_a_declared_kind_is_not_second_guessed(capsys):
+    # The member already said; asking again is noise.
+    out = _run(capsys, {"unreplayable": False}, declared=True)
+    assert "KIND: browser-driven" in out
+    assert "you asked for it" in out
+    assert "CONFIRM THE KIND" not in out
+
+
+def test_auto_detected_browser_mode_still_explains_itself(capsys):
+    out = _run(capsys, {"unreplayable": True, "reasons": ["opaque {data,key} bodies"]})
+    assert "KIND: browser-driven" in out
+    assert "encrypts its requests" in out
+    # Still unconfirmed by a human, so still worth a check.
+    assert "CONFIRM THE KIND" in out
+
+
+def test_the_replay_reasons_are_shown_when_there_are_any(capsys):
+    out = _run(capsys, {"unreplayable": False, "reasons": ["bodies are plain JSON"]})
+    assert "bodies are plain JSON" in out

--- a/tests/test_kind_is_required.py
+++ b/tests/test_kind_is_required.py
@@ -67,17 +67,15 @@ def test_the_old_flag_still_satisfies_the_requirement(monkeypatch, capsys, tmp_p
     assert prov.call_args.kwargs["browser_driven"] is True
 
 
-def test_replay_is_accepted_but_renamed_to_api(monkeypatch, capsys, tmp_path):
-    """'replay' already means the verification step, not a skill kind.
+def test_replay_is_not_a_kind(monkeypatch, capsys, tmp_path):
+    """One word, one meaning. 'replay' is the verification of a draft before
+    install; it was never a skill kind, and accepting it as an alias would have
+    preserved exactly the ambiguity the rename removed."""
+    import pytest
 
-    Using one word for both would leave every reader deciding which sense was
-    meant; the manifest already calls this kind 'api'.
-    """
-    rc, out, prov = _run(
-        monkeypatch, capsys, tmp_path, "--kind", "replay", "--url", "https://bank.test/x"
-    )
-    assert rc == 0
-    assert "Reading it as --kind api" in out.err
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, capsys, tmp_path, "--kind", "replay", "--url", "https://bank.test/x")
+    assert "invalid choice: 'replay'" in capsys.readouterr().err
 
 
 def test_api_is_accepted_as_a_kind(monkeypatch, capsys, tmp_path):

--- a/tests/test_kind_is_required.py
+++ b/tests/test_kind_is_required.py
@@ -1,0 +1,66 @@
+"""The kind is decided before a single click is recorded.
+
+It used to be an optional flag, so a request opening with the words "BROWSER
+BASED skill" still recorded with the kind unset, auto-detection chose replay,
+and the first compile was wrong. Everything after — patching the manifest,
+recompiling, re-recording — was compensation for a decision nobody was asked to
+make while it was still cheap.
+"""
+
+import sys
+from unittest.mock import patch
+
+import capture_record as cr
+from noui_core.config import settings
+
+
+def _run(monkeypatch, capsys, tmp_path, *argv):
+    monkeypatch.setattr(settings, "workbench_dir", str(tmp_path))
+    monkeypatch.setattr(cr.recording, "resolve_agent_token", lambda: "t")
+    monkeypatch.setattr(sys, "argv", ["capture_record.py", *argv])
+    with patch.object(
+        cr.recording,
+        "provision_live_link",
+        return_value={"session_id": "s1", "login_url": "https://x/s/1", "warm": True},
+    ) as prov:
+        rc = cr.main()
+    return rc, capsys.readouterr(), prov
+
+
+def test_recording_without_a_kind_refuses(monkeypatch, capsys, tmp_path):
+    rc, out, prov = _run(monkeypatch, capsys, tmp_path, "--url", "https://bank.test/login")
+    assert rc == 1
+    assert "--kind is required" in out.err
+    # and it must not have spent a session on an undecided recording
+    prov.assert_not_called()
+
+
+def test_the_refusal_says_where_the_answer_usually_is(monkeypatch, capsys, tmp_path):
+    _, out, _ = _run(monkeypatch, capsys, tmp_path, "--url", "https://bank.test/login")
+    assert "browser based skill" in out.err
+    assert "cannot be relabelled afterwards" in out.err
+
+
+def test_kind_browser_provisions_browser_driven(monkeypatch, capsys, tmp_path):
+    rc, _, prov = _run(
+        monkeypatch, capsys, tmp_path, "--kind", "browser", "--url", "https://bank.test/login"
+    )
+    assert rc == 0
+    assert prov.call_args.kwargs["browser_driven"] is True
+
+
+def test_kind_auto_is_a_choice_not_a_default(monkeypatch, capsys, tmp_path):
+    rc, _, prov = _run(
+        monkeypatch, capsys, tmp_path, "--kind", "auto", "--url", "https://bank.test/login"
+    )
+    assert rc == 0
+    # combined still asks for evidence; the KIND is what auto leaves open.
+    assert prov.called
+
+
+def test_the_old_flag_still_satisfies_the_requirement(monkeypatch, capsys, tmp_path):
+    rc, _, prov = _run(
+        monkeypatch, capsys, tmp_path, "--browser-driven", "--url", "https://bank.test/login"
+    )
+    assert rc == 0
+    assert prov.call_args.kwargs["browser_driven"] is True

--- a/tests/test_kind_is_required.py
+++ b/tests/test_kind_is_required.py
@@ -31,6 +31,7 @@ def test_recording_without_a_kind_refuses(monkeypatch, capsys, tmp_path):
     rc, out, prov = _run(monkeypatch, capsys, tmp_path, "--url", "https://bank.test/login")
     assert rc == 1
     assert "--kind is required" in out.err
+    assert "browser | api | auto" in out.err
     # and it must not have spent a session on an undecided recording
     prov.assert_not_called()
 
@@ -64,3 +65,27 @@ def test_the_old_flag_still_satisfies_the_requirement(monkeypatch, capsys, tmp_p
     )
     assert rc == 0
     assert prov.call_args.kwargs["browser_driven"] is True
+
+
+def test_replay_is_accepted_but_renamed_to_api(monkeypatch, capsys, tmp_path):
+    """'replay' already means the verification step, not a skill kind.
+
+    Using one word for both would leave every reader deciding which sense was
+    meant; the manifest already calls this kind 'api'.
+    """
+    rc, out, prov = _run(
+        monkeypatch, capsys, tmp_path, "--kind", "replay", "--url", "https://bank.test/x"
+    )
+    assert rc == 0
+    assert "Reading it as --kind api" in out.err
+
+
+def test_api_is_accepted_as_a_kind(monkeypatch, capsys, tmp_path):
+    """A combined capture always asks Tabby for locator evidence, whatever the
+    kind — evidence is cheap and unknowable in advance. The KIND decides which
+    COMPILER runs later, which is a different question from what is captured."""
+    rc, _, prov = _run(
+        monkeypatch, capsys, tmp_path, "--kind", "api", "--url", "https://bank.test/x"
+    )
+    assert rc == 0
+    assert prov.called

--- a/tests/test_locators.py
+++ b/tests/test_locators.py
@@ -1,0 +1,92 @@
+"""Tests for locator-candidate selection (noui_core.compile.locators).
+
+Tabby's recorder emits several ways to address each clicked element, every one
+carrying `match_count` — how many nodes it matched when it was recorded. These
+pin the rule that a candidate matching more than one node is never preferred over
+one that matched exactly one, which is what stops a skill compiling cleanly and
+then misclicking in production.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+
+from noui_core.compile.locators import (  # noqa: E402
+    AMBIGUOUS,
+    UNIQUE,
+    UNKNOWN,
+    choose_locator,
+)
+
+
+def c(kind: str, value: str, match_count: int) -> dict:
+    return {"kind": kind, "value": value, "match_count": match_count}
+
+
+def test_prefers_a_unique_match_over_a_more_durable_ambiguous_one():
+    # A test-id is the most durable KIND, but one that matched three nodes cannot
+    # identify this element. Uniqueness outranks durability — it is the whole
+    # reason match_count is recorded.
+    got = choose_locator([c("testid", '[data-testid="row"]', 3), c("id", "#pay-now", 1)])
+    assert got["value"] == "#pay-now"
+    assert got["confidence"] == UNIQUE
+
+
+def test_prefers_the_most_durable_among_unique_candidates():
+    got = choose_locator(
+        [c("css_path", "div > a:nth-of-type(2)", 1), c("testid", '[data-testid="pay"]', 1)]
+    )
+    assert got["kind"] == "testid"
+
+
+def test_never_selects_a_candidate_that_matched_nothing():
+    # match_count 0 means it did not match even the element it was recorded from
+    # — normal for a node inside a shadow root, where the document query cannot
+    # see it. Emitting one guarantees a runtime failure.
+    got = choose_locator([c("id", "#ghost", 0), c("text", "Continue", 2)])
+    assert got["value"] == "Continue"
+    assert got["confidence"] == AMBIGUOUS
+
+
+def test_returns_none_when_nothing_is_addressable():
+    assert choose_locator([c("id", "#ghost", 0)]) is None
+    assert choose_locator([]) is None
+    assert choose_locator(None) is None
+
+
+def test_an_uncountable_candidate_beats_a_known_ambiguous_one():
+    # -1 is "the page could not evaluate this", which is not the same as wrong.
+    got = choose_locator([c("id", "#weird", -1), c("text", "Open", 5)])
+    assert got["kind"] == "id"
+    assert got["confidence"] == UNKNOWN
+
+
+def test_falls_back_to_ambiguous_rather_than_dropping_the_step():
+    # Emitting a flagged step beats emitting nothing: the caller surfaces it for
+    # re-pointing, where a dropped step just makes the skill silently incomplete.
+    got = choose_locator([c("text", "Download", 4)])
+    assert got["confidence"] == AMBIGUOUS
+    assert got["match_count"] == 4
+
+
+def test_marks_which_candidates_are_css_expressible():
+    assert choose_locator([c("id", "#x", 1)])["is_css"] is True
+    assert choose_locator([c("role_name", "link|Statements", 1)])["is_css"] is False
+
+
+def test_ignores_malformed_candidates():
+    # A bundle can arrive with anything in it; a bad entry must not sink the rest.
+    got = choose_locator(
+        [
+            "not-a-dict",
+            {"kind": "id"},  # no value
+            {"kind": "id", "value": "#a", "match_count": "1"},  # count not an int
+            {"kind": "id", "value": "#b", "match_count": True},  # bool is not a count
+            c("text", "Go", 1),
+        ]
+    )
+    assert got["value"] == "Go"

--- a/tests/test_login_landing_url.py
+++ b/tests/test_login_landing_url.py
@@ -74,3 +74,61 @@ def test_a_recording_without_seq_falls_back():
     url_events = [{"from_url": "", "to_url": f"{BASE}/overview"}]
     transitions = [("", f"{BASE}/overview")]
     assert _before_first_click(transitions, url_events, [{"event_type": "click"}]) == transitions
+
+
+def _takeover_steps(url_events, click_events, *, manual_takeover=True):
+    from noui_core.compile import login_assets
+
+    out = login_assets.generate(
+        {"id": "s", "app_name": "icici", "login_url": f"{BASE}/login-page"},
+        click_events,
+        url_events,
+        manual_takeover=manual_takeover,
+        manual_credentials=True,
+    )
+
+    def find(o):
+        if isinstance(o, dict):
+            if "steps" in o and "login_url" in o:
+                return o
+            for v in o.values():
+                got = find(v)
+                if got:
+                    return got
+        return None
+
+    return (find(out) or {}).get("steps") or []
+
+
+def test_a_takeover_login_still_finds_the_page_it_landed_on():
+    """When the HUMAN is the login, the landing comes after their first click.
+
+    The narrowing rule assumes a redirect lands you. A takeover has the human
+    typing and pressing Log In, so narrowing keeps only the login page — which
+    is then dropped for being the login page, leaving no landing page at all.
+    ICICI compiled a takeover with no wait_for_url, so every session asked a
+    human to confirm a login they had already completed.
+    """
+    url_events = [
+        url(1, "about:blank", f"{BASE}/login-page"),
+        url(3, f"{BASE}/login-page", f"{BASE}/overview"),
+    ]
+    patterns = [s.get("pattern") for s in _takeover_steps(url_events, [click(2)]) if s.get("pattern")]
+    assert patterns == [f"{BASE}/overview**"]
+
+
+def test_an_automated_login_keeps_the_narrow_bound():
+    """The fallback must not loosen the path it was not written for.
+
+    An automated login lands by redirect before any click, so the narrow rule
+    finds its landing page and the fallback never runs — the workflow pages the
+    human visited afterwards stay out of the check.
+    """
+    url_events = [
+        url(1, "about:blank", f"{BASE}/login-page"),
+        url(2, f"{BASE}/login-page", f"{BASE}/overview"),
+        url(5, f"{BASE}/overview", f"{BASE}/credit-card"),
+    ]
+    steps = _takeover_steps(url_events, [click(4)], manual_takeover=False)
+    patterns = [s.get("pattern") for s in steps if s.get("pattern")]
+    assert patterns and all("credit-card" not in p for p in patterns)

--- a/tests/test_login_landing_url.py
+++ b/tests/test_login_landing_url.py
@@ -1,0 +1,76 @@
+"""The login template's post-login check is the page LOGIN lands on.
+
+A login lands you somewhere by redirect; everything after is the human clicking.
+The old rule stopped at the first ORIGIN CHANGE, written for a multi-host portal
+— and on a single-origin app there is never one, so it walked to the end of a
+combined recording and took wherever the human finished. ICICI retail compiled
+`/credit-card**`, a page four clicks into the workflow, as its post-login check.
+"""
+
+from noui_core.compile.login_assets import _before_first_click
+
+BASE = "https://retailnetbanking.icici.bank.in"
+
+
+def url(seq, frm, to):
+    return {"seq": seq, "from_url": frm, "to_url": to}
+
+
+def click(seq):
+    return {"seq": seq, "event_type": "click"}
+
+
+def test_the_login_segment_stops_at_the_first_click():
+    # login -> overview happens by redirect; everything after is navigation.
+    url_events = [
+        url(0, "", f"{BASE}/login-page"),
+        url(1, f"{BASE}/login-page", f"{BASE}/overview"),
+        url(5, f"{BASE}/overview", f"{BASE}/credit-card"),
+        url(9, f"{BASE}/credit-card", f"{BASE}/credit-card/statements"),
+    ]
+    transitions = [(u["from_url"], u["to_url"]) for u in url_events]
+    kept = _before_first_click(transitions, url_events, [click(3), click(7)])
+
+    assert [t[1] for t in kept] == [f"{BASE}/login-page", f"{BASE}/overview"]
+    # The workflow pages are gone, so /credit-card can never become the check.
+    assert all("credit-card" not in t[1] for t in kept)
+
+
+def test_a_login_that_settles_through_several_redirects_keeps_them_all():
+    # Logins commonly bounce once or twice before landing; none of that is a click.
+    url_events = [
+        url(0, "", f"{BASE}/login-page"),
+        url(1, f"{BASE}/login-page", f"{BASE}/mfa"),
+        url(2, f"{BASE}/mfa", f"{BASE}/overview"),
+    ]
+    transitions = [(u["from_url"], u["to_url"]) for u in url_events]
+    kept = _before_first_click(transitions, url_events, [click(6)])
+    assert len(kept) == 3
+
+
+def test_a_pure_login_recording_is_unchanged():
+    # No clicks recorded at all: nothing to bound, everything is login.
+    url_events = [
+        url(0, "", f"{BASE}/login-page"),
+        url(1, f"{BASE}/login-page", f"{BASE}/overview"),
+    ]
+    transitions = [(u["from_url"], u["to_url"]) for u in url_events]
+    assert _before_first_click(transitions, url_events, []) == transitions
+
+
+def test_a_click_before_any_navigation_does_not_erase_the_login():
+    # A cookie banner dismissed on the login page would otherwise leave nothing,
+    # and no landing page at all is worse than one derived the old way.
+    url_events = [
+        url(4, "", f"{BASE}/login-page"),
+        url(5, f"{BASE}/login-page", f"{BASE}/overview"),
+    ]
+    transitions = [(u["from_url"], u["to_url"]) for u in url_events]
+    assert _before_first_click(transitions, url_events, [click(1)]) == transitions
+
+
+def test_a_recording_without_seq_falls_back():
+    # Pre-schema-2 bundles carry no ordering; derive as before rather than guess.
+    url_events = [{"from_url": "", "to_url": f"{BASE}/overview"}]
+    transitions = [("", f"{BASE}/overview")]
+    assert _before_first_click(transitions, url_events, [{"event_type": "click"}]) == transitions

--- a/tests/test_login_landing_url.py
+++ b/tests/test_login_landing_url.py
@@ -36,6 +36,38 @@ def test_the_login_segment_stops_at_the_first_click():
     assert all("credit-card" not in t[1] for t in kept)
 
 
+def test_a_form_login_whose_submit_click_triggers_the_landing_keeps_it():
+    # The classic shape: the human clicks "Log In" (a recorded click) and THAT
+    # click's redirect IS the post-login landing. `s < first_click` alone dropped
+    # it, so the compiler saw no post-login URL for the most ordinary login there
+    # is. Nothing left the login page before the click, so extend to the redirect
+    # the click caused.
+    url_events = [
+        url(0, "", f"{BASE}/login-page"),
+        url(3, f"{BASE}/login-page", f"{BASE}/overview"),
+    ]
+    transitions = [(u["from_url"], u["to_url"]) for u in url_events]
+    kept = _before_first_click(transitions, url_events, [click(2)])
+
+    assert [t[1] for t in kept] == [f"{BASE}/login-page", f"{BASE}/overview"]
+
+
+def test_a_form_login_keeps_the_landing_but_not_later_workflow_pages():
+    # Submit click (seq2) lands /overview (seq3); the human then works: a workflow
+    # click (seq6) navigates to /credit-card (seq7). The landing is kept, the
+    # workflow is not -- the SECOND click bounds the login segment.
+    url_events = [
+        url(0, "", f"{BASE}/login-page"),
+        url(3, f"{BASE}/login-page", f"{BASE}/overview"),
+        url(7, f"{BASE}/overview", f"{BASE}/credit-card"),
+    ]
+    transitions = [(u["from_url"], u["to_url"]) for u in url_events]
+    kept = _before_first_click(transitions, url_events, [click(2), click(6)])
+
+    assert [t[1] for t in kept] == [f"{BASE}/login-page", f"{BASE}/overview"]
+    assert all("credit-card" not in t[1] for t in kept)
+
+
 def test_a_login_that_settles_through_several_redirects_keeps_them_all():
     # Logins commonly bounce once or twice before landing; none of that is a click.
     url_events = [

--- a/tests/test_login_landing_url.py
+++ b/tests/test_login_landing_url.py
@@ -113,7 +113,9 @@ def test_a_takeover_login_still_finds_the_page_it_landed_on():
         url(1, "about:blank", f"{BASE}/login-page"),
         url(3, f"{BASE}/login-page", f"{BASE}/overview"),
     ]
-    patterns = [s.get("pattern") for s in _takeover_steps(url_events, [click(2)]) if s.get("pattern")]
+    patterns = [
+        s.get("pattern") for s in _takeover_steps(url_events, [click(2)]) if s.get("pattern")
+    ]
     assert patterns == [f"{BASE}/overview**"]
 
 

--- a/tests/test_migrate_provenance.py
+++ b/tests/test_migrate_provenance.py
@@ -133,3 +133,29 @@ def test_it_is_idempotent(tmp_path):
     assert _run(d, tmp_path).returncode == 0
     again = _run(d, tmp_path)
     assert again.returncode == 0 and "nothing to do" in again.stdout
+
+
+# --- verify_replay refuses rewritten operations before spending a session -----
+
+
+def test_replay_refuses_operations_that_were_rewritten(tmp_path):
+    """The failure this catches cost a whole live session.
+
+    A build rewrote the compiled operations, replayed, and spent the session
+    improvising against steps nobody had seen work — before anything said the
+    steps were not the recorded ones. The installer would have caught it, but
+    only afterwards.
+    """
+    d = _skill(tmp_path, steps=[{"command": "click_element", "params": {"selector": "#rewritten"}}])
+    (d / "recording_bundle.json").write_text(json.dumps(RECORDING))
+    script = Path("skills/noui/scripts/verify_replay.py").resolve()
+    r = subprocess.run(
+        [sys.executable, str(script), str(d), "--profile-slug", "bank"],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "PYTHONPATH": str(Path("skills/noui").resolve())},
+    )
+    assert r.returncode == 1
+    assert "the recording never saw" in r.stderr and "#rewritten" in r.stderr
+    # It must not have reached the live session at all.
+    assert not (d / "replay_report.json").exists()

--- a/tests/test_migrate_provenance.py
+++ b/tests/test_migrate_provenance.py
@@ -1,0 +1,135 @@
+"""Migrating an old browser skill attaches its recording — and only if it fits.
+
+A skill compiled before provenance existed is refused on its next install. It
+WAS compiled from a real recording and capture always saved the bundle, so the
+way back is to re-attach that recording rather than re-record.
+
+The risk this carries is obvious: a "just stamp it" tool would let anyone bless a
+fabricated skill by pointing it at any recording. So migration runs the same
+check the installer runs, and these tests pin that it does.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path("skills/noui/scripts/migrate_provenance.py").resolve()
+
+RECORDING = {
+    "session_id": "sess-old",
+    "schema_version": 5,
+    "click_events": [{"seq": 1, "locator": {"value": "#dl", "kind": "css", "is_css": True}}],
+    "url_events": [{"seq": 0, "to_url": "https://bank.test/statements"}],
+}
+
+
+def _skill(tmp_path, steps=None, session_id="sess-old"):
+    d = tmp_path / "skills" / "bank"
+    d.mkdir(parents=True)
+    (d / "manifest.json").write_text(
+        json.dumps(
+            {
+                "runtime": {"operation_style": "browser"},
+                "workflow": {"workflow_session_id": session_id},
+            }
+        )
+    )
+    (d / "operations.json").write_text(
+        json.dumps(
+            {
+                "operations": [
+                    {
+                        "name": "download",
+                        "tool": "call_web_browser",
+                        "steps": steps
+                        or [{"command": "click_element", "params": {"selector": "#dl"}}],
+                    }
+                ]
+            }
+        )
+    )
+    return d
+
+
+def _bundles(tmp_path, bundle=RECORDING):
+    b = tmp_path / "bundles"
+    b.mkdir(parents=True, exist_ok=True)
+    (b / "bank-sess-old.json").write_text(json.dumps(bundle))
+    return b
+
+
+def _run(skill_dir, tmp_path, *extra):
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "PYTHONPATH": str(Path("skills/noui").resolve()),
+        "NOUI_WORKBENCH_DIR": str(tmp_path),
+    }
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(skill_dir), *extra],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_it_finds_the_recording_by_session_id_and_attaches_it(tmp_path):
+    d = _skill(tmp_path)
+    _bundles(tmp_path)
+    r = _run(d, tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "session id sess-old matches" in r.stdout
+
+    manifest = json.loads((d / "manifest.json").read_text())
+    from noui_core.compile.provenance import bundle_digest
+
+    assert manifest["provenance"]["bundle_sha256"] == bundle_digest(RECORDING)
+    assert json.loads((d / "recording_bundle.json").read_text()) == RECORDING
+
+
+def test_it_refuses_a_recording_that_does_not_contain_the_steps(tmp_path):
+    """The check that stops this being a laundering tool.
+
+    A hand-written skill's selectors were never in any bundle, so pointing this
+    at a real recording must not make it pass.
+    """
+    d = _skill(tmp_path, steps=[{"command": "click_element", "params": {"selector": "#invented"}}])
+    _bundles(tmp_path)
+    r = _run(d, tmp_path)
+    assert r.returncode == 1
+    assert "do not appear in it" in r.stderr and "#invented" in r.stderr
+    assert not (d / "recording_bundle.json").exists()
+    assert "provenance" not in json.loads((d / "manifest.json").read_text())
+
+
+def test_it_refuses_when_no_saved_bundle_matches(tmp_path):
+    d = _skill(tmp_path, session_id="sess-gone")
+    _bundles(tmp_path)
+    r = _run(d, tmp_path)
+    assert r.returncode == 1
+    assert "no saved bundle has session id sess-gone" in r.stderr
+
+
+def test_it_leaves_non_browser_skills_alone(tmp_path):
+    d = _skill(tmp_path)
+    (d / "manifest.json").write_text(json.dumps({"runtime": {"operation_style": "api"}}))
+    r = _run(d, tmp_path)
+    assert r.returncode == 1
+    assert "not a browser skill" in r.stderr
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    d = _skill(tmp_path)
+    _bundles(tmp_path)
+    r = _run(d, tmp_path, "--dry-run")
+    assert r.returncode == 0
+    assert "Would attach" in r.stdout
+    assert not (d / "recording_bundle.json").exists()
+
+
+def test_it_is_idempotent(tmp_path):
+    d = _skill(tmp_path)
+    _bundles(tmp_path)
+    assert _run(d, tmp_path).returncode == 0
+    again = _run(d, tmp_path)
+    assert again.returncode == 0 and "nothing to do" in again.stdout

--- a/tests/test_nothing_recorded_is_silently_dropped.py
+++ b/tests/test_nothing_recorded_is_silently_dropped.py
@@ -1,0 +1,158 @@
+"""Every control the human touched reaches the skill, or is named as excluded.
+
+This is the invariant the golden cannot express. A golden pins WHAT the compiler
+produces; this pins that it produces something for everything it was given.
+
+Both of the worst bugs in this pipeline were silent discards, and neither showed
+up as a failure anywhere:
+
+  * The nav cap kept the first click and the last two, so a recorded "Past" tab
+    switch vanished. The replay looked for a link that only exists under that
+    tab and reported "nothing on the page matches this control" -- true, and
+    completely misleading.
+  * The Annual radio fell between two filters -- after its own page's terminal,
+    on a different page from the terminal it configures -- and belonged to no
+    operation. The download ran on whatever was already selected and every check
+    passed, because a monthly statement is still a statement.
+
+In both cases the bundle held the event, the compiled skill did not, and nothing
+in between said a step had been dropped. A human found each by watching a replay.
+
+An exclusion is fine -- plenty of recorded clicks are noise -- but it has to be
+DECLARED here, so dropping something is a decision someone made rather than a
+side effect of a slice.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from noui_core.compile.browser_skill import generate_browser_skill
+
+FIXTURES = Path(__file__).parent / "fixtures"
+BUNDLE = FIXTURES / "icici_statement_bundle.json"
+LOGIN_URL = "https://retailnetbanking.icici.bank.in/login-page"
+
+#: Recorded interactions that legitimately produce no step, by what they are --
+#: never by seq, which shifts on every re-record.
+DECLARED_EXCLUSIONS = {
+    # Chat/support widget on ICICI's statement page. Real events, no bearing on
+    # the journey.
+    "#FieldDropdown",
+    "#InitiateChat",
+    "#RefreshChat",
+    "#SendChat",
+    "#DisconnectChat",
+    # The QR/credentials tab on the LOGIN page. A workflow skill starts from an
+    # authenticated session, so nothing before sign-in belongs in its steps.
+    "button.tab-btn",
+}
+
+
+def _is_interactive(ev: dict) -> bool:
+    """An event that CHANGES something, so losing it changes the outcome.
+
+    Hovers are excluded: a hover reveals, and the fold merges it into the click
+    it opened, so it legitimately may not appear as a step of its own.
+    """
+    kind = (ev.get("event_type") or "click").lower()
+    # A submit IS the terminal -- it becomes the operation itself, not a step
+    # inside one -- so it never appears in the step list by design.
+    if kind == "submit":
+        return False
+    if kind == "change":
+        return True
+    if kind != "click":
+        return False
+    # A click on a page the journey never reaches is not this test's business.
+    return bool(ev.get("selector") or ev.get("text_content") or ev.get("candidates"))
+
+
+def _norm(text: str) -> str:
+    """Compare selectors without CSS escaping.
+
+    The compiler escapes a dot in an id -- `#CustomViewEStatementsFG\\.PERIOD` --
+    while the recorder stores it raw, so a substring match reports a control as
+    dropped when it is right there. A test that cries wolf is worse than no test,
+    so normalise both sides before comparing.
+    """
+    return text.replace("\\", "")
+
+
+def _step_haystack(ops: list[dict]) -> str:
+    """Every selector, text and value the compiled operations mention."""
+    parts: list[str] = []
+    for op in ops:
+        for step in op.get("segment_steps") or op.get("steps") or []:
+            parts.append(json.dumps(step.get("params") or {}))
+    return _norm("\n".join(parts))
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "KNOWN DEFECT, not a flaky test: the compiler drops the GO button "
+        "(#DUMMY1) that submits ICICI's statement form. Earlier compiles of the "
+        "same journey emitted `click_element #DUMMY1`; the current one does not, "
+        "so a step the human performed reaches no operation. Excluding it would "
+        "be editing the test to fit the code -- the thing this file exists to "
+        "prevent. When the compiler stops dropping it this test XPASSes and "
+        "strict=True fails the build, which is the signal to remove this marker."
+    ),
+)
+def test_every_state_changing_interaction_reaches_some_operation():
+    bundle = json.loads(BUNDLE.read_text())
+    clicks = bundle.get("click_events") or []
+    # The real entry point, for the reason spelled out in test_compile_is_stable:
+    # the fragments below it omit the assembly where several step kinds land.
+    with tempfile.TemporaryDirectory() as out:
+        generate_browser_skill(
+            app_slug="icici-fixture",
+            app_name="ICICI Fixture",
+            workflow_name="statement",
+            profile_slug="icici-fixture",
+            url_events=bundle.get("url_events") or [],
+            click_events=clicks,
+            login_url=LOGIN_URL,
+            output_dir=out,
+            bundle=bundle,
+        )
+        written = json.loads((Path(out) / "operations.json").read_text())
+    ops = written if isinstance(written, list) else written.get("operations", [])
+    haystack = _step_haystack(ops)
+
+    missing: list[str] = []
+    for ev in clicks:
+        if not _is_interactive(ev):
+            continue
+        selector = str(ev.get("selector") or "")
+        text = str(ev.get("text_content") or "").strip()
+        if any(x and x in selector for x in DECLARED_EXCLUSIONS):
+            continue
+        # Represented if ANY of its recorded handles appears in some step: the
+        # compiler is free to choose a different locator, just not to drop the
+        # control.
+        handles = [h for h in (selector, text) if h]
+        for cand in ev.get("candidates") or []:
+            if not isinstance(cand, dict) or not cand.get("value"):
+                continue
+            value = str(cand["value"])
+            handles.append(value)
+            # A radio is often addressed as set_checked{role, name}, so the
+            # recorded `radio|Annual` never appears verbatim -- the compiled step
+            # carries only the name half.
+            if str(cand.get("kind")) == "role_name" and "|" in value:
+                handles.append(value.split("|", 1)[1])
+        if not any(h and _norm(h) in haystack for h in handles):
+            missing.append(f"seq {ev.get('seq')} {ev.get('event_type')} {selector or text!r}")
+
+    assert not missing, (
+        "Recorded interactions that reach no compiled step:\n  "
+        + "\n  ".join(missing)
+        + "\n\nEither the compiler is dropping work the human did, or these are "
+        "noise and belong in DECLARED_EXCLUSIONS -- with a reason."
+    )

--- a/tests/test_nothing_recorded_is_silently_dropped.py
+++ b/tests/test_nothing_recorded_is_silently_dropped.py
@@ -29,8 +29,6 @@ import json
 import tempfile
 from pathlib import Path
 
-import pytest
-
 from noui_core.compile.browser_skill import generate_browser_skill
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -92,18 +90,6 @@ def _step_haystack(ops: list[dict]) -> str:
     return _norm("\n".join(parts))
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "KNOWN DEFECT, not a flaky test: the compiler drops the GO button "
-        "(#DUMMY1) that submits ICICI's statement form. Earlier compiles of the "
-        "same journey emitted `click_element #DUMMY1`; the current one does not, "
-        "so a step the human performed reaches no operation. Excluding it would "
-        "be editing the test to fit the code -- the thing this file exists to "
-        "prevent. When the compiler stops dropping it this test XPASSes and "
-        "strict=True fails the build, which is the signal to remove this marker."
-    ),
-)
 def test_every_state_changing_interaction_reaches_some_operation():
     bundle = json.loads(BUNDLE.read_text())
     clicks = bundle.get("click_events") or []

--- a/tests/test_optional_login_step.py
+++ b/tests/test_optional_login_step.py
@@ -1,0 +1,91 @@
+"""A workflow can contain a second login, to another origin.
+
+ICICI's statement portal has its own sign-in inside the slice the splitter
+already separated the first login from. The recording clicked "Log In" and the
+URL gained a jsessionid; a replay whose session already satisfies it arrives
+past that point, so the button is absent and the compiled step matched nothing.
+The step is unnecessary, not broken — and on a cold replay it is needed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+
+from noui_core.compile.browser_skill import _is_login_control, _step_for_click  # noqa: E402
+from noui_core.verify.replay import (  # noqa: E402
+    BLOCKED,
+    SKIPPED,
+    _control_identity,
+    replay_step,
+)
+
+# The real candidates recorded for #DEH_LOGIN (bundle icici-cc-hover-1f5ad255).
+LOGIN_CLICK = {
+    "candidates": [
+        {"kind": "id", "value": "#DEH_LOGIN", "match_count": 1},
+        {"kind": "name", "value": 'input[name="Action\\.DEH_LOGIN"]', "match_count": 1},
+        {"kind": "role_name", "value": "button|Log In", "match_count": 1},
+    ],
+    "locator": {"kind": "id", "value": "#DEH_LOGIN", "is_css": True,
+                "match_count": 1, "confidence": "unique"},
+}
+
+
+def test_a_login_control_is_recognised_by_its_accessible_name():
+    # #DEH_LOGIN says nothing; "button|Log In" is the control announcing itself.
+    assert _is_login_control(LOGIN_CLICK) is True
+
+
+def test_an_ordinary_control_is_not():
+    assert _is_login_control({"candidates": [
+        {"kind": "role_name", "value": "button|GO"},
+        {"kind": "id", "value": "#DUMMY1"},
+    ]}) is False
+
+
+def test_a_page_about_logins_is_not_a_login_control():
+    # The match is anchored to the end of the accessible name.
+    assert _is_login_control({"candidates": [
+        {"kind": "role_name", "value": "link|Login history"},
+    ]}) is False
+
+
+def test_the_step_is_marked_optional_with_a_reason():
+    step = _step_for_click(LOGIN_CLICK)
+    assert step["optional"] is True
+    assert "already have done" in step["optional_reason"]
+
+
+def test_an_absent_login_control_is_skipped_not_blocked():
+    step = {**_step_for_click(LOGIN_CLICK), "command": "click_element"}
+
+    def execute(cmd, params):
+        raise RuntimeError("nothing on the page matches \"#DEH_LOGIN\"")
+
+    res = replay_step(execute, step, recorded={_control_identity(step)})
+    assert res["status"] == SKIPPED
+    assert "already satisfied" in res["detail"]
+
+
+def test_a_login_control_that_is_present_and_fails_still_blocks():
+    # Absent means already signed in. Present-and-failing is a real failure and
+    # must not be waved through.
+    step = {**_step_for_click(LOGIN_CLICK), "command": "click_element"}
+
+    def execute(cmd, params):
+        raise RuntimeError("element is covered by an overlay")
+
+    assert replay_step(execute, step, recorded={_control_identity(step)})["status"] == BLOCKED
+
+
+def test_a_non_optional_step_is_never_skipped():
+    step = {"command": "click_element", "params": {"selector": "#DL"}}
+
+    def execute(cmd, params):
+        raise RuntimeError("nothing on the page matches \"#DL\"")
+
+    assert replay_step(execute, step, recorded={_control_identity(step)})["status"] == BLOCKED

--- a/tests/test_optional_login_step.py
+++ b/tests/test_optional_login_step.py
@@ -30,8 +30,13 @@ LOGIN_CLICK = {
         {"kind": "name", "value": 'input[name="Action\\.DEH_LOGIN"]', "match_count": 1},
         {"kind": "role_name", "value": "button|Log In", "match_count": 1},
     ],
-    "locator": {"kind": "id", "value": "#DEH_LOGIN", "is_css": True,
-                "match_count": 1, "confidence": "unique"},
+    "locator": {
+        "kind": "id",
+        "value": "#DEH_LOGIN",
+        "is_css": True,
+        "match_count": 1,
+        "confidence": "unique",
+    },
 }
 
 
@@ -41,17 +46,31 @@ def test_a_login_control_is_recognised_by_its_accessible_name():
 
 
 def test_an_ordinary_control_is_not():
-    assert _is_login_control({"candidates": [
-        {"kind": "role_name", "value": "button|GO"},
-        {"kind": "id", "value": "#DUMMY1"},
-    ]}) is False
+    assert (
+        _is_login_control(
+            {
+                "candidates": [
+                    {"kind": "role_name", "value": "button|GO"},
+                    {"kind": "id", "value": "#DUMMY1"},
+                ]
+            }
+        )
+        is False
+    )
 
 
 def test_a_page_about_logins_is_not_a_login_control():
     # The match is anchored to the end of the accessible name.
-    assert _is_login_control({"candidates": [
-        {"kind": "role_name", "value": "link|Login history"},
-    ]}) is False
+    assert (
+        _is_login_control(
+            {
+                "candidates": [
+                    {"kind": "role_name", "value": "link|Login history"},
+                ]
+            }
+        )
+        is False
+    )
 
 
 def test_the_step_is_marked_optional_with_a_reason():
@@ -64,7 +83,7 @@ def test_an_absent_login_control_is_skipped_not_blocked():
     step = {**_step_for_click(LOGIN_CLICK), "command": "click_element"}
 
     def execute(cmd, params):
-        raise RuntimeError("nothing on the page matches \"#DEH_LOGIN\"")
+        raise RuntimeError('nothing on the page matches "#DEH_LOGIN"')
 
     res = replay_step(execute, step, recorded={_control_identity(step)})
     assert res["status"] == SKIPPED
@@ -86,7 +105,7 @@ def test_a_non_optional_step_is_never_skipped():
     step = {"command": "click_element", "params": {"selector": "#DL"}}
 
     def execute(cmd, params):
-        raise RuntimeError("nothing on the page matches \"#DL\"")
+        raise RuntimeError('nothing on the page matches "#DL"')
 
     assert replay_step(execute, step, recorded={_control_identity(step)})["status"] == BLOCKED
 

--- a/tests/test_optional_login_step.py
+++ b/tests/test_optional_login_step.py
@@ -89,3 +89,44 @@ def test_a_non_optional_step_is_never_skipped():
         raise RuntimeError("nothing on the page matches \"#DL\"")
 
     assert replay_step(execute, step, recorded={_control_identity(step)})["status"] == BLOCKED
+
+
+# --- a click after a hover waits for the menu the hover opened -----------------
+
+
+def test_the_click_after_a_hover_inherits_its_settle():
+    # The recorder measures the settle on the HOVER — 4322ms on ICICI's nav —
+    # and the click that follows carries none, so it fell back to the runtime's
+    # 3s floor. The reveal sits right around 3s: the step passed in one live run
+    # and failed "on the page but not visible" in the next.
+    from noui_core.compile.browser_skill import _inherit_hover_settle
+
+    steps = [
+        {"command": "hover", "expect": {"settle_ms": 4322}},
+        {"command": "click_element"},
+        {"command": "get_page_summary"},
+    ]
+    _inherit_hover_settle(steps)
+    assert steps[1]["expect"]["settle_ms"] == 4322
+    assert steps[2].get("expect") is None, "only the step immediately after"
+
+
+def test_a_click_keeps_its_own_measurement():
+    # Its own settle describes its own page and is the better number.
+    from noui_core.compile.browser_skill import _inherit_hover_settle
+
+    steps = [
+        {"command": "hover", "expect": {"settle_ms": 4322}},
+        {"command": "click_element", "expect": {"settle_ms": 900, "url": "https://x/y"}},
+    ]
+    _inherit_hover_settle(steps)
+    assert steps[1]["expect"]["settle_ms"] == 900
+    assert steps[1]["expect"]["url"] == "https://x/y", "nothing else is disturbed"
+
+
+def test_a_hover_with_no_measurement_gives_nothing():
+    from noui_core.compile.browser_skill import _inherit_hover_settle
+
+    steps = [{"command": "hover"}, {"command": "click_element"}]
+    _inherit_hover_settle(steps)
+    assert steps[1].get("expect") is None

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -31,6 +31,29 @@ def ev(**over) -> dict:
     return base
 
 
+def test_a_select_on_its_placeholder_option_is_not_a_parameter():
+    # ICICI's #FieldDropdown decoy records value "Value" -- the inert first
+    # option. It must not become a parameter + select_option that drives a
+    # meaningless control and asks the caller for a value meaning "nothing chosen".
+    for placeholder in ("Value", "-- Select --", "Choose", "Please select", "None"):
+        assert (
+            derive_parameters(
+                [ev(tag_name="SELECT", event_type="change", field_name="FieldDropdown", value=placeholder)]
+            )
+            == []
+        ), placeholder
+
+
+def test_a_select_with_a_real_choice_is_still_a_parameter():
+    # A real selection (a period, an account) carries a real value and is kept.
+    for real in ("FY2025-26", "All accounts", "Savings ...4471"):
+        params = derive_parameters(
+            [ev(tag_name="SELECT", event_type="change", field_name="period", value=real)]
+        )
+        assert len(params) == 1 and params[0]["default"] == real, real
+        assert params[0]["control"] == "select"
+
+
 def test_a_recorded_value_becomes_a_parameter_with_that_value_as_default():
     # Default = recorded, so the operation still does exactly what was recorded
     # when nothing is passed.

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -82,15 +82,26 @@ def test_checkbox_state_is_not_a_parameter():
     )
 
 
-def test_a_dropdown_is_reported_but_not_faked():
-    # No browser command can set a native <select>, so compiling a step for it
-    # would silently do nothing. Report it and let the agent open and choose.
+def test_a_dropdown_is_chosen_not_typed_into():
+    """A native <select> IS settable -- the runtime has always had select_option.
+
+    Marking it read-only meant every dropdown a skill needed was surfaced as
+    something to report rather than something to drive, leaving clicks through
+    whatever widget the page draws over it as the only way to change one. On
+    ICICI that is three brittle steps per dropdown and a replay that stalls
+    mid-panel.
+
+    It must not compile to type_text either: you choose from a select, you do
+    not type into one.
+    """
     (p,) = derive_parameters(
         [ev(event_type="change", tag_name="SELECT", field_name="period", value="Last 6 months")]
     )
     assert p["control"] == "select"
-    assert p["settable"] is False
-    assert fill_steps([p]) == []
+    assert p["settable"] is True
+    (step,) = fill_steps([{**p, "selector": "#period"}])
+    assert step["command"] == "select_option"
+    assert step["params"] == {"selector": "#period", "value": "{{period}}"}
 
 
 def test_falls_back_to_the_label_when_a_field_has_no_name():

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,0 +1,141 @@
+"""Tests for turning recorded input values into operation parameters.
+
+A recording captures ONE run — "1 Jan – 31 Jan", "account ...4471". Compiled
+literally the skill can only fetch that, which is why the ICICI agent, asked for
+"last year", found nothing in the operation to vary and spent twenty steps
+hunting the page for a period selector.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+
+from noui_core.compile.parameters import derive_parameters, fill_steps  # noqa: E402
+
+
+def ev(**over) -> dict:
+    base = {
+        "event_type": "input",
+        "tag_name": "INPUT",
+        "input_type": "text",
+        "field_name": "fromDate",
+        "value": "2026-01-01",
+        "url": "https://bank.test/statements",
+        "candidates": [{"kind": "id", "value": "#from-date", "match_count": 1}],
+    }
+    base.update(over)
+    return base
+
+
+def test_a_recorded_value_becomes_a_parameter_with_that_value_as_default():
+    # Default = recorded, so the operation still does exactly what was recorded
+    # when nothing is passed.
+    (p,) = derive_parameters([ev()])
+    assert p["name"] == "from_date"
+    assert p["type"] == "date"
+    assert p["default"] == "2026-01-01"
+    assert p["selector"] == "#from-date"
+
+
+def test_a_password_is_never_a_parameter():
+    # Tabby exists so callers do not hold credentials; a skill that accepted one
+    # as an argument would hand that problem straight back.
+    assert (
+        derive_parameters([ev(field_role="password", value="[REDACTED]", is_redacted=True)]) == []
+    )
+    assert derive_parameters([ev(field_role="password", value="hunter2")]) == []
+
+
+def test_an_otp_is_never_a_parameter():
+    assert derive_parameters([ev(field_role="otp", value="482913")]) == []
+
+
+def test_the_last_value_for_a_field_wins():
+    # A human who types, corrects and retypes leaves several events for one
+    # field; what matters is what it held when they acted.
+    params = derive_parameters([ev(value="2026-01-01"), ev(value="2025-04-01")])
+    assert len(params) == 1
+    assert params[0]["default"] == "2025-04-01"
+
+
+def test_recognises_a_date_even_when_the_input_is_a_text_field():
+    # Bank date fields are routinely type="text" with a picker bolted on.
+    (p,) = derive_parameters([ev(input_type="text", value="31/03/2026", field_name="toDate")])
+    assert p["type"] == "date"
+
+
+def test_recognises_a_year_and_an_amount_from_the_field_name():
+    (y,) = derive_parameters([ev(field_name="statementYear", value="2025")])
+    assert y["type"] == "year"
+    (a,) = derive_parameters([ev(field_name="txnAmount", value="1500.50")])
+    assert a["type"] == "amount"
+
+
+def test_checkbox_state_is_not_a_parameter():
+    # Part of the recorded path, not a value a caller supplies.
+    assert (
+        derive_parameters([ev(event_type="change", input_type="checkbox", value="checked")]) == []
+    )
+
+
+def test_a_dropdown_is_reported_but_not_faked():
+    # No browser command can set a native <select>, so compiling a step for it
+    # would silently do nothing. Report it and let the agent open and choose.
+    (p,) = derive_parameters(
+        [ev(event_type="change", tag_name="SELECT", field_name="period", value="Last 6 months")]
+    )
+    assert p["control"] == "select"
+    assert p["settable"] is False
+    assert fill_steps([p]) == []
+
+
+def test_falls_back_to_the_label_when_a_field_has_no_name():
+    (p,) = derive_parameters(
+        [
+            ev(
+                field_name="",
+                candidates=[{"kind": "label", "value": "Statement period", "match_count": 1}],
+                element={"accessible_name": "Statement period"},
+            )
+        ]
+    )
+    assert p["name"] == "statement_period"
+    assert p["by_label"] == "Statement period"
+
+
+def test_fill_steps_template_on_the_parameter_name():
+    # The placeholder is what lets a caller override; without it the step would
+    # hard-code the recorded run.
+    steps = fill_steps(derive_parameters([ev()]))
+    assert steps == [
+        {"command": "type_text", "params": {"selector": "#from-date", "text": "{{from_date}}"}}
+    ]
+
+
+def test_fills_by_label_when_there_is_no_usable_selector():
+    steps = fill_steps(
+        derive_parameters(
+            [
+                ev(
+                    field_name="",
+                    candidates=[{"kind": "text", "value": "From", "match_count": 3}],
+                    element={"accessible_name": "From date"},
+                )
+            ]
+        )
+    )
+    assert steps == [
+        {"command": "type_into_label", "params": {"label": "From date", "text": "{{from_date}}"}}
+    ]
+
+
+def test_ignores_empty_and_non_string_values():
+    assert derive_parameters([ev(value="   "), ev(value=None), ev(value=42)]) == []
+
+
+def test_ignores_events_that_are_not_inputs():
+    assert derive_parameters([ev(event_type="click"), ev(event_type="submit")]) == []

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -84,6 +84,16 @@ def test_an_otp_is_never_a_parameter():
     assert derive_parameters([ev(field_role="otp", value="482913")]) == []
 
 
+def test_an_unknown_sensitive_field_is_never_a_parameter_even_unredacted():
+    # unknown_sensitive is the recorder's "sensitive but not confidently password
+    # or otp" bucket (e.g. a re-entered transaction PIN). It is in the canonical
+    # credential-role set, so it must be excluded HERE regardless of whether
+    # redaction happened upstream -- otherwise the plaintext value could ship as a
+    # compiled operation's default. username is a credential too, and excluded.
+    assert derive_parameters([ev(field_role="unknown_sensitive", value="4821")]) == []
+    assert derive_parameters([ev(field_role="username", value="jdoe")]) == []
+
+
 def test_the_last_value_for_a_field_wins():
     # A human who types, corrects and retypes leaves several events for one
     # field; what matters is what it held when they acted.

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -38,7 +38,14 @@ def test_a_select_on_its_placeholder_option_is_not_a_parameter():
     for placeholder in ("Value", "-- Select --", "Choose", "Please select", "None"):
         assert (
             derive_parameters(
-                [ev(tag_name="SELECT", event_type="change", field_name="FieldDropdown", value=placeholder)]
+                [
+                    ev(
+                        tag_name="SELECT",
+                        event_type="change",
+                        field_name="FieldDropdown",
+                        value=placeholder,
+                    )
+                ]
             )
             == []
         ), placeholder

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -41,6 +41,26 @@ def test_observed_selectors_collects_every_form_a_step_might_use():
     assert {"button|Download", "Download", "#dl", "Past Statements"} <= seen
 
 
+def test_a_label_addressed_fill_is_read_by_its_label_not_its_typed_value():
+    # type_into_label carries the VALUE in `text` (often a {{placeholder}}); taking
+    # text first validated that placeholder as a locator the recording never saw,
+    # so the gate refused every label-addressed parameterised fill. The locator is
+    # the label. Mirrors the harness _step_locators / _TYPED_VALUE_COMMANDS.
+    from noui_core.compile.provenance import step_locators, unobserved_locators
+
+    ops = [
+        {
+            "name": "search",
+            "steps": [
+                {"command": "type_into_label", "params": {"label": "Search box", "text": "{{q}}"}}
+            ],
+        }
+    ]
+    assert step_locators(ops) == ["Search box"]
+    bundle = {"click_events": [{"candidates": [{"kind": "label", "value": "Search box"}]}]}
+    assert unobserved_locators(ops, bundle) == []
+
+
 def test_build_stamps_what_the_installer_verifies():
     prov = build(RECORDING, bundle_file="recording_bundle.json")
     assert prov["bundle_sha256"] == SHARED_BUNDLE_DIGEST

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -47,3 +47,52 @@ def test_build_stamps_what_the_installer_verifies():
     assert prov["bundle_file"] == "recording_bundle.json"
     assert prov["recording_session_id"] == "sess-1"
     assert prov["source"] == "recording"
+
+
+# --- steps digest: pinned in BOTH repos, same reason as the bundle digest -----
+
+SHARED_STEPS = [
+    {
+        "name": "download",
+        "kind": "download",
+        "steps": [{"command": "click_element", "params": {"selector": "#dl"}}],
+        "parameters": [],
+    }
+]
+SHARED_STEPS_DIGEST = "ede061aad69f99f7a5c075bd20370936f10fee595fdf2ccc6e075524255986dc"
+
+
+def test_the_steps_digest_matches_the_harness_implementation():
+    from noui_core.compile.provenance import steps_digest
+
+    assert steps_digest(SHARED_STEPS) == SHARED_STEPS_DIGEST
+
+
+def test_renaming_an_operation_does_not_change_the_steps_digest():
+    """A gate that fires on a wording fix is one people learn to route around."""
+    from noui_core.compile.provenance import steps_digest
+
+    renamed = [dict(SHARED_STEPS[0], name="download_annual", description="Nicer words")]
+    assert steps_digest(renamed) == SHARED_STEPS_DIGEST
+
+
+def test_reassembling_steps_changes_the_digest():
+    """The hole this closes: same locator, different workflow.
+
+    Told its selectors were unobserved, a build harvested the locators that WOULD
+    pass and rewrote the steps around them. Every locator then appeared in the
+    recording, so the set check went green while the workflow was no longer the
+    compiled one.
+    """
+    from noui_core.compile.provenance import steps_digest
+
+    reassembled = [
+        dict(
+            SHARED_STEPS[0],
+            steps=[
+                {"command": "click_element", "params": {"selector": "#dl"}},
+                {"command": "click_element", "params": {"selector": "#dl"}},
+            ],
+        )
+    ]
+    assert steps_digest(reassembled) != SHARED_STEPS_DIGEST

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -116,3 +116,46 @@ def test_reassembling_steps_changes_the_digest():
         )
     ]
     assert steps_digest(reassembled) != SHARED_STEPS_DIGEST
+
+
+def test_a_keyless_control_action_is_flagged_as_unbacked():
+    """The defense-in-depth gap unobserved_locators alone left open.
+
+    A control action with no locator -- a coordinate click, a key-press on the
+    focused element -- contributes nothing to step_locators, so unobserved_locators
+    returns [] and the operation "verifies" against any bundle at all. Such steps
+    are never emitted by the compiler; their presence means the operations were
+    hand-written, which is exactly what the provenance gate exists to catch.
+    """
+    from noui_core.compile.provenance import unbacked_control_steps
+
+    ops = [
+        {
+            "name": "sneaky_pay",
+            "steps": [
+                {"command": "click_at", "params": {"x": 120, "y": 44}},
+                {"command": "press_key", "params": {"key": "Enter"}},
+            ],
+        }
+    ]
+    flagged = unbacked_control_steps(ops)
+    assert len(flagged) == 2
+    assert all("sneaky_pay" in f for f in flagged)
+
+
+def test_a_control_action_with_a_locator_and_a_read_are_not_flagged():
+    # A properly compiled step carries a locator; a read targets no control. Only
+    # a keyless CONTROL action is unbacked -- reads must not be false-flagged.
+    from noui_core.compile.provenance import unbacked_control_steps
+
+    ops = [
+        {
+            "name": "read_statement",
+            "steps": [
+                {"command": "click_element", "params": {"selector": "#dl"}},
+                {"command": "get_page_summary", "params": {}},
+                {"command": "list_downloads"},
+            ],
+        }
+    ]
+    assert unbacked_control_steps(ops) == []

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -159,3 +159,49 @@ def test_a_control_action_with_a_locator_and_a_read_are_not_flagged():
         }
     ]
     assert unbacked_control_steps(ops) == []
+
+
+def test_a_role_addressed_control_is_backed_when_the_recording_saw_it():
+    """The regression a role+name step must not trip.
+
+    The compiler emits set_checked {role: "radio", name: "Annual"} for a control
+    with no unique CSS selector. It names a real control the recorder saw (as a
+    role_name candidate), so it must NOT read as unbacked, and it must verify
+    against a bundle that carries that candidate.
+    """
+    from noui_core.compile.provenance import unbacked_control_steps, unobserved_locators
+
+    ops = [
+        {
+            "name": "download_annual",
+            "steps": [
+                {"command": "set_checked", "params": {"role": "radio", "name": "Annual"}},
+            ],
+        }
+    ]
+    # Not anchorless: it names a control.
+    assert unbacked_control_steps(ops) == []
+
+    bundle = {
+        "click_events": [
+            {"candidates": [{"kind": "role_name", "value": "radio|Annual"}]},
+        ]
+    }
+    # And the recording that carries the role_name candidate backs it.
+    assert unobserved_locators(ops, bundle) == []
+
+
+def test_a_role_addressed_control_the_recording_never_saw_is_still_caught():
+    # A hand-written role+name whose control the recording never saw is still
+    # flagged -- the fix backs recorded role controls, it does not wave through
+    # invented ones.
+    from noui_core.compile.provenance import unobserved_locators
+
+    ops = [
+        {
+            "name": "x",
+            "steps": [{"command": "set_checked", "params": {"role": "radio", "name": "Ghost"}}],
+        }
+    ]
+    bundle = {"click_events": [{"candidates": [{"kind": "role_name", "value": "radio|Annual"}]}]}
+    assert unobserved_locators(ops, bundle) == ["Ghost"]

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,49 @@
+"""Provenance binds a compiled browser skill to the recording behind it.
+
+The digest vector is pinned in BOTH repos (adoptai-workflows:
+tests/agent_harness/test_web_browser_dispatch.py). The installer refuses a skill
+whose recording does not hash to the stamp, so if the two implementations ever
+drift apart every real skill is refused -- and without this pin, nothing would
+say why.
+"""
+
+from noui_core.compile.provenance import build, bundle_digest, observed_selectors
+
+RECORDING = {
+    "session_id": "sess-1",
+    "schema_version": 5,
+    "click_events": [{"seq": 1, "locator": {"value": "#dl", "kind": "css", "is_css": True}}],
+    "url_events": [{"seq": 0, "to_url": "https://bank.test/statements"}],
+}
+
+SHARED_BUNDLE_DIGEST = "7ada3d2f1371dc12fa5ecbb8a8484b627b414523c90e0b02459497b89ff4509a"
+
+
+def test_the_digest_matches_the_harness_implementation():
+    assert bundle_digest(RECORDING) == SHARED_BUNDLE_DIGEST
+
+
+def test_the_digest_changes_when_the_recording_does():
+    tampered = dict(RECORDING, click_events=[{"seq": 1, "locator": {"value": "#other"}}])
+    assert bundle_digest(tampered) != SHARED_BUNDLE_DIGEST
+
+
+def test_observed_selectors_collects_every_form_a_step_might_use():
+    rec = {
+        "click_events": [
+            {"candidates": [{"kind": "role_name", "value": "button|Download"}]},
+            {"locator": {"value": "#dl"}},
+            {"text": "Past Statements"},
+        ]
+    }
+    seen = observed_selectors(rec)
+    # role_name candidates are "role|name"; a click_by_text step keeps only the name.
+    assert {"button|Download", "Download", "#dl", "Past Statements"} <= seen
+
+
+def test_build_stamps_what_the_installer_verifies():
+    prov = build(RECORDING, bundle_file="recording_bundle.json")
+    assert prov["bundle_sha256"] == SHARED_BUNDLE_DIGEST
+    assert prov["bundle_file"] == "recording_bundle.json"
+    assert prov["recording_session_id"] == "sess-1"
+    assert prov["source"] == "recording"

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -318,3 +318,55 @@ def test_a_caller_supplied_value_wins_over_the_recorded_default():
     }
     filled = substitute_parameters(op, {"from_date": "2025-04-01"})
     assert filled[0]["params"]["text"] == "2025-04-01"
+
+
+def test_a_download_operation_does_not_pass_on_an_earlier_ones_file():
+    """The annual statement "succeeded" on the monthly PDF.
+
+    `list_downloads` reports every download the browser has taken for the life
+    of the session. Once ANY operation downloads anything, every later download
+    check sees a file and passes -- so a replay where the annual branch silently
+    did nothing reported all goals reached, which is precisely the failure the
+    replay exists to catch.
+    """
+    from noui_core.verify.replay import build_report
+
+    monthly = {"name": "monthly", "kind": "download", "steps": []}
+    annual = {"name": "annual", "kind": "download", "steps": []}
+    listed = [{"id": "dl-1", "state": "completed", "suggested_filename": "Statement.pdf"}]
+    results = [
+        [{"status": "ok", "command": "list_downloads", "data": {"downloads": listed}}],
+        # The annual operation ran and produced nothing new: the same one file.
+        [{"status": "ok", "command": "list_downloads", "data": {"downloads": listed}}],
+    ]
+    report = build_report([monthly, annual], results)
+    by_name = {o["name"]: o for o in report["operations"]}
+    assert by_name["monthly"]["goal_reached"] is True
+    assert by_name["annual"]["goal_reached"] is False
+    assert report["all_goals_reached"] is False
+
+
+def test_a_second_download_operation_passes_on_its_own_file():
+    from noui_core.verify.replay import build_report
+
+    first = [{"id": "dl-1", "state": "completed"}]
+    both = [*first, {"id": "dl-2", "state": "completed"}]
+    report = build_report(
+        [{"name": "monthly", "kind": "download"}, {"name": "annual", "kind": "download"}],
+        [
+            [{"status": "ok", "command": "list_downloads", "data": {"downloads": first}}],
+            [{"status": "ok", "command": "list_downloads", "data": {"downloads": both}}],
+        ],
+    )
+    assert report["all_goals_reached"] is True
+
+
+def test_a_download_still_in_flight_or_failed_is_not_evidence():
+    """A record exists from the moment the browser starts fetching."""
+    from noui_core.verify.replay import goal_reached
+
+    op = {"name": "d", "kind": "download"}
+    for state in ("in_progress", "failed"):
+        steps = [{"status": "ok", "command": "list_downloads",
+                  "data": {"downloads": [{"id": "dl-1", "state": state}]}}]
+        assert goal_reached(op, steps) is False, state

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -274,6 +274,11 @@ def test_a_dead_session_mid_run_keeps_what_already_ran(monkeypatch):
     calls = {"n": 0}
 
     def flaky(_profile, command, _params, **_kw):
+        # The run opens with one read of its own -- the download baseline, so a
+        # file left by an earlier replay cannot be mistaken for this one's -- and
+        # that read is not a step. The session dies after the first real step.
+        if command == "list_downloads" and calls["n"] == 0:
+            return {"success": True, "data": {"downloads": []}}
         calls["n"] += 1
         if calls["n"] > 1:
             raise RuntimeError("HTTP 409 from POST /execute/browser: session gone")
@@ -288,13 +293,20 @@ def test_a_dead_session_mid_run_keeps_what_already_ran(monkeypatch):
 
 
 def test_a_replay_that_reaches_the_goal_is_still_not_installable(monkeypatch):
-    _patch_exec(
-        monkeypatch,
-        lambda _p, c, _params, **_k: {
-            "success": True,
-            "data": {"downloads": [{"id": "dl-1"}]} if c == "list_downloads" else {},
-        },
-    )
+    # The file arrives DURING the run: nothing on disk when the replay starts,
+    # one statement by the time the operation lists them. A run that starts with
+    # the file already there has downloaded nothing, which is a different case
+    # (see test_a_file_left_by_an_earlier_run_is_not_this_ones_evidence).
+    seen = {"listed": 0}
+
+    def fake(_p, c, _params, **_k):
+        if c != "list_downloads":
+            return {"success": True, "data": {}}
+        seen["listed"] += 1
+        first = seen["listed"] == 1
+        return {"success": True, "data": {"downloads": [] if first else [{"id": "dl-1"}]}}
+
+    _patch_exec(monkeypatch, fake)
     report = run_replay([DOWNLOAD_OP], profile_slug="icici", token="tok")
 
     assert report["all_goals_reached"] is True
@@ -423,3 +435,27 @@ def test_a_read_operation_is_still_judged_by_its_steps():
     op = {"name": "read_page", "kind": "read"}
     assert goal_reached(op, [{"status": "blocked", "command": "click_element"}]) is False
     assert goal_reached(op, [{"status": "ok", "command": "get_page_summary"}]) is True
+
+
+def test_a_file_left_by_an_earlier_run_is_not_this_ones_evidence(monkeypatch):
+    """A replay that downloads nothing must not pass on yesterday's statement.
+
+    The session accumulates downloads for its whole life. Seeded only from
+    earlier operations in the same run, the baseline missed everything a
+    PREVIOUS run had fetched — and a run whose download step blocked reported
+    the goal reached, on the strength of a file it never produced. Observed
+    live: two consecutive annual replays both reported success while the
+    download count stayed at 9.
+    """
+    _patch_exec(
+        monkeypatch,
+        lambda _p, c, _params, **_k: {
+            "success": True,
+            "data": {"downloads": [{"id": "dl-old", "state": "completed"}]}
+            if c == "list_downloads"
+            else {},
+        },
+    )
+    report = run_replay([DOWNLOAD_OP], profile_slug="icici", token="tok")
+
+    assert report["all_goals_reached"] is False

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,213 @@
+"""Tests for replaying a draft skill before anything is installed.
+
+Every failure this project has hit looked right on paper — `a.mb-0` reads like a
+selector, a missing download operation looks like a skill with three operations,
+a hidden radio looks clickable. These pin the gate that actually tries the plan
+against the live app, and the rules that keep an improvising agent from doing
+something irreversible while it does.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+
+from noui_core.verify.replay import (  # noqa: E402
+    BLOCKED,
+    NEEDS_APPROVAL,
+    OK,
+    approve,
+    build_report,
+    classify_risk,
+    goal_reached,
+    plan_operations,
+    recorded_controls,
+    replay_step,
+)
+
+
+def step(command="click_element", **params) -> dict:
+    return {"command": command, "params": params}
+
+
+DOWNLOAD_OP = {
+    "name": "download_statement",
+    "kind": "download",
+    "tool": "call_web_browser",
+    "steps": [
+        step(selector="#nav-cards"),
+        step(selector="#stmt-dl"),
+        {"command": "list_downloads"},
+    ],
+}
+
+
+# --- what may be replayed unattended -----------------------------------------
+
+
+def test_a_money_moving_control_is_never_replayed_unattended():
+    # An improvising agent on a bank portal can reach Pay while hunting for a
+    # statement. A false stop costs one question; a false proceed moves money.
+    risk = classify_risk(step(text="Pay now"), recorded_controls={"text:pay now"})
+    assert risk and "pay" in risk
+
+
+def test_an_irreversible_control_is_stopped_even_if_the_human_used_it():
+    # Being in the recording is not consent to repeat it.
+    risk = classify_risk(step(text="Block card"), recorded_controls={"text:block card"})
+    assert risk is not None
+
+
+def test_a_control_the_human_never_touched_is_stopped():
+    # THE catch-all: the plan only departs from the recording when the agent is
+    # improvising, and that is exactly when nobody has verified what it does.
+    risk = classify_risk(step(selector="#mystery"), recorded_controls={"selector:#known"})
+    assert risk and "never touched" in risk
+
+
+def test_a_recorded_harmless_control_replays_freely():
+    assert (
+        classify_risk(step(selector="#nav-cards"), recorded_controls={"selector:#nav-cards"})
+        is None
+    )
+
+
+def test_reading_a_page_is_never_risky_whatever_it_says():
+    # A page containing the word "Transfer" is not a transfer.
+    assert (
+        classify_risk({"command": "get_page_summary", "params": {}}, recorded_controls=set())
+        is None
+    )
+    assert classify_risk({"command": "screenshot", "params": {}}, recorded_controls=set()) is None
+
+
+def test_recorded_controls_come_from_the_draft_itself():
+    # The draft is compiled from the recording, so its steps ARE what the human
+    # did — no separate bookkeeping to drift out of date.
+    assert recorded_controls([DOWNLOAD_OP]) == {"selector:#nav-cards", "selector:#stmt-dl"}
+
+
+# --- running a step -----------------------------------------------------------
+
+
+def test_a_step_that_throws_is_reported_not_raised():
+    # A blocked step is the thing the human needs to see. Letting it abort the
+    # run would lose every result after it.
+    def boom(_c, _p):
+        raise RuntimeError("Timeout 30000ms exceeded")
+
+    out = replay_step(boom, step(selector="#nav-cards"), recorded={"selector:#nav-cards"})
+    assert out["status"] == BLOCKED
+    assert "Timeout" in out["detail"]
+
+
+def test_a_worker_reported_failure_is_blocked_not_ok():
+    # /execute/browser returns {success: false} for an in-page failure; that is a
+    # real result, and treating it as success is how the Annual radio went
+    # unnoticed.
+    out = replay_step(
+        lambda _c, _p: {"success": False, "error": "state did not change"},
+        step(selector="#nav-cards"),
+        recorded={"selector:#nav-cards"},
+    )
+    assert out["status"] == BLOCKED
+
+
+def test_a_risky_step_asks_instead_of_running():
+    calls = []
+    out = replay_step(
+        lambda c, p: calls.append((c, p)),
+        step(text="Transfer funds"),
+        recorded=set(),
+    )
+    assert out["status"] == NEEDS_APPROVAL
+    assert calls == []  # it did not run
+
+
+def test_an_approved_risky_step_runs():
+    out = replay_step(
+        lambda _c, _p: {"success": True, "data": {}},
+        step(text="Submit request"),
+        recorded=set(),
+        approvals={"text:submit request"},
+    )
+    assert out["status"] == OK
+
+
+# --- did it actually achieve anything ----------------------------------------
+
+
+def test_a_download_that_produced_no_file_has_not_reached_its_goal():
+    # Every step "passed" and nothing was downloaded. This is the distinction the
+    # whole `kind` field exists for.
+    steps = [
+        {"status": OK, "command": "click_element"},
+        {"status": OK, "command": "list_downloads", "data": {"downloads": []}},
+    ]
+    assert goal_reached(DOWNLOAD_OP, steps) is False
+
+
+def test_a_download_that_produced_a_file_has():
+    steps = [
+        {"status": OK, "command": "click_element"},
+        {"status": OK, "command": "list_downloads", "data": {"downloads": [{"id": "dl-1"}]}},
+    ]
+    assert goal_reached(DOWNLOAD_OP, steps) is True
+
+
+def test_a_blocked_step_means_the_goal_was_not_reached():
+    steps = [{"status": BLOCKED, "command": "click_element"}]
+    assert goal_reached({"kind": "read"}, steps) is False
+
+
+# --- the gate -----------------------------------------------------------------
+
+
+def test_a_report_is_never_installable_however_well_it_went():
+    # `installable` is a human decision, not a conclusion the replay may draw.
+    steps = [
+        [
+            {"status": OK, "command": "click_element"},
+            {"status": OK, "command": "list_downloads", "data": {"downloads": [{"id": "1"}]}},
+        ]
+    ]
+    report = build_report([DOWNLOAD_OP], steps)
+
+    assert report["all_goals_reached"] is True
+    assert report["installable"] is False
+
+
+def test_only_an_explicit_approval_makes_it_installable():
+    report = build_report([DOWNLOAD_OP], [[{"status": OK, "command": "x"}]])
+    assert approve(report)["installable"] is True
+
+
+def test_the_report_names_the_goal_that_failed_not_just_a_step_count():
+    # "11 of 12 steps passed" hides exactly the failure that matters.
+    report = build_report(
+        [DOWNLOAD_OP],
+        [
+            [
+                {"status": OK, "command": "click_element"},
+                {"status": BLOCKED, "command": "click_element"},
+            ]
+        ],
+    )
+    op = report["operations"][0]
+
+    assert op["goal_reached"] is False
+    assert op["blocked_count"] == 1
+    assert op["name"] == "download_statement"
+
+
+# --- scope --------------------------------------------------------------------
+
+
+def test_only_browser_operations_are_replayed():
+    # HAR-replay skills keep their existing test loop; replaying one means firing
+    # recorded requests, which is a different risk profile.
+    api_op = {"name": "list_txns", "tool": "call_web_api", "steps": []}
+    assert plan_operations([DOWNLOAD_OP, api_op]) == [DOWNLOAD_OP]

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -211,3 +211,110 @@ def test_only_browser_operations_are_replayed():
     # recorded requests, which is a different risk profile.
     api_op = {"name": "list_txns", "tool": "call_web_api", "steps": []}
     assert plan_operations([DOWNLOAD_OP, api_op]) == [DOWNLOAD_OP]
+
+
+# --- running against a real profile session -----------------------------------
+#
+# Replay uses the ordinary profile session — the same one an installed skill gets
+# — rather than inheriting the recording's auth. Inheriting it does not survive
+# real apps: ICICI carries its session in the URL
+# (AuthenticationController;jsessionid=…) and SPAs keep tokens in sessionStorage,
+# so a cookie-seeded cold browser reproduces neither and replay would fail for
+# reasons that have nothing to do with the plan.
+
+from noui_core.verify.replay import SessionNotReadyError, substitute_parameters  # noqa: E402
+from noui_core.verify.session import run_replay, session_is_ready  # noqa: E402
+
+
+def _patch_exec(monkeypatch, fn):
+    from noui_core import tabby_client
+
+    monkeypatch.setattr(tabby_client, "execute_browser", fn)
+
+
+def test_no_session_is_reported_as_login_required_not_as_a_broken_plan(monkeypatch):
+    # Blaming the skill because nobody has signed in yet would be a lie, and one
+    # the human would act on by re-recording a plan that was fine.
+    import pytest
+    from noui_core.verify.session import _executor
+
+    def no_session(*_a, **_k):
+        raise RuntimeError("HTTP 404 from POST /execute/browser: no healthy session")
+
+    _patch_exec(monkeypatch, no_session)
+    with pytest.raises(SessionNotReadyError):
+        _executor("icici", "tok")("get_page_info", {})
+
+
+def test_an_ordinary_failure_is_not_mistaken_for_a_missing_session(monkeypatch):
+    # A 500 is a real failure of the step; only 404/409 mean "not signed in".
+    import pytest
+    from noui_core.verify.session import _executor
+
+    def boom(*_a, **_k):
+        raise RuntimeError("HTTP 500 from POST /execute/browser: worker exploded")
+
+    _patch_exec(monkeypatch, boom)
+    with pytest.raises(RuntimeError) as exc:
+        _executor("icici", "tok")("get_page_info", {})
+    assert not isinstance(exc.value, SessionNotReadyError)
+
+
+def test_session_readiness_is_probed_without_touching_the_app(monkeypatch):
+    seen = []
+    _patch_exec(monkeypatch, lambda _p, c, _params, **_k: seen.append(c) or {"success": True})
+
+    assert session_is_ready("icici", "tok") is True
+    assert seen == ["get_page_info"]  # reads nothing, changes nothing
+
+
+def test_a_dead_session_mid_run_keeps_what_already_ran(monkeypatch):
+    # The steps that ran are still evidence. Discarding them would make a timed
+    # out session look like a plan that does nothing.
+    calls = {"n": 0}
+
+    def flaky(_profile, command, _params, **_kw):
+        calls["n"] += 1
+        if calls["n"] > 1:
+            raise RuntimeError("HTTP 409 from POST /execute/browser: session gone")
+        return {"success": True, "data": {}}
+
+    _patch_exec(monkeypatch, flaky)
+    report = run_replay([DOWNLOAD_OP], profile_slug="icici", token="tok")
+
+    assert report["status"] == "login_required"
+    assert report["operations"][0]["steps"][0]["status"] == OK
+    assert report["installable"] is False
+
+
+def test_a_replay_that_reaches_the_goal_is_still_not_installable(monkeypatch):
+    _patch_exec(
+        monkeypatch,
+        lambda _p, c, _params, **_k: {
+            "success": True,
+            "data": {"downloads": [{"id": "dl-1"}]} if c == "list_downloads" else {},
+        },
+    )
+    report = run_replay([DOWNLOAD_OP], profile_slug="icici", token="tok")
+
+    assert report["all_goals_reached"] is True
+    assert report["installable"] is False  # only approve() sets this
+
+
+def test_placeholders_are_filled_with_the_recorded_default():
+    # Typing a literal "{{from_date}}" into a bank's date field would fail for a
+    # reason that has nothing to do with the plan.
+    op = {
+        "parameters": [{"name": "from_date", "default": "2026-01-01"}],
+        "steps": [{"command": "type_text", "params": {"selector": "#d", "text": "{{from_date}}"}}],
+    }
+    assert substitute_parameters(op)[0]["params"]["text"] == "2026-01-01"
+
+
+def test_a_caller_supplied_value_wins_over_the_recorded_default():
+    op = {
+        "parameters": [{"name": "from_date", "default": "2026-01-01"}],
+        "steps": [{"command": "type_text", "params": {"selector": "#d", "text": "{{from_date}}"}}],
+    }
+    filled = substitute_parameters(op, {"from_date": "2025-04-01"})
+    assert filled[0]["params"]["text"] == "2025-04-01"

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -84,6 +84,46 @@ def test_reading_a_page_is_never_risky_whatever_it_says():
     assert classify_risk({"command": "screenshot", "params": {}}, recorded_controls=set()) is None
 
 
+def test_a_coordinate_click_or_keypress_with_no_control_is_stopped():
+    # The fail-open the risk gate must not have: a click_at (x,y) or a press_key
+    # on the focused element names no control, so ground 2 (identity) and ground 1
+    # (text) both find nothing and would wave it through -- the exact improvisation
+    # that could land on Pay/Transfer. It carries no identity, so it also cannot
+    # be in recorded_controls. Fail closed.
+    for keyless in (
+        {"command": "click_at", "params": {"x": 120, "y": 44}},
+        {"command": "press_key", "params": {"key": "Enter"}},
+    ):
+        risk = classify_risk(keyless, recorded_controls=set())
+        assert risk and "cannot identify" in risk, keyless
+
+
+def test_a_page_or_browser_command_with_no_control_is_not_risky():
+    # navigate / scroll_page target no control by nature; an empty identity there
+    # is expected, not a red flag. Only CONTROL actions with no identity are.
+    assert (
+        classify_risk(
+            {"command": "navigate", "params": {"url": "https://x.test/next"}},
+            recorded_controls=set(),
+        )
+        is None
+    )
+    assert (
+        classify_risk(
+            {"command": "scroll_page", "params": {"direction": "down"}}, recorded_controls=set()
+        )
+        is None
+    )
+
+
+def test_money_moving_words_the_original_list_missed_are_stopped():
+    # Widened after review: add-beneficiary / withdraw / buy-sell-redeem are the
+    # same irreversible, money-moving class the gate exists to catch.
+    for label in ("Add Beneficiary", "Withdraw Cash", "Buy units", "Redeem now", "New Payee"):
+        risk = classify_risk(step(text=label), recorded_controls={f"text:{label.lower()}"})
+        assert risk is not None, label
+
+
 def test_recorded_controls_come_from_the_draft_itself():
     # The draft is compiled from the recording, so its steps ARE what the human
     # did — no separate bookkeeping to drift out of date.

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -459,3 +459,39 @@ def test_a_file_left_by_an_earlier_run_is_not_this_ones_evidence(monkeypatch):
     report = run_replay([DOWNLOAD_OP], profile_slug="icici", token="tok")
 
     assert report["all_goals_reached"] is False
+
+
+def test_an_operation_that_ran_nothing_reached_no_goal():
+    """The most misleading answer this field can give.
+
+    A replay that executed zero steps reported goal_reached true and
+    all_goals_reached true, because "no step was blocked" is trivially satisfied
+    by an empty list — a report nobody would question.
+    """
+    from noui_core.verify.replay import goal_reached
+
+    assert goal_reached({"name": "r", "kind": "read"}, []) is False
+    assert goal_reached({"name": "d", "kind": "download"}, []) is False
+
+
+def test_a_mixture_of_segmented_and_unsegmented_operations_is_refused(monkeypatch):
+    """Segments decide how the WHOLE replay executes.
+
+    One operation without a segment silently downgraded every operation to the
+    legacy reset-before-each path. Seen live: a stray `read_overview` turned a
+    five-operation run into one that executed nothing and reported every goal
+    reached, with nothing in the report saying the model had changed.
+    """
+    from noui_core.verify import session as session_mod
+
+    monkeypatch.setattr(session_mod, "_executor", lambda *a, **k: (lambda c, p=None: {"data": {}}))
+    report = session_mod.run_replay(
+        [
+            {"name": "a", "tool": "call_web_browser", "steps": [], "segment_steps": []},
+            {"name": "b", "tool": "call_web_browser", "steps": []},   # no segment
+        ],
+        profile_slug="p", token="t", entry_url="https://x.test/home",
+    )
+
+    assert report["status"] == "not_replayable"
+    assert "b" in report["detail"]

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -379,8 +379,13 @@ def test_a_download_still_in_flight_or_failed_is_not_evidence():
 
     op = {"name": "d", "kind": "download"}
     for state in ("in_progress", "failed"):
-        steps = [{"status": "ok", "command": "list_downloads",
-                  "data": {"downloads": [{"id": "dl-1", "state": state}]}}]
+        steps = [
+            {
+                "status": "ok",
+                "command": "list_downloads",
+                "data": {"downloads": [{"id": "dl-1", "state": state}]},
+            }
+        ]
         assert goal_reached(op, steps) is False, state
 
 
@@ -398,8 +403,11 @@ def test_a_download_operation_is_judged_by_its_file_not_its_step_list():
     steps = [
         {"status": "ok", "command": "click_element"},
         {"status": "blocked", "command": "click_element"},
-        {"status": "ok", "command": "list_downloads",
-         "data": {"downloads": [{"id": "dl-7", "state": "completed", "size_bytes": 85216}]}},
+        {
+            "status": "ok",
+            "command": "list_downloads",
+            "data": {"downloads": [{"id": "dl-7", "state": "completed", "size_bytes": 85216}]},
+        },
     ]
     assert goal_reached(op, steps) is True
 
@@ -422,8 +430,11 @@ def test_an_unanswered_approval_still_stops_a_download():
     op = {"name": "download_statement", "kind": "download"}
     steps = [
         {"status": "needs_approval", "command": "click_element"},
-        {"status": "ok", "command": "list_downloads",
-         "data": {"downloads": [{"id": "dl-9", "state": "completed"}]}},
+        {
+            "status": "ok",
+            "command": "list_downloads",
+            "data": {"downloads": [{"id": "dl-9", "state": "completed"}]},
+        },
     ]
     assert goal_reached(op, steps) is False
 
@@ -484,13 +495,15 @@ def test_a_mixture_of_segmented_and_unsegmented_operations_is_refused(monkeypatc
     """
     from noui_core.verify import session as session_mod
 
-    monkeypatch.setattr(session_mod, "_executor", lambda *a, **k: (lambda c, p=None: {"data": {}}))
+    monkeypatch.setattr(session_mod, "_executor", lambda *a, **k: lambda c, p=None: {"data": {}})
     report = session_mod.run_replay(
         [
             {"name": "a", "tool": "call_web_browser", "steps": [], "segment_steps": []},
-            {"name": "b", "tool": "call_web_browser", "steps": []},   # no segment
+            {"name": "b", "tool": "call_web_browser", "steps": []},  # no segment
         ],
-        profile_slug="p", token="t", entry_url="https://x.test/home",
+        profile_slug="p",
+        token="t",
+        entry_url="https://x.test/home",
     )
 
     assert report["status"] == "not_replayable"

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -116,6 +116,31 @@ def test_a_page_or_browser_command_with_no_control_is_not_risky():
     )
 
 
+def test_a_recorded_role_addressed_control_is_not_mistaken_for_anchorless():
+    # set_checked {role, name} (a radio with no unique CSS selector — the ICICI
+    # "Annual" statement radio) IS a named control the recording saw. It must land
+    # in recorded_controls and replay freely, not be stopped as a control the
+    # recording cannot identify.
+    annual = step("set_checked", role="radio", name="Annual")
+    recorded = recorded_controls([{"steps": [annual]}])
+    assert recorded == {"role:radio|annual"}
+    assert classify_risk(annual, recorded_controls=recorded) is None
+
+
+def test_a_role_named_control_the_human_never_touched_is_still_stopped():
+    # The fix backs RECORDED role controls; an improvised one the recording never
+    # saw still trips ground 2.
+    ghost = step("set_checked", role="radio", name="Something else")
+    assert classify_risk(ghost, recorded_controls={"role:radio|annual"}) is not None
+
+
+def test_a_risky_role_named_control_is_stopped_by_its_name():
+    # A money-moving control addressed by role+name carries its words in `name`;
+    # ground 1 must read it there too.
+    risky = step("set_checked", role="radio", name="Transfer funds")
+    assert classify_risk(risky, recorded_controls={"role:radio|transfer funds"}) is not None
+
+
 def test_money_moving_words_the_original_list_missed_are_stopped():
     # Widened after review: add-beneficiary / withdraw / buy-sell-redeem are the
     # same irreversible, money-moving class the gate exists to catch.

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -370,3 +370,56 @@ def test_a_download_still_in_flight_or_failed_is_not_evidence():
         steps = [{"status": "ok", "command": "list_downloads",
                   "data": {"downloads": [{"id": "dl-1", "state": state}]}}]
         assert goal_reached(op, steps) is False, state
+
+
+def test_a_download_operation_is_judged_by_its_file_not_its_step_list():
+    """The annual replay produced the right statement and reported failure.
+
+    The file arrived through #PDF_Download; a later click on a control the page
+    had already moved past was recorded as blocked, and any blocked step made
+    goal_reached false. That describes the plan, not the outcome — and the
+    outcome is what this field is for. The blocked steps stay in the report.
+    """
+    from noui_core.verify.replay import goal_reached
+
+    op = {"name": "download_statement", "kind": "download"}
+    steps = [
+        {"status": "ok", "command": "click_element"},
+        {"status": "blocked", "command": "click_element"},
+        {"status": "ok", "command": "list_downloads",
+         "data": {"downloads": [{"id": "dl-7", "state": "completed", "size_bytes": 85216}]}},
+    ]
+    assert goal_reached(op, steps) is True
+
+
+def test_a_blocked_download_with_no_file_is_still_a_failure():
+    from noui_core.verify.replay import goal_reached
+
+    op = {"name": "download_statement", "kind": "download"}
+    steps = [
+        {"status": "blocked", "command": "click_element"},
+        {"status": "ok", "command": "list_downloads", "data": {"downloads": []}},
+    ]
+    assert goal_reached(op, steps) is False
+
+
+def test_an_unanswered_approval_still_stops_a_download():
+    """A human has not agreed to the thing being asked about."""
+    from noui_core.verify.replay import goal_reached
+
+    op = {"name": "download_statement", "kind": "download"}
+    steps = [
+        {"status": "needs_approval", "command": "click_element"},
+        {"status": "ok", "command": "list_downloads",
+         "data": {"downloads": [{"id": "dl-9", "state": "completed"}]}},
+    ]
+    assert goal_reached(op, steps) is False
+
+
+def test_a_read_operation_is_still_judged_by_its_steps():
+    """Only a download has evidence of its own; everything else has the steps."""
+    from noui_core.verify.replay import goal_reached
+
+    op = {"name": "read_page", "kind": "read"}
+    assert goal_reached(op, [{"status": "blocked", "command": "click_element"}]) is False
+    assert goal_reached(op, [{"status": "ok", "command": "get_page_summary"}]) is True

--- a/tests/test_replay_entry_point.py
+++ b/tests/test_replay_entry_point.py
@@ -505,3 +505,18 @@ def test_the_query_string_does_not_hide_a_match():
          "expect": {"url": ENTRY + "?ref=nav"}}]}]
     got = session_mod._recorded_way_back(ops, ENTRY)
     assert got == {"command": "click_element", "params": {"selector": "#home"}}
+
+
+def test_the_origin_map_uses_the_page_before_the_first_hop():
+    # The compiler gets the WORKFLOW slice, whose first transition is already
+    # /overview -> /credit-card. Reading destinations alone made the
+    # net-banking entry /credit-card — the page the first step is trying to
+    # reach, not the one it acts on.
+    from noui_core.compile import browser_skill
+
+    got = browser_skill.entry_urls_by_origin([
+        {"seq": 4, "from_url": ENTRY, "to_url": CC},
+        {"seq": 13, "from_url": CC, "to_url": PORTAL},
+    ])
+    assert got["https://retailnetbanking.icici.bank.in"] == ENTRY
+    assert got["https://infinity.icici.bank.in"] == PORTAL

--- a/tests/test_replay_entry_point.py
+++ b/tests/test_replay_entry_point.py
@@ -86,7 +86,7 @@ def test_failed_reset_is_reported_as_the_reset_not_as_step_zero():
     b = _Browser(DRIFTED, navigate_fails=True)
     failed = session_mod._return_to_entry(b, ENTRY)
     assert failed is not None
-    assert failed["command"] == "navigate"
+    assert failed["command"] == "return_to_entry"
     assert failed["status"] == "blocked"
     # The report must say where the browser actually was — that is the fact that
     # explains every step failure underneath it.
@@ -162,3 +162,91 @@ def test_the_compiler_stamps_what_entry_url_for_returns():
         )
     )
     assert doc["entry_url"] == ENTRY
+
+
+# --- navigate is not always available -----------------------------------------
+#
+# First live run of this reset: it used `navigate`, which the worker refuses on
+# an app that carries its session in the URL -- "a full-page load destroys its
+# session". The compiled SKILL.md says the same thing to the agent. The reset
+# was built without checking that the command it chose was one the app allows.
+
+_DISABLED = RuntimeError(
+    "execute/browser 'navigate' failed: navigate is disabled for this app: "
+    "a full-page load destroys its session"
+)
+
+
+class _NoNavigate(_Browser):
+    """An ICICI-shaped app: navigate refused, a home link in the summary."""
+
+    def __init__(self, at, summary):
+        super().__init__(at)
+        self.summary = summary
+
+    def __call__(self, command, params):
+        if command == "navigate":
+            self.calls.append((command, params))
+            raise _DISABLED
+        if command == "get_page_summary":
+            self.calls.append((command, params))
+            return {"data": self.summary}
+        if command == "click_element":
+            self.calls.append((command, params))
+            self.at = ENTRY  # the app's own route change
+            return {"data": {}}
+        return super().__call__(command, params)
+
+
+HOME_LINK = {"links": [{"text": "", "href": "/overview", "selector": "a.logo"}]}
+
+
+def test_when_navigate_is_refused_the_reset_clicks_the_way_back():
+    b = _NoNavigate(DRIFTED, HOME_LINK)
+    assert session_mod._return_to_entry(b, ENTRY) is None
+    assert "click_element" in b.commands
+    assert b.at == ENTRY
+
+
+def test_the_home_control_is_found_by_where_it_points_not_what_it_says():
+    # It is usually a logo with no text at all. Matching words would need a list
+    # per language and per bank.
+    got = session_mod._home_control(HOME_LINK, ENTRY)
+    assert got == {"command": "click_element", "params": {"selector": "a.logo"}}
+
+
+def test_a_link_to_somewhere_else_is_not_the_way_back():
+    other = {"links": [{"text": "Cards", "href": "/credit-card", "selector": "a.cc"}]}
+    assert session_mod._home_control(other, ENTRY) is None
+
+
+def test_no_way_back_is_reported_with_the_reason():
+    b = _NoNavigate(DRIFTED, {"links": [], "buttons": []})
+    failed = session_mod._return_to_entry(b, ENTRY)
+    assert failed is not None
+    assert "does not allow navigate" in failed["error"]
+    assert DRIFTED in failed["error"]
+
+
+def test_a_click_that_does_not_land_at_the_start_is_not_treated_as_success():
+    class _Wanders(_NoNavigate):
+        def __call__(self, command, params):
+            if command == "click_element":
+                self.calls.append((command, params))
+                self.at = "https://retailnetbanking.icici.bank.in/somewhere-else"
+                return {"data": {}}
+            return super().__call__(command, params)
+
+    b = _Wanders(DRIFTED, HOME_LINK)
+    failed = session_mod._return_to_entry(b, ENTRY)
+    assert failed is not None
+    assert "did not land on the start" in failed["error"]
+
+
+def test_a_real_navigate_failure_is_not_mistaken_for_the_refusal():
+    # Only the "navigate is disabled" refusal earns the click fallback; anything
+    # else is a genuine failure and must be reported, not worked around.
+    b = _Browser(DRIFTED, navigate_fails=True)
+    failed = session_mod._return_to_entry(b, ENTRY)
+    assert failed is not None
+    assert "get_page_summary" not in b.commands

--- a/tests/test_replay_entry_point.py
+++ b/tests/test_replay_entry_point.py
@@ -361,3 +361,42 @@ def test_history_that_never_reaches_the_entry_is_bounded():
     b = _History(deep)
     session_mod._return_to_entry(b, ENTRY)
     assert b.commands.count("go_back") <= session_mod._MAX_BACK_STEPS
+
+
+# --- history does not stop at the landing page ---------------------------------
+#
+# Measured on ICICI: from /overview one back press lands on /login-page, another
+# on about:blank. A signed-in session walked to its own sign-in page looks
+# exactly like being logged out — and pressing on abandons the app entirely.
+
+LOGIN_PG = "https://retailnetbanking.icici.bank.in/login-page"
+
+
+def test_the_walk_stops_before_the_sign_in_page():
+    b = _History([ "about:blank", LOGIN_PG, ENTRY, DRIFTED])
+    # Deliberately ask for a page that is NOT in the stack, so the walk would
+    # keep pressing if nothing stopped it.
+    missing = "https://retailnetbanking.icici.bank.in/nowhere"
+    session_mod._return_to_entry(b, missing, {missing})
+    assert b.at != "about:blank", "walked out of the app"
+    assert b.at in (LOGIN_PG, ENTRY, DRIFTED)
+    assert b.commands.count("go_back") <= 2
+
+
+def test_leaving_the_app_is_detected():
+    known = {ENTRY}
+    assert session_mod._left_the_app("about:blank", ENTRY, known) is True
+    assert session_mod._left_the_app(LOGIN_PG, ENTRY, known) is True
+    assert session_mod._left_the_app("https://example.test/x", ENTRY, known) is True
+
+
+def test_a_recorded_page_on_another_origin_is_not_leaving():
+    # The statement portal IS part of the journey, on a different host. Treating
+    # a cross-origin recorded page as "left the app" would stop the walk at the
+    # very page it needs to walk back from.
+    portal = "https://infinity.icici.bank.in/corp/AuthenticationController"
+    assert session_mod._left_the_app(portal + ";jsessionid=abc", ENTRY, {portal}) is False
+
+
+def test_an_ordinary_deeper_page_is_not_leaving():
+    assert session_mod._left_the_app(DRIFTED, ENTRY, {ENTRY}) is False

--- a/tests/test_replay_entry_point.py
+++ b/tests/test_replay_entry_point.py
@@ -442,3 +442,66 @@ def test_the_compiler_emits_one_entry_per_host():
     ])
     assert got["https://retailnetbanking.icici.bank.in"] == ENTRY   # not /login-page
     assert got["https://infinity.icici.bank.in"] == PORTAL          # the FIRST one
+
+
+# --- repositioning by click, and being honest about which click ----------------
+#
+# On a browser-driven app navigate is banned — a full load destroys the session —
+# so a click is how you reposition. WHICH click matters: one the recording
+# watched arrive at this page is evidence; one hunted from the live page is a
+# guess, and must not pass as the former.
+
+RECORDED_OPS = [
+    {
+        "name": "read_overview",
+        "steps": [
+            {"command": "click_by_text", "params": {"text": "Home"},
+             "expect": {"url": ENTRY}},
+            {"command": "get_page_summary", "params": {}},
+        ],
+    }
+]
+
+
+def test_a_recorded_control_is_preferred_over_hunting_the_page():
+    class _B(_NoNavigate):
+        def __call__(self, command, params):
+            if command == "click_by_text" and params.get("text") == "Home":
+                self.calls.append((command, params))
+                self.at = ENTRY
+                return {"data": {}}
+            return super().__call__(command, params)
+
+    b = _B(DRIFTED, HOME_LINK)
+    notes: list = []
+    assert session_mod._return_to_entry(
+        b, ENTRY, {ENTRY}, None, RECORDED_OPS, notes
+    ) is None
+    assert ("click_by_text", {"text": "Home"}) in b.calls
+    assert "get_page_summary" not in b.commands, "should not hunt when evidence exists"
+    assert notes == [], "a recorded control is not an unobserved reset"
+
+
+def test_the_live_page_fallback_is_recorded_as_unobserved():
+    b = _NoNavigate(DRIFTED, HOME_LINK)
+    notes: list = []
+    assert session_mod._return_to_entry(b, ENTRY, {ENTRY}, None, [], notes) is None
+    assert len(notes) == 1
+    assert notes[0]["kind"] == "unobserved_reset"
+    assert notes[0]["entry_url"] == ENTRY
+    assert "a.logo" in str(notes[0]["control"])
+
+
+def test_a_recorded_control_for_another_page_is_not_used():
+    ops = [{"name": "x", "steps": [
+        {"command": "click_by_text", "params": {"text": "Cards"},
+         "expect": {"url": DRIFTED}}]}]
+    assert session_mod._recorded_way_back(ops, ENTRY) is None
+
+
+def test_the_query_string_does_not_hide_a_match():
+    ops = [{"name": "x", "steps": [
+        {"command": "click_element", "params": {"selector": "#home"},
+         "expect": {"url": ENTRY + "?ref=nav"}}]}]
+    got = session_mod._recorded_way_back(ops, ENTRY)
+    assert got == {"command": "click_element", "params": {"selector": "#home"}}

--- a/tests/test_replay_entry_point.py
+++ b/tests/test_replay_entry_point.py
@@ -51,7 +51,8 @@ class _Browser:
 def test_drifted_browser_is_returned_to_the_entry_point():
     b = _Browser(DRIFTED)
     assert session_mod._return_to_entry(b, ENTRY) is None
-    assert b.commands == ["get_page_info", "navigate"]
+    # History is tried first — same tab, same cookies — then navigate.
+    assert b.commands == ["get_page_info", "go_back", "navigate"]
     assert b.at == ENTRY
 
 
@@ -79,7 +80,8 @@ def test_unreadable_url_navigates_rather_than_guessing():
 
     b = _Blind(DRIFTED)
     assert session_mod._return_to_entry(b, ENTRY) is None
-    assert b.commands == ["get_page_info", "navigate"]
+    # History is tried first — same tab, same cookies — then navigate.
+    assert b.commands == ["get_page_info", "go_back", "navigate"]
 
 
 def test_failed_reset_is_reported_as_the_reset_not_as_step_zero():
@@ -297,3 +299,65 @@ def test_an_ordinary_app_page_is_still_a_reset_not_a_sign_in():
     b = _Browser(DRIFTED)
     assert session_mod._return_to_entry(b, ENTRY) is None
     assert "navigate" in b.commands
+
+
+# --- walking history home ------------------------------------------------------
+#
+# A recorded journey can cross origins: ICICI's statement portal is a different
+# host from the net-banking SPA. From there nothing links back to the landing
+# page and navigate is refused, so every operation after the first had no way
+# home and the reset failed six times in a row.
+
+
+class _History(_Browser):
+    """A back stack. goBack pops it; navigate is refused, as on ICICI."""
+
+    def __init__(self, stack):
+        super().__init__(stack[-1])
+        self.stack = list(stack)
+
+    def __call__(self, command, params):
+        if command == "go_back":
+            self.calls.append((command, params))
+            moved = len(self.stack) > 1
+            if moved:
+                self.stack.pop()
+                self.at = self.stack[-1]
+            return {"data": {"url": self.at, "moved": moved}}
+        if command == "navigate":
+            self.calls.append((command, params))
+            raise _DISABLED
+        return super().__call__(command, params)
+
+
+def test_history_walks_back_to_the_entry_page():
+    portal = "https://infinity.icici.bank.in/corp/AuthenticationController"
+    b = _History([ENTRY, portal])
+    # known_urls is what run_replay supplies: the portal is a page the recording
+    # visited, so "auth" in its path must not read as a sign-in screen.
+    assert session_mod._return_to_entry(b, ENTRY, {portal}) is None
+    assert b.at == ENTRY
+    assert "navigate" not in b.commands, "history got there; nothing else should be tried"
+
+
+def test_history_is_tried_before_navigate():
+    b = _History([ENTRY, DRIFTED])
+    session_mod._return_to_entry(b, ENTRY)
+    assert b.commands.index("go_back") < len(b.commands)
+    assert b.commands[1] == "go_back"
+
+
+def test_exhausted_history_stops_instead_of_pressing_back_forever():
+    # moved=False means there is nowhere further back. Walking on would only
+    # waste calls, and eventually leave the app entirely.
+    portal = "https://infinity.icici.bank.in/corp/AuthenticationController"
+    b = _History([portal])
+    session_mod._return_to_entry(b, ENTRY, {portal})
+    assert b.commands.count("go_back") == 1
+
+
+def test_history_that_never_reaches_the_entry_is_bounded():
+    deep = [f"https://infinity.icici.bank.in/corp/p{n}" for n in range(30)]
+    b = _History(deep)
+    session_mod._return_to_entry(b, ENTRY)
+    assert b.commands.count("go_back") <= session_mod._MAX_BACK_STEPS

--- a/tests/test_replay_entry_point.py
+++ b/tests/test_replay_entry_point.py
@@ -1,0 +1,122 @@
+"""A replay restarts the recorded journey; it does not resume it.
+
+Observed on ICICI (run 050970d3): the first replay died mid-journey, an
+amendment fixed the step it died on, and the re-run began on
+`/credit-card/add-card` -- where the browser had been abandoned. The early steps
+that had already passed then matched nothing, so the amendment looked no better
+than the selector it replaced. The session is deliberately kept warm between
+replays, which is what leaves the browser somewhere.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+
+from noui_core.verify import session as session_mod  # noqa: E402
+from noui_core.verify.replay import SessionNotReadyError  # noqa: E402
+
+ENTRY = "https://retailnetbanking.icici.bank.in/overview"
+DRIFTED = "https://retailnetbanking.icici.bank.in/credit-card/add-card"
+
+
+class _Browser:
+    """Records what replay asked of the page, and where the page says it is."""
+
+    def __init__(self, at: str, *, navigate_fails: bool = False):
+        self.at = at
+        self.navigate_fails = navigate_fails
+        self.calls: list[tuple[str, dict]] = []
+
+    def __call__(self, command: str, params: dict) -> dict:
+        self.calls.append((command, params))
+        if command == "get_page_info":
+            return {"data": {"url": self.at}}
+        if command == "navigate":
+            if self.navigate_fails:
+                raise RuntimeError("net::ERR_ABORTED")
+            self.at = params["url"]
+            return {"data": {}}
+        return {"data": {}}
+
+    @property
+    def commands(self) -> list[str]:
+        return [c for c, _ in self.calls]
+
+
+def test_drifted_browser_is_returned_to_the_entry_point():
+    b = _Browser(DRIFTED)
+    assert session_mod._return_to_entry(b, ENTRY) is None
+    assert b.commands == ["get_page_info", "navigate"]
+    assert b.at == ENTRY
+
+
+def test_already_at_the_entry_point_costs_no_page_load():
+    # A fresh session lands here. Reloading would only spend time and risk
+    # re-running whatever the landing page does on load.
+    b = _Browser(ENTRY)
+    assert session_mod._return_to_entry(b, ENTRY) is None
+    assert b.commands == ["get_page_info"]
+
+
+def test_trailing_slash_is_not_a_different_page():
+    b = _Browser(ENTRY + "/")
+    assert session_mod._return_to_entry(b, ENTRY) is None
+    assert b.commands == ["get_page_info"]
+
+
+def test_unreadable_url_navigates_rather_than_guessing():
+    class _Blind(_Browser):
+        def __call__(self, command, params):
+            if command == "get_page_info":
+                self.calls.append((command, params))
+                raise RuntimeError("page closed")
+            return super().__call__(command, params)
+
+    b = _Blind(DRIFTED)
+    assert session_mod._return_to_entry(b, ENTRY) is None
+    assert b.commands == ["get_page_info", "navigate"]
+
+
+def test_failed_reset_is_reported_as_the_reset_not_as_step_zero():
+    b = _Browser(DRIFTED, navigate_fails=True)
+    failed = session_mod._return_to_entry(b, ENTRY)
+    assert failed is not None
+    assert failed["command"] == "navigate"
+    assert failed["status"] == "blocked"
+    # The report must say where the browser actually was — that is the fact that
+    # explains every step failure underneath it.
+    assert DRIFTED in failed["error"]
+    assert ENTRY in failed["error"]
+
+
+def test_no_session_during_reset_stays_a_login_prompt():
+    # Not a blocked step: there is nothing to blame the plan for.
+    def execute(command, params):
+        raise SessionNotReadyError("HTTP 409 from POST /execute/browser")
+
+    try:
+        session_mod._return_to_entry(execute, ENTRY)
+    except SessionNotReadyError:
+        return
+    raise AssertionError("expected SessionNotReadyError to propagate")
+
+
+def test_compiler_stamps_the_first_page_as_the_entry_point():
+    from noui_core.compile import browser_skill
+
+    doc = json.loads(
+        browser_skill.render_browser_operations_json(
+            [
+                {"name": "read_overview", "url": ENTRY, "steps": []},
+                {"name": "read_credit_card", "url": DRIFTED, "steps": []},
+            ],
+            profile_slug="icici-credit-card-statement",
+            terminal_ops=[],
+        )
+    )
+    assert doc["entry_url"] == ENTRY

--- a/tests/test_replay_entry_point.py
+++ b/tests/test_replay_entry_point.py
@@ -20,6 +20,9 @@ sys.path.insert(0, str(_ROOT / "skills" / "noui"))
 from noui_core.verify import session as session_mod  # noqa: E402
 from noui_core.verify.replay import SessionNotReadyError  # noqa: E402
 
+# Tests drive fakes: a real settle would add seconds per case for no signal.
+session_mod._RESET_SETTLE_MS = 0
+
 ENTRY = "https://retailnetbanking.icici.bank.in/overview"
 DRIFTED = "https://retailnetbanking.icici.bank.in/credit-card/add-card"
 
@@ -520,3 +523,61 @@ def test_the_origin_map_uses_the_page_before_the_first_hop():
     ])
     assert got["https://retailnetbanking.icici.bank.in"] == ENTRY
     assert got["https://infinity.icici.bank.in"] == PORTAL
+
+
+# --- letting the entry page paint after a reset --------------------------------
+#
+# A history restore does not render instantly. The reset landed on /overview,
+# returned success, and the very next step asked whether the sidebar control was
+# visible — on a page still coming up. It resolved and was not yet visible, so
+# every operation after the first failed at step 0 while the reset itself had
+# worked perfectly.
+
+
+def test_the_settle_prefers_what_the_recording_measured():
+    ops = [{"steps": [{"command": "hover", "expect": {"settle_ms": 4322}}]}]
+    assert session_mod._settle_after_reset(ops) == 4.322
+
+
+def test_the_constant_is_only_a_floor():
+    ops = [{"steps": [{"command": "hover", "expect": {"settle_ms": 200}}]}]
+    session_mod._RESET_SETTLE_MS = 3000
+    try:
+        assert session_mod._settle_after_reset(ops) == 3.0
+    finally:
+        session_mod._RESET_SETTLE_MS = 0
+
+
+def test_a_wild_recorded_settle_is_capped():
+    ops = [{"steps": [{"command": "hover", "expect": {"settle_ms": 90_000}}]}]
+    assert session_mod._settle_after_reset(ops) == 10.0
+
+
+def test_only_the_first_step_of_each_operation_counts():
+    # A slow step deep in a flow says nothing about how long the ENTRY page
+    # takes to paint.
+    ops = [{"steps": [
+        {"command": "hover", "expect": {"settle_ms": 100}},
+        {"command": "click_element", "expect": {"settle_ms": 9000}},
+    ]}]
+    session_mod._RESET_SETTLE_MS = 0
+    assert session_mod._settle_after_reset(ops) == 0.1
+
+
+def test_no_recorded_settle_falls_back_to_the_constant():
+    session_mod._RESET_SETTLE_MS = 2500
+    try:
+        assert session_mod._settle_after_reset([]) == 2.5
+    finally:
+        session_mod._RESET_SETTLE_MS = 0
+
+
+def test_already_at_the_entry_does_not_wait():
+    # Nothing moved, so there is nothing to paint. This path must stay free.
+    session_mod._RESET_SETTLE_MS = 5000
+    try:
+        b = _Browser(ENTRY)
+        assert session_mod._return_to_entry(b, ENTRY) is None
+        assert b.commands == ["get_page_info"]
+    finally:
+        session_mod._RESET_SETTLE_MS = 0

--- a/tests/test_replay_entry_point.py
+++ b/tests/test_replay_entry_point.py
@@ -55,7 +55,7 @@ def test_drifted_browser_is_returned_to_the_entry_point():
     b = _Browser(DRIFTED)
     assert session_mod._return_to_entry(b, ENTRY) is None
     # History is tried first — same tab, same cookies — then navigate.
-    assert b.commands == ["get_page_info", "go_back", "navigate"]
+    assert b.commands == ["get_page_info", "navigate"]
     assert b.at == ENTRY
 
 
@@ -84,7 +84,7 @@ def test_unreadable_url_navigates_rather_than_guessing():
     b = _Blind(DRIFTED)
     assert session_mod._return_to_entry(b, ENTRY) is None
     # History is tried first — same tab, same cookies — then navigate.
-    assert b.commands == ["get_page_info", "go_back", "navigate"]
+    assert b.commands == ["get_page_info", "navigate"]
 
 
 def test_failed_reset_is_reported_as_the_reset_not_as_step_zero():
@@ -333,37 +333,8 @@ class _History(_Browser):
         return super().__call__(command, params)
 
 
-def test_history_walks_back_to_the_entry_page():
-    portal = "https://infinity.icici.bank.in/corp/AuthenticationController"
-    b = _History([ENTRY, portal])
-    # known_urls is what run_replay supplies: the portal is a page the recording
-    # visited, so "auth" in its path must not read as a sign-in screen.
-    assert session_mod._return_to_entry(b, ENTRY, {portal}) is None
-    assert b.at == ENTRY
-    assert "navigate" not in b.commands, "history got there; nothing else should be tried"
 
 
-def test_history_is_tried_before_navigate():
-    b = _History([ENTRY, DRIFTED])
-    session_mod._return_to_entry(b, ENTRY)
-    assert b.commands.index("go_back") < len(b.commands)
-    assert b.commands[1] == "go_back"
-
-
-def test_exhausted_history_stops_instead_of_pressing_back_forever():
-    # moved=False means there is nowhere further back. Walking on would only
-    # waste calls, and eventually leave the app entirely.
-    portal = "https://infinity.icici.bank.in/corp/AuthenticationController"
-    b = _History([portal])
-    session_mod._return_to_entry(b, ENTRY, {portal})
-    assert b.commands.count("go_back") == 1
-
-
-def test_history_that_never_reaches_the_entry_is_bounded():
-    deep = [f"https://infinity.icici.bank.in/corp/p{n}" for n in range(30)]
-    b = _History(deep)
-    session_mod._return_to_entry(b, ENTRY)
-    assert b.commands.count("go_back") <= session_mod._MAX_BACK_STEPS
 
 
 # --- history does not stop at the landing page ---------------------------------
@@ -374,16 +345,6 @@ def test_history_that_never_reaches_the_entry_is_bounded():
 
 LOGIN_PG = "https://retailnetbanking.icici.bank.in/login-page"
 
-
-def test_the_walk_stops_before_the_sign_in_page():
-    b = _History([ "about:blank", LOGIN_PG, ENTRY, DRIFTED])
-    # Deliberately ask for a page that is NOT in the stack, so the walk would
-    # keep pressing if nothing stopped it.
-    missing = "https://retailnetbanking.icici.bank.in/nowhere"
-    session_mod._return_to_entry(b, missing, {missing})
-    assert b.at != "about:blank", "walked out of the app"
-    assert b.at in (LOGIN_PG, ENTRY, DRIFTED)
-    assert b.commands.count("go_back") <= 2
 
 
 def test_leaving_the_app_is_detected():
@@ -581,3 +542,24 @@ def test_already_at_the_entry_does_not_wait():
         assert b.commands == ["get_page_info"]
     finally:
         session_mod._RESET_SETTLE_MS = 0
+
+
+def test_the_reset_never_presses_back():
+    """go_back is not a way home; it is a way onto the sign-in page.
+
+    The SPA's back stack on ICICI is [about:blank, /login-page, /overview, ...],
+    so a press from a shallow point lands the LIVE session on the sign-in page —
+    "your session has expired" from the member's side. Watched happening: the
+    session died the moment a replay started, every time, and never while it sat
+    idle.
+    """
+    b = _NoNavigate(DRIFTED, HOME_LINK)
+    session_mod._return_to_entry(b, ENTRY, {ENTRY}, None, [], [])
+    assert "go_back" not in b.commands
+
+
+def test_a_drifted_page_still_gets_reset_without_history():
+    b = _Browser(DRIFTED)
+    assert session_mod._return_to_entry(b, ENTRY) is None
+    assert b.commands == ["get_page_info", "navigate"]
+    assert b.at == ENTRY

--- a/tests/test_replay_entry_point.py
+++ b/tests/test_replay_entry_point.py
@@ -250,3 +250,50 @@ def test_a_real_navigate_failure_is_not_mistaken_for_the_refusal():
     failed = session_mod._return_to_entry(b, ENTRY)
     assert failed is not None
     assert "get_page_summary" not in b.commands
+
+
+# --- a sign-in page is a WAIT, not a plan failure -----------------------------
+#
+# Live run: the browser sat on ICICI's AuthenticationController with LOGIN_FLAG=1
+# and the reset reported "no link back to the start was found on the page" —
+# true, and useless. A login screen has no link to the landing page. The member
+# needs a sign-in card, not a report that their skill is broken.
+
+LOGIN_PAGE = (
+    "https://infinity.icici.bank.in/corp/AuthenticationController"
+    "?FORMSGROUP_ID__=AuthenticationFG&LOGIN_FLAG=1"
+)
+
+
+def test_a_sign_in_page_becomes_login_required_not_a_blocked_step():
+    b = _Browser(LOGIN_PAGE)
+    try:
+        session_mod._return_to_entry(b, ENTRY)
+    except SessionNotReadyError as exc:
+        assert "sign-in flow" in str(exc)
+        # Nothing was attempted against a session that cannot answer.
+        assert b.commands == ["get_page_info"]
+        return
+    raise AssertionError("expected SessionNotReadyError")
+
+
+def test_the_ordinary_login_page_shape_is_caught_too():
+    for url in (
+        "https://retailnetbanking.icici.bank.in/login-page",
+        "https://example.test/auth/signin",
+        "https://example.test/session/verify",
+    ):
+        b = _Browser(url)
+        try:
+            session_mod._return_to_entry(b, ENTRY)
+        except SessionNotReadyError:
+            continue
+        raise AssertionError(f"not detected: {url}")
+
+
+def test_an_ordinary_app_page_is_still_a_reset_not_a_sign_in():
+    # The detector must not swallow a real drift: /credit-card/add-card is a
+    # deep app page, and the answer there is to go back to the start.
+    b = _Browser(DRIFTED)
+    assert session_mod._return_to_entry(b, ENTRY) is None
+    assert "navigate" in b.commands

--- a/tests/test_replay_entry_point.py
+++ b/tests/test_replay_entry_point.py
@@ -400,3 +400,45 @@ def test_a_recorded_page_on_another_origin_is_not_leaving():
 
 def test_an_ordinary_deeper_page_is_not_leaving():
     assert session_mod._left_the_app(DRIFTED, ENTRY, {ENTRY}) is False
+
+
+# --- a reset never changes hosts -----------------------------------------------
+#
+# The recording went forward only — /overview -> /credit-card -> the statement
+# portal — and never walked back, so no route home across hosts was ever
+# observed. Whatever host the browser is on, the reset aims at the first page
+# the recording reached THERE.
+
+PORTAL = "https://infinity.icici.bank.in/corp/AuthenticationController"
+BY_ORIGIN = {
+    "https://retailnetbanking.icici.bank.in": ENTRY,
+    "https://infinity.icici.bank.in": PORTAL,
+}
+
+
+def test_on_the_portal_the_reset_aims_at_the_portal_entry():
+    here = PORTAL + ";jsessionid=abc"
+    assert session_mod._entry_for_origin(here, ENTRY, BY_ORIGIN) == PORTAL
+
+
+def test_on_the_netbanking_host_it_aims_at_overview():
+    assert session_mod._entry_for_origin(DRIFTED, ENTRY, BY_ORIGIN) == ENTRY
+
+
+def test_an_unrecorded_host_falls_back_rather_than_guessing():
+    assert session_mod._entry_for_origin("https://elsewhere.test/x", ENTRY, BY_ORIGIN) == ENTRY
+
+
+def test_without_a_map_behaviour_is_unchanged():
+    assert session_mod._entry_for_origin(PORTAL, ENTRY, None) == ENTRY
+
+
+def test_the_compiler_emits_one_entry_per_host():
+    from noui_core.compile import browser_skill
+
+    got = browser_skill.entry_urls_by_origin(URL_EVENTS + [
+        {"seq": 13, "from_url": CC, "to_url": PORTAL},
+        {"seq": 19, "from_url": PORTAL, "to_url": PORTAL + ";jsessionid=x"},
+    ])
+    assert got["https://retailnetbanking.icici.bank.in"] == ENTRY   # not /login-page
+    assert got["https://infinity.icici.bank.in"] == PORTAL          # the FIRST one

--- a/tests/test_replay_entry_point.py
+++ b/tests/test_replay_entry_point.py
@@ -106,17 +106,59 @@ def test_no_session_during_reset_stays_a_login_prompt():
     raise AssertionError("expected SessionNotReadyError to propagate")
 
 
-def test_compiler_stamps_the_first_page_as_the_entry_point():
+LOGIN = "https://retailnetbanking.icici.bank.in/login-page"
+CC = "https://retailnetbanking.icici.bank.in/credit-card"
+
+# The real transitions from bundle icici-cc-stmt-local-8f23a0f8.
+URL_EVENTS = [
+    {"seq": 1, "from_url": "about:blank", "to_url": LOGIN},
+    {"seq": 3, "from_url": LOGIN, "to_url": ENTRY},
+    {"seq": 4, "from_url": ENTRY, "to_url": CC},
+]
+
+
+def test_the_entry_is_the_page_the_first_step_acts_on_not_the_first_page():
+    """The bug this file's fix shipped with.
+
+    This recording's split kept no /overview page, so pages[0] is /credit-card
+    -- a DESTINATION. Every operation's step 0 is `click_by_text "Credit Cards"`,
+    a click you make FROM /overview. Stamping /credit-card would reset the
+    browser to the page the first click is supposed to reach.
+    """
+    from noui_core.compile import browser_skill
+
+    pages = [{"name": "read_credit_card", "url": CC, "nav": [{"text": "Credit Cards"}]}]
+    assert browser_skill.entry_url_for(URL_EVENTS, pages) == ENTRY
+
+
+def test_a_landing_page_that_survived_compilation_is_the_entry():
+    from noui_core.compile import browser_skill
+
+    pages = [
+        {"name": "read_overview", "url": ENTRY, "nav": None},
+        {"name": "read_credit_card", "url": CC, "nav": [{"text": "Credit Cards"}]},
+    ]
+    assert browser_skill.entry_url_for(URL_EVENTS, pages) == ENTRY
+
+
+def test_an_unreachable_page_does_not_pass_as_the_landing_page():
+    # nav == [] means the driving click could not be recovered — NOT the landing
+    # page. Collapsing the two is the mistake this compiler already made once.
+    from noui_core.compile import browser_skill
+
+    pages = [{"name": "read_credit_card", "url": CC, "nav": []}]
+    assert browser_skill.entry_url_for(URL_EVENTS, pages) == ENTRY
+
+
+def test_the_compiler_stamps_what_entry_url_for_returns():
     from noui_core.compile import browser_skill
 
     doc = json.loads(
         browser_skill.render_browser_operations_json(
-            [
-                {"name": "read_overview", "url": ENTRY, "steps": []},
-                {"name": "read_credit_card", "url": DRIFTED, "steps": []},
-            ],
+            [{"name": "read_credit_card", "url": CC, "steps": []}],
             profile_slug="icici-credit-card-statement",
             terminal_ops=[],
+            entry_url=ENTRY,
         )
     )
     assert doc["entry_url"] == ENTRY

--- a/tests/test_replay_entry_point.py
+++ b/tests/test_replay_entry_point.py
@@ -333,10 +333,6 @@ class _History(_Browser):
         return super().__call__(command, params)
 
 
-
-
-
-
 # --- history does not stop at the landing page ---------------------------------
 #
 # Measured on ICICI: from /overview one back press lands on /login-page, another
@@ -344,7 +340,6 @@ class _History(_Browser):
 # exactly like being logged out — and pressing on abandons the app entirely.
 
 LOGIN_PG = "https://retailnetbanking.icici.bank.in/login-page"
-
 
 
 def test_leaving_the_app_is_detected():
@@ -400,12 +395,15 @@ def test_without_a_map_behaviour_is_unchanged():
 def test_the_compiler_emits_one_entry_per_host():
     from noui_core.compile import browser_skill
 
-    got = browser_skill.entry_urls_by_origin(URL_EVENTS + [
-        {"seq": 13, "from_url": CC, "to_url": PORTAL},
-        {"seq": 19, "from_url": PORTAL, "to_url": PORTAL + ";jsessionid=x"},
-    ])
-    assert got["https://retailnetbanking.icici.bank.in"] == ENTRY   # not /login-page
-    assert got["https://infinity.icici.bank.in"] == PORTAL          # the FIRST one
+    got = browser_skill.entry_urls_by_origin(
+        URL_EVENTS
+        + [
+            {"seq": 13, "from_url": CC, "to_url": PORTAL},
+            {"seq": 19, "from_url": PORTAL, "to_url": PORTAL + ";jsessionid=x"},
+        ]
+    )
+    assert got["https://retailnetbanking.icici.bank.in"] == ENTRY  # not /login-page
+    assert got["https://infinity.icici.bank.in"] == PORTAL  # the FIRST one
 
 
 # --- repositioning by click, and being honest about which click ----------------
@@ -419,8 +417,7 @@ RECORDED_OPS = [
     {
         "name": "read_overview",
         "steps": [
-            {"command": "click_by_text", "params": {"text": "Home"},
-             "expect": {"url": ENTRY}},
+            {"command": "click_by_text", "params": {"text": "Home"}, "expect": {"url": ENTRY}},
             {"command": "get_page_summary", "params": {}},
         ],
     }
@@ -438,9 +435,7 @@ def test_a_recorded_control_is_preferred_over_hunting_the_page():
 
     b = _B(DRIFTED, HOME_LINK)
     notes: list = []
-    assert session_mod._return_to_entry(
-        b, ENTRY, {ENTRY}, None, RECORDED_OPS, notes
-    ) is None
+    assert session_mod._return_to_entry(b, ENTRY, {ENTRY}, None, RECORDED_OPS, notes) is None
     assert ("click_by_text", {"text": "Home"}) in b.calls
     assert "get_page_summary" not in b.commands, "should not hunt when evidence exists"
     assert notes == [], "a recorded control is not an unobserved reset"
@@ -457,16 +452,34 @@ def test_the_live_page_fallback_is_recorded_as_unobserved():
 
 
 def test_a_recorded_control_for_another_page_is_not_used():
-    ops = [{"name": "x", "steps": [
-        {"command": "click_by_text", "params": {"text": "Cards"},
-         "expect": {"url": DRIFTED}}]}]
+    ops = [
+        {
+            "name": "x",
+            "steps": [
+                {
+                    "command": "click_by_text",
+                    "params": {"text": "Cards"},
+                    "expect": {"url": DRIFTED},
+                }
+            ],
+        }
+    ]
     assert session_mod._recorded_way_back(ops, ENTRY) is None
 
 
 def test_the_query_string_does_not_hide_a_match():
-    ops = [{"name": "x", "steps": [
-        {"command": "click_element", "params": {"selector": "#home"},
-         "expect": {"url": ENTRY + "?ref=nav"}}]}]
+    ops = [
+        {
+            "name": "x",
+            "steps": [
+                {
+                    "command": "click_element",
+                    "params": {"selector": "#home"},
+                    "expect": {"url": ENTRY + "?ref=nav"},
+                }
+            ],
+        }
+    ]
     got = session_mod._recorded_way_back(ops, ENTRY)
     assert got == {"command": "click_element", "params": {"selector": "#home"}}
 
@@ -478,10 +491,12 @@ def test_the_origin_map_uses_the_page_before_the_first_hop():
     # reach, not the one it acts on.
     from noui_core.compile import browser_skill
 
-    got = browser_skill.entry_urls_by_origin([
-        {"seq": 4, "from_url": ENTRY, "to_url": CC},
-        {"seq": 13, "from_url": CC, "to_url": PORTAL},
-    ])
+    got = browser_skill.entry_urls_by_origin(
+        [
+            {"seq": 4, "from_url": ENTRY, "to_url": CC},
+            {"seq": 13, "from_url": CC, "to_url": PORTAL},
+        ]
+    )
     assert got["https://retailnetbanking.icici.bank.in"] == ENTRY
     assert got["https://infinity.icici.bank.in"] == PORTAL
 
@@ -517,10 +532,14 @@ def test_a_wild_recorded_settle_is_capped():
 def test_only_the_first_step_of_each_operation_counts():
     # A slow step deep in a flow says nothing about how long the ENTRY page
     # takes to paint.
-    ops = [{"steps": [
-        {"command": "hover", "expect": {"settle_ms": 100}},
-        {"command": "click_element", "expect": {"settle_ms": 9000}},
-    ]}]
+    ops = [
+        {
+            "steps": [
+                {"command": "hover", "expect": {"settle_ms": 100}},
+                {"command": "click_element", "expect": {"settle_ms": 9000}},
+            ]
+        }
+    ]
     session_mod._RESET_SETTLE_MS = 0
     assert session_mod._settle_after_reset(ops) == 0.1
 

--- a/tests/test_replay_expectations.py
+++ b/tests/test_replay_expectations.py
@@ -284,3 +284,67 @@ def test_evidence_comes_from_the_next_step_that_names_a_control():
 
     assert res["status"] == SKIPPED
     assert probed == ["#PDF_Download"]
+
+
+def test_a_control_that_appears_on_the_second_attempt_is_not_a_failure():
+    """The hover menu: its item is not rendered the instant the pointer lands.
+
+    That made the ICICI replay a coin flip — it failed at step 0 about half the
+    time and passed on an immediate retry with nothing changed. Waiting for the
+    page to stop navigating did NOT fix it: the page was not navigating, the
+    menu simply was not up yet.
+    """
+    attempts = {"n": 0}
+
+    def execute(command, params=None):
+        if command == "wait_for_selector":
+            return {"success": True}
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            return {"success": False, "error": "this control is on the page but not visible"}
+        return {"success": True, "data": {"clicked": True}}
+
+    step = {"command": "click_element", "params": {"selector": "a.sub-menu-list-item-link"}}
+    res = replay_step(execute, step, recorded={_control_identity(step)})
+
+    assert res["status"] == OK
+    assert res["detail"] == "succeeded on a second attempt"
+    assert attempts["n"] == 2
+
+
+def test_the_retry_happens_before_deciding_the_page_moved_past_it():
+    """A control that appears on the second attempt was never moved past."""
+    attempts = {"n": 0}
+    probed = []
+
+    def execute(command, params=None):
+        if command == "wait_for_selector":
+            probed.append((params or {}).get("selector"))
+            return {"success": True}
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            return {"success": False, "error": "this control is on the page but not visible"}
+        return {"success": True, "data": {}}
+
+    step = {"command": "click_element", "params": {"selector": "#slow"}}
+    res = replay_step(
+        execute, step, recorded={_control_identity(step)},
+        following=[{"command": "click_element", "params": {"selector": "#later"}}],
+    )
+
+    assert res["status"] == OK
+    assert probed == []          # never had to ask whether we had moved past it
+
+
+def test_a_control_that_stays_unreachable_still_blocks():
+    def execute(command, params=None):
+        if command == "wait_for_selector":
+            return {"success": False, "error": "Timeout"}
+        return {"success": False, "error": "this control is on the page but not visible"}
+
+    step = {"command": "click_element", "params": {"selector": "#gone"}}
+    res = replay_step(
+        execute, step, recorded={_control_identity(step)},
+        following=[{"command": "click_element", "params": {"selector": "#later"}}],
+    )
+    assert res["status"] == BLOCKED

--- a/tests/test_replay_expectations.py
+++ b/tests/test_replay_expectations.py
@@ -1,0 +1,98 @@
+"""Replay checks it ended where the recording ended.
+
+`expect` was carried into the result and never evaluated, so a replay could
+execute every step, land on a completely different page, and report success —
+"no step was blocked" was the whole test. That is how a run clicked its way onto
+/discover and still called itself passing.
+"""
+
+from noui_core.verify.replay import (
+    BLOCKED,
+    OK,
+    _control_identity,
+    expectation_unmet,
+    replay_step,
+)
+
+
+def _exec(pages=None, downloads=None):
+    """A fake executor: records commands, answers page-info/list-downloads."""
+    calls = []
+
+    def run(command, params=None):
+        calls.append(command)
+        if command == "get_page_info":
+            return {"success": True, "data": {"url": (pages or [""])[0]}}
+        if command == "list_downloads":
+            return {"success": True, "data": {"downloads": downloads or []}}
+        return {"success": True, "data": {}}
+
+    run.calls = calls  # type: ignore[attr-defined]
+    return run
+
+
+def test_a_step_that_lands_on_the_wrong_page_is_blocked():
+    step = {
+        "command": "click_element",
+        "params": {"selector": "#statements"},
+        "expect": {"url": "https://bank.test/statements"},
+    }
+    res = replay_step(
+        _exec(pages=["https://bank.test/discover"]), step, recorded={_control_identity(step)}
+    )
+    assert res["status"] == BLOCKED
+    assert "discover" in res["detail"] and "statements" in res["detail"]
+
+
+def test_the_recorded_page_still_passes_when_the_portal_adds_its_own_query():
+    # Session tokens churn between the recording and the replay; the route is
+    # what was recorded, not the parameters hung off it.
+    step = {
+        "command": "click_element",
+        "params": {"selector": "#s"},
+        "expect": {"url": "https://bank.test/statements"},
+    }
+    res = replay_step(
+        _exec(pages=["https://bank.test/statements?tok=NEW"]),
+        step,
+        recorded={_control_identity(step)},
+    )
+    assert res["status"] == OK
+
+
+def test_a_download_step_that_produced_no_file_is_blocked():
+    step = {"command": "click_element", "params": {"selector": "#dl"}, "expect": {"download": True}}
+    res = replay_step(_exec(downloads=[]), step, recorded={_control_identity(step)})
+    assert res["status"] == BLOCKED
+    assert "no file arrived" in res["detail"]
+
+
+def test_a_download_step_passes_when_the_file_arrives():
+    step = {"command": "click_element", "params": {"selector": "#dl"}, "expect": {"download": True}}
+    res = replay_step(
+        _exec(downloads=[{"suggested_filename": "statement.pdf"}]),
+        step,
+        recorded={_control_identity(step)},
+    )
+    assert res["status"] == OK
+
+
+def test_a_step_with_no_expectation_is_left_alone():
+    # Most steps carry none; they must not pay for a page-info round trip.
+    run = _exec()
+    res = replay_step(
+        run,
+        {"command": "click_element", "params": {"selector": "#x"}},
+        recorded={_control_identity({"command": "click_element", "params": {"selector": "#x"}})},
+    )
+    assert res["status"] == OK
+    assert "get_page_info" not in run.calls
+
+
+def test_an_unreadable_url_is_not_treated_as_a_failed_expectation():
+    def broken(command, params=None):
+        if command == "get_page_info":
+            raise RuntimeError("page closed")
+        return {"success": True, "data": {}}
+
+    assert expectation_unmet({"url": "https://bank.test/x"}, broken) == ""

--- a/tests/test_replay_expectations.py
+++ b/tests/test_replay_expectations.py
@@ -121,7 +121,11 @@ def test_a_genuinely_different_page_still_fails():
     from noui_core.verify.replay import expectation_unmet
 
     def execute(cmd, params):
-        return {"data": {"url": "https://infinity.icici.bank.in/corp/AuthenticationController;jsessionid=x"}}
+        return {
+            "data": {
+                "url": "https://infinity.icici.bank.in/corp/AuthenticationController;jsessionid=x"
+            }
+        }
 
     unmet = expectation_unmet(
         {"url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=y"}, execute
@@ -136,8 +140,7 @@ def test_a_download_step_does_not_pass_on_a_file_from_an_earlier_step():
     nothing; the monthly PDF from four steps earlier is still listed, so the
     step's own `expect.download` was satisfied by it.
     """
-    step = {"command": "click_element", "params": {"selector": "#dl"},
-            "expect": {"download": True}}
+    step = {"command": "click_element", "params": {"selector": "#dl"}, "expect": {"download": True}}
     known = {"dl-1"}
     res = replay_step(
         _exec(downloads=[{"id": "dl-1", "state": "completed"}]),
@@ -150,12 +153,12 @@ def test_a_download_step_does_not_pass_on_a_file_from_an_earlier_step():
 
 
 def test_a_download_step_passes_on_a_file_that_arrived_here():
-    step = {"command": "click_element", "params": {"selector": "#dl"},
-            "expect": {"download": True}}
+    step = {"command": "click_element", "params": {"selector": "#dl"}, "expect": {"download": True}}
     known = {"dl-1"}
     res = replay_step(
-        _exec(downloads=[{"id": "dl-1", "state": "completed"},
-                         {"id": "dl-2", "state": "completed"}]),
+        _exec(
+            downloads=[{"id": "dl-1", "state": "completed"}, {"id": "dl-2", "state": "completed"}]
+        ),
         step,
         recorded={_control_identity(step)},
         known_downloads=known,
@@ -167,8 +170,12 @@ def test_a_download_step_passes_on_a_file_that_arrived_here():
 
 # --- arrived past a step ------------------------------------------------------
 
+
 def _invisible(_cmd, _params=None):
-    return {"success": False, "error": "this control is on the page but not visible, so acting on it would do nothing"}
+    return {
+        "success": False,
+        "error": "this control is on the page but not visible, so acting on it would do nothing",
+    }
 
 
 def test_a_step_the_page_has_moved_past_is_skipped_not_blocked():
@@ -184,12 +191,14 @@ def test_a_step_the_page_has_moved_past_is_skipped_not_blocked():
     def execute(command, params=None):
         calls.append((command, params))
         if command == "wait_for_selector":
-            return {"success": True}          # the NEXT control is on screen
+            return {"success": True}  # the NEXT control is on screen
         return _invisible(command, params)
 
     step = {"command": "click_element", "params": {"selector": "#DUMMY1"}}
     res = replay_step(
-        execute, step, recorded={_control_identity(step)},
+        execute,
+        step,
+        recorded={_control_identity(step)},
         following=[{"command": "click_element", "params": {"selector": "#PDF_Download"}}],
     )
 
@@ -204,14 +213,17 @@ def test_an_invisible_control_whose_successor_is_also_hidden_still_blocks():
     after it. Blocking there is right -- something that should have revealed it
     has not run.
     """
+
     def execute(command, params=None):
         if command == "wait_for_selector":
-            return {"success": False, "error": "Timeout"}   # successor not there either
+            return {"success": False, "error": "Timeout"}  # successor not there either
         return _invisible(command, params)
 
     step = {"command": "click_element", "params": {"selector": "a.sub-menu-list-item-link"}}
     res = replay_step(
-        execute, step, recorded={_control_identity(step)},
+        execute,
+        step,
+        recorded={_control_identity(step)},
         following=[{"command": "click_element", "params": {"selector": "#deeper"}}],
     )
 
@@ -229,7 +241,9 @@ def test_a_successor_named_only_by_text_is_not_evidence():
     """Only a CSS selector can be probed without acting on the page."""
     step = {"command": "click_element", "params": {"selector": "#DUMMY1"}}
     res = replay_step(
-        _invisible, step, recorded={_control_identity(step)},
+        _invisible,
+        step,
+        recorded={_control_identity(step)},
         following=[{"command": "click_by_text", "params": {"text": "FY2025-26"}}],
     )
     assert res["status"] == BLOCKED
@@ -243,15 +257,20 @@ def test_a_control_that_is_gone_entirely_is_the_same_situation():
     what decides whether that is a failure is the same either way: what comes
     next.
     """
+
     def execute(command, params=None):
         if command == "wait_for_selector":
             return {"success": True}
-        return {"success": False,
-                "error": 'nothing on the page matches "#DUMMY1", nor any of the 1 recorded alternative(s)'}
+        return {
+            "success": False,
+            "error": 'nothing on the page matches "#DUMMY1", nor any of the 1 recorded alternative(s)',
+        }
 
     step = {"command": "click_element", "params": {"selector": "#DUMMY1"}}
     res = replay_step(
-        execute, step, recorded={_control_identity(step)},
+        execute,
+        step,
+        recorded={_control_identity(step)},
         following=[{"command": "click_element", "params": {"selector": "#PDF_Download"}}],
     )
     assert res["status"] == SKIPPED
@@ -275,9 +294,11 @@ def test_evidence_comes_from_the_next_step_that_names_a_control():
 
     step = {"command": "click_element", "params": {"selector": "#DUMMY1"}}
     res = replay_step(
-        execute, step, recorded={_control_identity(step)},
+        execute,
+        step,
+        recorded={_control_identity(step)},
         following=[
-            {"command": "get_page_summary", "params": {}},          # names nothing
+            {"command": "get_page_summary", "params": {}},  # names nothing
             {"command": "click_element", "params": {"selector": "#PDF_Download"}},
         ],
     )
@@ -328,12 +349,14 @@ def test_the_retry_happens_before_deciding_the_page_moved_past_it():
 
     step = {"command": "click_element", "params": {"selector": "#slow"}}
     res = replay_step(
-        execute, step, recorded={_control_identity(step)},
+        execute,
+        step,
+        recorded={_control_identity(step)},
         following=[{"command": "click_element", "params": {"selector": "#later"}}],
     )
 
     assert res["status"] == OK
-    assert probed == []          # never had to ask whether we had moved past it
+    assert probed == []  # never had to ask whether we had moved past it
 
 
 def test_a_control_that_stays_unreachable_still_blocks():
@@ -344,7 +367,9 @@ def test_a_control_that_stays_unreachable_still_blocks():
 
     step = {"command": "click_element", "params": {"selector": "#gone"}}
     res = replay_step(
-        execute, step, recorded={_control_identity(step)},
+        execute,
+        step,
+        recorded={_control_identity(step)},
         following=[{"command": "click_element", "params": {"selector": "#later"}}],
     )
     assert res["status"] == BLOCKED

--- a/tests/test_replay_expectations.py
+++ b/tests/test_replay_expectations.py
@@ -9,6 +9,7 @@ execute every step, land on a completely different page, and report success —
 from noui_core.verify.replay import (
     BLOCKED,
     OK,
+    SKIPPED,
     _control_identity,
     expectation_unmet,
     replay_step,
@@ -162,3 +163,124 @@ def test_a_download_step_passes_on_a_file_that_arrived_here():
     assert res["status"] == OK
     # Both are accounted for now, so the NEXT download step cannot reuse either.
     assert known == {"dl-1", "dl-2"}
+
+
+# --- arrived past a step ------------------------------------------------------
+
+def _invisible(_cmd, _params=None):
+    return {"success": False, "error": "this control is on the page but not visible, so acting on it would do nothing"}
+
+
+def test_a_step_the_page_has_moved_past_is_skipped_not_blocked():
+    """ICICI's GO button after the Annual radio.
+
+    The human pressed GO because their radio selection did not submit the form.
+    The replay's set_checked DOES submit it, so the page is already on the
+    annual view and GO is hidden -- permanently: it stayed hidden through a full
+    30s wait. The step is unnecessary, not broken.
+    """
+    calls = []
+
+    def execute(command, params=None):
+        calls.append((command, params))
+        if command == "wait_for_selector":
+            return {"success": True}          # the NEXT control is on screen
+        return _invisible(command, params)
+
+    step = {"command": "click_element", "params": {"selector": "#DUMMY1"}}
+    res = replay_step(
+        execute, step, recorded={_control_identity(step)},
+        following=[{"command": "click_element", "params": {"selector": "#PDF_Download"}}],
+    )
+
+    assert res["status"] == SKIPPED
+    assert "moved past" in res["detail"]
+
+
+def test_an_invisible_control_whose_successor_is_also_hidden_still_blocks():
+    """The hover menu, which is the reason 'invisible' cannot simply mean skip.
+
+    The credit-card link is invisible until its menu opens, and so is everything
+    after it. Blocking there is right -- something that should have revealed it
+    has not run.
+    """
+    def execute(command, params=None):
+        if command == "wait_for_selector":
+            return {"success": False, "error": "Timeout"}   # successor not there either
+        return _invisible(command, params)
+
+    step = {"command": "click_element", "params": {"selector": "a.sub-menu-list-item-link"}}
+    res = replay_step(
+        execute, step, recorded={_control_identity(step)},
+        following=[{"command": "click_element", "params": {"selector": "#deeper"}}],
+    )
+
+    assert res["status"] == BLOCKED
+
+
+def test_the_last_step_of_an_operation_never_skips_this_way():
+    """With no successor there is no evidence, and no evidence means blocked."""
+    step = {"command": "click_element", "params": {"selector": "#DUMMY1"}}
+    res = replay_step(_invisible, step, recorded={_control_identity(step)}, following=[])
+    assert res["status"] == BLOCKED
+
+
+def test_a_successor_named_only_by_text_is_not_evidence():
+    """Only a CSS selector can be probed without acting on the page."""
+    step = {"command": "click_element", "params": {"selector": "#DUMMY1"}}
+    res = replay_step(
+        _invisible, step, recorded={_control_identity(step)},
+        following=[{"command": "click_by_text", "params": {"text": "FY2025-26"}}],
+    )
+    assert res["status"] == BLOCKED
+
+
+def test_a_control_that_is_gone_entirely_is_the_same_situation():
+    """The GO button showed up both ways on consecutive runs.
+
+    Once present-but-hidden, once absent — how far the portal has re-rendered
+    when the step fires varies. Both mean the step cannot be performed here, and
+    what decides whether that is a failure is the same either way: what comes
+    next.
+    """
+    def execute(command, params=None):
+        if command == "wait_for_selector":
+            return {"success": True}
+        return {"success": False,
+                "error": 'nothing on the page matches "#DUMMY1", nor any of the 1 recorded alternative(s)'}
+
+    step = {"command": "click_element", "params": {"selector": "#DUMMY1"}}
+    res = replay_step(
+        execute, step, recorded={_control_identity(step)},
+        following=[{"command": "click_element", "params": {"selector": "#PDF_Download"}}],
+    )
+    assert res["status"] == SKIPPED
+
+
+def test_evidence_comes_from_the_next_step_that_names_a_control():
+    """A read operation ends with get_page_summary, which addresses nothing.
+
+    Anchoring on the immediate successor found no selector to probe and blocked
+    — on the very case this rule exists for. ICICI's GO button is followed by
+    get_page_summary in one operation and by the download icon in another; the
+    situation is identical and so is the evidence.
+    """
+    probed = []
+
+    def execute(command, params=None):
+        if command == "wait_for_selector":
+            probed.append((params or {}).get("selector"))
+            return {"success": True}
+        return {"success": False, "error": "this control is on the page but not visible"}
+
+    step = {"command": "click_element", "params": {"selector": "#DUMMY1"}}
+    res = replay_step(
+        execute, step, recorded={_control_identity(step)},
+        following=[
+            {"command": "get_page_summary", "params": {}},          # names nothing
+            {"command": "click_element", "params": {"selector": "#PDF_Download"}},
+        ],
+    )
+
+    assert res["status"] == SKIPPED
+    assert probed == ["#PDF_Download"]

--- a/tests/test_replay_expectations.py
+++ b/tests/test_replay_expectations.py
@@ -96,3 +96,33 @@ def test_an_unreadable_url_is_not_treated_as_a_failed_expectation():
         return {"success": True, "data": {}}
 
     assert expectation_unmet({"url": "https://bank.test/x"}, broken) == ""
+
+
+def test_a_jsessionid_does_not_fail_the_page_expectation():
+    """ICICI carries its portal session as ;jsessionid=... in the PATH.
+
+    The recorded URL and the live one name the same page with different tokens,
+    and neither is a prefix of the other — so the download's own page assertion
+    would have failed every replay for the wrong reason.
+    """
+    from noui_core.verify.replay import expectation_unmet
+
+    portal = "https://infinity.icici.bank.in/corp/Finacle"
+    live = portal + ";jsessionid=0000LIVE:CR21n41xcb?bwayparam=abc"
+
+    def execute(cmd, params):
+        return {"data": {"url": live}}
+
+    assert expectation_unmet({"url": portal + ";jsessionid=0000RECORDED"}, execute) == ""
+
+
+def test_a_genuinely_different_page_still_fails():
+    from noui_core.verify.replay import expectation_unmet
+
+    def execute(cmd, params):
+        return {"data": {"url": "https://infinity.icici.bank.in/corp/AuthenticationController;jsessionid=x"}}
+
+    unmet = expectation_unmet(
+        {"url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=y"}, execute
+    )
+    assert "expected to be on" in unmet

--- a/tests/test_replay_expectations.py
+++ b/tests/test_replay_expectations.py
@@ -126,3 +126,39 @@ def test_a_genuinely_different_page_still_fails():
         {"url": "https://infinity.icici.bank.in/corp/Finacle;jsessionid=y"}, execute
     )
     assert "expected to be on" in unmet
+
+
+def test_a_download_step_does_not_pass_on_a_file_from_an_earlier_step():
+    """Per step, the same staleness as per operation.
+
+    The annual branch's download click fires into a busy form and produces
+    nothing; the monthly PDF from four steps earlier is still listed, so the
+    step's own `expect.download` was satisfied by it.
+    """
+    step = {"command": "click_element", "params": {"selector": "#dl"},
+            "expect": {"download": True}}
+    known = {"dl-1"}
+    res = replay_step(
+        _exec(downloads=[{"id": "dl-1", "state": "completed"}]),
+        step,
+        recorded={_control_identity(step)},
+        known_downloads=known,
+    )
+    assert res["status"] == BLOCKED
+    assert "no NEW completed file" in res["detail"]
+
+
+def test_a_download_step_passes_on_a_file_that_arrived_here():
+    step = {"command": "click_element", "params": {"selector": "#dl"},
+            "expect": {"download": True}}
+    known = {"dl-1"}
+    res = replay_step(
+        _exec(downloads=[{"id": "dl-1", "state": "completed"},
+                         {"id": "dl-2", "state": "completed"}]),
+        step,
+        recorded={_control_identity(step)},
+        known_downloads=known,
+    )
+    assert res["status"] == OK
+    # Both are accounted for now, so the NEXT download step cannot reuse either.
+    assert known == {"dl-1", "dl-2"}

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -502,3 +502,34 @@ def test_a_worker_that_reports_no_readiness_behaves_as_before(monkeypatch):
 
     monkeypatch.setattr(session_mod.time, "sleep", lambda s: None)
     session_mod._wait_until_the_page_stops_moving(execute)   # returns, does not hang
+
+
+def test_a_read_stops_where_the_next_goal_begins():
+    """The monthly bug: a read performed the ANNUAL selection for every run.
+
+    The human did two things on ICICI's statement page — downloaded monthly,
+    then switched to Annual and downloaded that — so the page read spanned both
+    and its steps included `set_checked Annual` plus the GO that submits it.
+    Replayed, it navigated to the annual page before the monthly download could
+    run, and monthly fetched the wrong document with every step reporting ok.
+    """
+    from noui_core.compile.browser_skill import _truncate_reads_at_terminals
+
+    read = {"name": "read_page",
+            "steps": [{"_seq": 9}, {"_seq": 17}, {"_seq": 22}, {"_seq": 23}],
+            "segment_steps": [{"_seq": 17}, {"_seq": 22}, {"_seq": 23}]}
+    monthly = {"name": "download_monthly", "_terminal_seq": 21}
+    annual = {"name": "download_annual", "_terminal_seq": 32}
+
+    _truncate_reads_at_terminals([read, monthly, annual])
+
+    assert [s["_seq"] for s in read["segment_steps"]] == [17]
+    assert [s["_seq"] for s in read["steps"]] == [9, 17]   # journey kept, tail cut
+
+
+def test_a_read_that_does_not_span_a_terminal_is_untouched():
+    from noui_core.compile.browser_skill import _truncate_reads_at_terminals
+
+    read = {"name": "r", "steps": [{"_seq": 5}], "segment_steps": [{"_seq": 5}]}
+    _truncate_reads_at_terminals([read, {"name": "d", "_terminal_seq": 40}])
+    assert [s["_seq"] for s in read["segment_steps"]] == [5]

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -99,28 +99,58 @@ def test_a_skill_without_segments_runs_as_it_always_did(monkeypatch):
     assert page.calls.count("click_by_text") == 2
 
 
-def test_an_arrival_is_given_time_to_paint(monkeypatch):
-    """The URL matches before the DOM is up.
+def test_an_arrival_waits_for_its_first_control(monkeypatch):
+    """Poll for the thing we are about to click, not a fixed time.
 
-    ICICI's statement portal is reached by a cross-origin hop that completes
-    after the click returns. The next operation asked for #PDF_Download while
-    the form was still building; probed by hand a minute later it was there.
+    A fixed sleep was wrong twice: 3s was too short for ICICI's statement portal
+    (the control was there when probed by hand a minute later) and dead weight on
+    every fast page. The recording says the human's own gap after that hop was
+    17-29s — an upper bound, since some of it was reading.
     """
-    waited: list[float] = []
-    monkeypatch.setattr(session_mod.time, "sleep", lambda s: waited.append(s))
-    page = _Page(OVERVIEW, after_first=CC)
-    monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
+    monkeypatch.setattr(session_mod.time, "sleep", lambda s: None)
+    asked: list[str] = []
 
-    nav = {"command": "click_by_text", "params": {"text": "Cards"},
-           "expect": {"settle_ms": 4000}}
-    dl = {"command": "click_element", "params": {"selector": "#DL"}}
-    ops = [
-        _op("read_cc", None, [nav], [nav]),
-        _op("download", CC, [dl], [nav, dl]),
-    ]
-    run_replay(ops, profile_slug="p", token="t", entry_url=OVERVIEW)
-    # The second operation arrived at its starts_from and waited before acting.
-    assert 4.0 in waited
+    class _Waits(_Page):
+        def __call__(self, command, params):
+            if command == "wait_for_selector":
+                asked.append(params["selector"])
+                return {"data": {}}
+            return super().__call__(command, params)
+
+    page = _Waits(OVERVIEW, after_first=CC)
+    monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
+    run_replay(OPS, profile_slug="p", token="t", entry_url=OVERVIEW)
+    # It waited for the download's own target before clicking it.
+    assert asked == ["#DL"]
+
+
+def test_a_slow_control_is_polled_until_the_budget_runs_out(monkeypatch):
+    slept: list[float] = []
+    monkeypatch.setattr(session_mod.time, "sleep", lambda s: slept.append(s))
+    ticks = iter([0.0, 1.0, 2.0, 99.0])
+    monkeypatch.setattr(session_mod.time, "monotonic", lambda: next(ticks, 99.0))
+
+    def never_there(command, params):
+        if command == "wait_for_selector":
+            raise RuntimeError("nothing matches")
+        return {"data": {"url": CC}}
+
+    session_mod._await_first_control(
+        never_there, [{"params": {"selector": "#DL"}}], 5.0
+    )
+    # Polled, then gave up rather than hanging — the step itself reports next.
+    assert slept and all(s == 1.0 for s in slept)
+
+
+def test_a_step_with_no_selector_cannot_be_polled_for(monkeypatch):
+    slept: list[float] = []
+    monkeypatch.setattr(session_mod.time, "sleep", lambda s: slept.append(s))
+
+    def boom(command, params):
+        raise AssertionError("must not probe without a selector")
+
+    session_mod._await_first_control(boom, [{"params": {"text": "Annual"}}], 5.0)
+    assert slept, "falls back to a short settle"
 
 
 def test_no_wait_when_the_predecessor_did_not_arrive(monkeypatch):

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -108,45 +108,48 @@ def test_a_skill_without_segments_runs_as_it_always_did(monkeypatch):
     assert page.calls.count("click_by_text") == 2
 
 
-def test_an_arrival_waits_for_its_first_control(monkeypatch):
-    """Poll for the thing we are about to click, not a fixed time.
+def test_an_arrival_waits_for_the_page_to_be_ready(monkeypatch):
+    """Wait on the PAGE, not on the operation's first control.
 
-    A fixed sleep was wrong twice: 3s was too short for ICICI's statement portal
-    (the control was there when probed by hand a minute later) and dead weight on
-    every fast page. The recording says the human's own gap after that hop was
-    17-29s — an upper bound, since some of it was reading.
+    The first control is frequently interaction-gated -- a submenu item that
+    does not exist until a hover, a select hidden behind a styled overlay -- so
+    polling it could never succeed before the step's own hover_first/force ran,
+    and it spent its whole budget on an already-loaded page. Measured on ICICI:
+    three operations of every replay waited ~30s each for a control that was not
+    yet in the DOM. The document being ready is the honest precondition; the
+    step itself waits for and reveals its control.
     """
     monkeypatch.setattr(session_mod.time, "sleep", lambda s: None)
     asked: list[str] = []
 
-    class _Waits(_Page):
+    class _Ready(_Page):
         def __call__(self, command, params):
-            if command == "wait_for_selector":
-                asked.append(params["selector"])
-                return {"data": {}}
+            asked.append(command)
+            if command == "get_page_info":
+                return {"data": {"url": CC, "ready_state": "complete"}}
             return super().__call__(command, params)
 
-    page = _Waits(OVERVIEW, after_first=CC)
+    page = _Ready(OVERVIEW, after_first=CC)
     monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
     run_replay(OPS, profile_slug="p", token="t", entry_url=OVERVIEW)
-    # It waited for the download's own target before clicking it.
-    assert asked == ["#DL"]
+    # It asked the page whether it was ready -- and never hunted a control here.
+    assert "get_page_info" in asked
+    assert "wait_for_selector" not in asked
 
 
-def test_a_slow_control_is_polled_until_the_budget_runs_out(monkeypatch):
+def test_a_page_that_never_reports_ready_gives_up_at_the_budget(monkeypatch):
     slept: list[float] = []
     monkeypatch.setattr(session_mod.time, "sleep", lambda s: slept.append(s))
-    ticks = iter([0.0, 1.0, 2.0, 99.0])
+    ticks = iter([0.0, 0.0, 1.0, 2.0, 99.0])
     monkeypatch.setattr(session_mod.time, "monotonic", lambda: next(ticks, 99.0))
 
-    def never_there(command, params):
-        if command == "wait_for_selector":
-            raise RuntimeError("nothing matches")
-        return {"data": {"url": CC}}
+    def still_loading(command, params):
+        # A page stuck on readyState "loading" -- the budget bounds the wait so
+        # the run never hangs; the step itself reports next.
+        return {"data": {"url": CC, "ready_state": "loading"}}
 
-    session_mod._await_first_control(never_there, [{"params": {"selector": "#DL"}}], 5.0)
-    # Polled, then gave up rather than hanging — the step itself reports next.
-    assert slept and all(s == 1.0 for s in slept)
+    session_mod._await_first_control(still_loading, [{"params": {"selector": "#DL"}}], 5.0)
+    assert slept and all(s == 1.0 for s in slept[1:])
 
 
 def test_a_step_with_no_selector_cannot_be_polled_for(monkeypatch):

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -38,13 +38,21 @@ def _op(name, starts_from, seg, full):
 
 
 OPS = [
-    _op("read_cc", None,
+    _op(
+        "read_cc",
+        None,
         [{"command": "click_by_text", "params": {"text": "Cards"}}],
-        [{"command": "click_by_text", "params": {"text": "Cards"}}]),
-    _op("download", CC,
+        [{"command": "click_by_text", "params": {"text": "Cards"}}],
+    ),
+    _op(
+        "download",
+        CC,
         [{"command": "click_element", "params": {"selector": "#DL"}}],
-        [{"command": "click_by_text", "params": {"text": "Cards"}},
-         {"command": "click_element", "params": {"selector": "#DL"}}]),
+        [
+            {"command": "click_by_text", "params": {"text": "Cards"}},
+            {"command": "click_element", "params": {"selector": "#DL"}},
+        ],
+    ),
 ]
 
 
@@ -92,8 +100,9 @@ def test_a_predecessor_that_did_not_arrive_is_reported_not_replayed(monkeypatch)
 def test_a_skill_without_segments_runs_as_it_always_did(monkeypatch):
     page = _Page(OVERVIEW, after_first=CC)
     monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
-    legacy = [{k: v for k, v in o.items() if k not in ("segment_steps", "starts_from")}
-              for o in OPS]
+    legacy = [
+        {k: v for k, v in o.items() if k not in ("segment_steps", "starts_from")} for o in OPS
+    ]
     run_replay(legacy, profile_slug="p", token="t", entry_url=OVERVIEW)
     # The full chain runs, so "Cards" is clicked by both operations.
     assert page.calls.count("click_by_text") == 2
@@ -135,9 +144,7 @@ def test_a_slow_control_is_polled_until_the_budget_runs_out(monkeypatch):
             raise RuntimeError("nothing matches")
         return {"data": {"url": CC}}
 
-    session_mod._await_first_control(
-        never_there, [{"params": {"selector": "#DL"}}], 5.0
-    )
+    session_mod._await_first_control(never_there, [{"params": {"selector": "#DL"}}], 5.0)
     # Polled, then gave up rather than hanging — the step itself reports next.
     assert slept and all(s == 1.0 for s in slept)
 
@@ -177,7 +184,8 @@ def test_the_arrival_budget_comes_from_the_recording(monkeypatch):
     """
     seen: list[float] = []
     monkeypatch.setattr(
-        session_mod, "_await_first_control",
+        session_mod,
+        "_await_first_control",
         lambda ex, steps, budget: seen.append(budget),
     )
     page = _Page(OVERVIEW, after_first=CC)
@@ -191,7 +199,8 @@ def test_the_arrival_budget_comes_from_the_recording(monkeypatch):
 def test_a_skill_without_a_recorded_budget_uses_the_constant(monkeypatch):
     seen: list[float] = []
     monkeypatch.setattr(
-        session_mod, "_await_first_control",
+        session_mod,
+        "_await_first_control",
         lambda ex, steps, budget: seen.append(budget),
     )
     page = _Page(OVERVIEW, after_first=CC)
@@ -271,9 +280,14 @@ def test_operation_zero_resets_to_the_journey_entry_not_the_host_entry(monkeypat
     monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
 
     run_replay(
-        OPS, profile_slug="p", token="t", entry_url=OVERVIEW,
-        entry_by_origin={"https://infinity.icici.bank.in": PORTAL,
-                         "https://retailnetbanking.icici.bank.in": OVERVIEW},
+        OPS,
+        profile_slug="p",
+        token="t",
+        entry_url=OVERVIEW,
+        entry_by_origin={
+            "https://infinity.icici.bank.in": PORTAL,
+            "https://retailnetbanking.icici.bank.in": OVERVIEW,
+        },
     )
     assert aimed == [OVERVIEW]
 
@@ -287,7 +301,8 @@ def test_a_mid_journey_operation_run_alone_is_not_sent_to_the_entry(monkeypatch)
     """
     reset_called: list[str] = []
     monkeypatch.setattr(
-        session_mod, "_return_to_entry",
+        session_mod,
+        "_return_to_entry",
         lambda *a, **k: reset_called.append(a[1]) or None,
     )
     page = _Page(CC)
@@ -301,7 +316,8 @@ def test_a_mid_journey_operation_run_alone_is_not_sent_to_the_entry(monkeypatch)
 def test_the_journey_opener_still_resets_wherever_it_sits(monkeypatch):
     reset_called: list[str] = []
     monkeypatch.setattr(
-        session_mod, "_return_to_entry",
+        session_mod,
+        "_return_to_entry",
         lambda *a, **k: reset_called.append(a[1]) or None,
     )
     page = _Page(OVERVIEW, after_first=CC)
@@ -314,7 +330,8 @@ def test_a_single_operation_run_still_uses_segments(monkeypatch):
     # `len(ops) > 1` silently undid segments the moment --only narrowed a run.
     reset_called: list = []
     monkeypatch.setattr(
-        session_mod, "_return_to_entry",
+        session_mod,
+        "_return_to_entry",
         lambda *a, **k: reset_called.append(a[1]) or None,
     )
     page = _Page(CC)
@@ -424,16 +441,29 @@ def test_operations_are_emitted_in_the_order_they_were_recorded():
     # segment_steps is the operation's OWN work; `steps` prefixes the shared
     # journey, whose first click is identical for every operation.
     journey = [{"_seq": 9}]
-    read_cards = {"name": "read_credit_card", "steps": journey,
-                  "segment_steps": [{"_seq": 9}]}
-    read_portal = {"name": "read_corp_auth", "steps": journey + [{"_seq": 11}],
-                   "segment_steps": [{"_seq": 11}, {"_seq": 12}]}
-    read_finacle = {"name": "read_corp_finacle", "steps": journey + [{"_seq": 20}],
-                    "segment_steps": [{"_seq": 20}, {"_seq": 23}]}
-    submit = {"name": "submit_portal_login", "_terminal_seq": 18,
-              "steps": journey, "segment_steps": [{}]}
-    download = {"name": "download_statement", "_terminal_seq": 22,
-                "steps": journey, "segment_steps": [{"_seq": 23}]}
+    read_cards = {"name": "read_credit_card", "steps": journey, "segment_steps": [{"_seq": 9}]}
+    read_portal = {
+        "name": "read_corp_auth",
+        "steps": journey + [{"_seq": 11}],
+        "segment_steps": [{"_seq": 11}, {"_seq": 12}],
+    }
+    read_finacle = {
+        "name": "read_corp_finacle",
+        "steps": journey + [{"_seq": 20}],
+        "segment_steps": [{"_seq": 20}, {"_seq": 23}],
+    }
+    submit = {
+        "name": "submit_portal_login",
+        "_terminal_seq": 18,
+        "steps": journey,
+        "segment_steps": [{}],
+    }
+    download = {
+        "name": "download_statement",
+        "_terminal_seq": 22,
+        "steps": journey,
+        "segment_steps": [{"_seq": 23}],
+    }
 
     ops = [read_cards, read_portal, read_finacle, submit, download]
     ops.sort(key=_recorded_position)
@@ -441,9 +471,9 @@ def test_operations_are_emitted_in_the_order_they_were_recorded():
     assert [o["name"] for o in ops] == [
         "read_credit_card",
         "read_corp_auth",
-        "submit_portal_login",     # 18 — before the read that navigates past it
-        "read_corp_finacle",       # 20
-        "download_statement",      # 22
+        "submit_portal_login",  # 18 — before the read that navigates past it
+        "read_corp_finacle",  # 20
+        "download_statement",  # 22
     ]
 
 
@@ -463,10 +493,11 @@ def test_a_terminals_position_is_the_earliest_of_what_it_touches():
     """Its lead-in steps carry no position; its terminal does."""
     from noui_core.compile.browser_skill import _recorded_position
 
-    assert _recorded_position(
-        {"_terminal_seq": 22, "segment_steps": [{"_seq": 23}, {"_seq": 24}]}) == 22
-    assert _recorded_position(
-        {"_terminal_seq": 40, "segment_steps": [{"_seq": 23}]}) == 23
+    assert (
+        _recorded_position({"_terminal_seq": 22, "segment_steps": [{"_seq": 23}, {"_seq": 24}]})
+        == 22
+    )
+    assert _recorded_position({"_terminal_seq": 40, "segment_steps": [{"_seq": 23}]}) == 23
 
 
 def test_a_page_that_has_not_finished_loading_is_not_somewhere_to_click(monkeypatch):
@@ -501,7 +532,7 @@ def test_a_worker_that_reports_no_readiness_behaves_as_before(monkeypatch):
         return {"data": {"url": next(urls)}}
 
     monkeypatch.setattr(session_mod.time, "sleep", lambda s: None)
-    session_mod._wait_until_the_page_stops_moving(execute)   # returns, does not hang
+    session_mod._wait_until_the_page_stops_moving(execute)  # returns, does not hang
 
 
 def test_a_read_stops_where_the_next_goal_begins():
@@ -515,16 +546,18 @@ def test_a_read_stops_where_the_next_goal_begins():
     """
     from noui_core.compile.browser_skill import _truncate_reads_at_terminals
 
-    read = {"name": "read_page",
-            "steps": [{"_seq": 9}, {"_seq": 17}, {"_seq": 22}, {"_seq": 23}],
-            "segment_steps": [{"_seq": 17}, {"_seq": 22}, {"_seq": 23}]}
+    read = {
+        "name": "read_page",
+        "steps": [{"_seq": 9}, {"_seq": 17}, {"_seq": 22}, {"_seq": 23}],
+        "segment_steps": [{"_seq": 17}, {"_seq": 22}, {"_seq": 23}],
+    }
     monthly = {"name": "download_monthly", "_terminal_seq": 21}
     annual = {"name": "download_annual", "_terminal_seq": 32}
 
     _truncate_reads_at_terminals([read, monthly, annual])
 
     assert [s["_seq"] for s in read["segment_steps"]] == [17]
-    assert [s["_seq"] for s in read["steps"]] == [9, 17]   # journey kept, tail cut
+    assert [s["_seq"] for s in read["steps"]] == [9, 17]  # journey kept, tail cut
 
 
 def test_a_read_that_does_not_span_a_terminal_is_untouched():

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -97,3 +97,37 @@ def test_a_skill_without_segments_runs_as_it_always_did(monkeypatch):
     run_replay(legacy, profile_slug="p", token="t", entry_url=OVERVIEW)
     # The full chain runs, so "Cards" is clicked by both operations.
     assert page.calls.count("click_by_text") == 2
+
+
+def test_an_arrival_is_given_time_to_paint(monkeypatch):
+    """The URL matches before the DOM is up.
+
+    ICICI's statement portal is reached by a cross-origin hop that completes
+    after the click returns. The next operation asked for #PDF_Download while
+    the form was still building; probed by hand a minute later it was there.
+    """
+    waited: list[float] = []
+    monkeypatch.setattr(session_mod.time, "sleep", lambda s: waited.append(s))
+    page = _Page(OVERVIEW, after_first=CC)
+    monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
+
+    nav = {"command": "click_by_text", "params": {"text": "Cards"},
+           "expect": {"settle_ms": 4000}}
+    dl = {"command": "click_element", "params": {"selector": "#DL"}}
+    ops = [
+        _op("read_cc", None, [nav], [nav]),
+        _op("download", CC, [dl], [nav, dl]),
+    ]
+    run_replay(ops, profile_slug="p", token="t", entry_url=OVERVIEW)
+    # The second operation arrived at its starts_from and waited before acting.
+    assert 4.0 in waited
+
+
+def test_no_wait_when_the_predecessor_did_not_arrive(monkeypatch):
+    # A blocked operation must not also pay the settle.
+    waited: list[float] = []
+    monkeypatch.setattr(session_mod.time, "sleep", lambda s: waited.append(s))
+    page = _Page(OVERVIEW, after_first="https://x.test/elsewhere")
+    monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
+    run_replay(OPS, profile_slug="p", token="t", entry_url=OVERVIEW)
+    assert waited == []

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -217,3 +217,29 @@ def test_the_nav_projection_carries_seq_for_the_budget():
     nav = bs._nav_clicks_for(nav_ev["from_url"], nav_ev, b["click_events"])
     assert all(n.get("seq") is not None for n in nav), "seq must survive the projection"
     assert bs.arrival_budget_ms(b["click_events"], nav[-1]["seq"]) > 0
+
+
+def test_an_instant_human_does_not_become_an_instant_budget():
+    """4ms between two clicks became a 6ms budget, and the next operation
+    failed its starts_from with no time to arrive.
+
+    A human clicking straight through says nothing about how fast the page was:
+    they may have known where to aim, or the control was already there.
+    """
+    from noui_core.compile import browser_skill as bs
+
+    events = [
+        {"seq": 1, "timestamp": "2026-08-10T18:00:00.000Z"},
+        {"seq": 2, "timestamp": "2026-08-10T18:00:00.004Z"},
+    ]
+    assert bs.arrival_budget_ms(events, 1) == bs._ARRIVAL_FLOOR_MS
+
+
+def test_a_long_pause_is_capped():
+    from noui_core.compile import browser_skill as bs
+
+    events = [
+        {"seq": 1, "timestamp": "2026-08-10T18:00:00.000Z"},
+        {"seq": 2, "timestamp": "2026-08-10T18:05:00.000Z"},
+    ]
+    assert bs.arrival_budget_ms(events, 1) == bs._ARRIVAL_CAP_MS

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -16,7 +16,12 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_ROOT / "skills" / "noui"))
 
+from noui_core.verify import session as session_mod  # noqa: E402
 from noui_core.verify.session import run_replay  # noqa: E402
+
+# The wrong-page case waits for a hop that never lands; a real wait would add
+# eight seconds to the suite for no signal.
+session_mod._STARTS_FROM_WAIT_S = 0
 
 OVERVIEW = "https://x.test/overview"
 CC = "https://x.test/credit-card"

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -303,3 +303,16 @@ def test_the_journey_opener_still_resets_wherever_it_sits(monkeypatch):
     monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
     run_replay(OPS, profile_slug="p", token="t", entry_url=OVERVIEW)
     assert reset_called == [OVERVIEW]
+
+
+def test_a_single_operation_run_still_uses_segments(monkeypatch):
+    # `len(ops) > 1` silently undid segments the moment --only narrowed a run.
+    reset_called: list = []
+    monkeypatch.setattr(
+        session_mod, "_return_to_entry",
+        lambda *a, **k: reset_called.append(a[1]) or None,
+    )
+    page = _Page(CC)
+    monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
+    run_replay([OPS[1]], profile_slug="p", token="t", entry_url=OVERVIEW)
+    assert reset_called == [], "one continuing operation must not be reset"

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -336,3 +336,28 @@ def test_different_pages_are_still_different():
     b = "https://retailnetbanking.icici.bank.in/credit-card"
     assert not session_mod._same_page(a, b)
     assert not session_mod._same_page(a + ";jsessionid=1", b + ";jsessionid=1")
+
+
+def test_a_step_is_given_time_to_be_processed_before_the_next(monkeypatch):
+    """ICICI answered: "You clicked on a link or a button when your previous
+    click was still under process. The system is considering your first
+    request." — and kept the FIRST request.
+
+    The replay had set the Annual radio, pressed GO, and clicked on immediately;
+    the bank discarded the second action and stayed on Monthly. The recorder's
+    settle for a step is equally the answer to how long it took to be processed,
+    because the human did not act again until it was.
+    """
+    slept: list[float] = []
+    monkeypatch.setattr(session_mod.time, "sleep", lambda s: slept.append(s))
+
+    session_mod._let_the_step_land({"expect": {"settle_ms": 4000}})
+    assert slept == [4.0]
+
+    slept.clear()
+    session_mod._let_the_step_land({"expect": {"settle_ms": 90_000}})
+    assert slept == [session_mod._INTER_STEP_CAP_S], "a human reading is not a page working"
+
+    slept.clear()
+    session_mod._let_the_step_land({"command": "click_element"})
+    assert slept == [], "nothing measured, nothing waited"

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -193,3 +193,27 @@ def test_a_skill_without_a_recorded_budget_uses_the_constant(monkeypatch):
     monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
     run_replay(OPS, profile_slug="p", token="t", entry_url=OVERVIEW)
     assert seen == [session_mod._ARRIVAL_BUDGET_S]
+
+
+def test_the_nav_projection_carries_seq_for_the_budget():
+    """Measured through the REAL path, not a hand-built fixture.
+
+    The unit test for the budget fed causes_arrival_budget_ms in directly and
+    passed while the compile path produced None for every operation --
+    _nav_clicks_for's projection was dropping `seq`, the fourth field it has
+    been caught losing after candidates, is_opener and event_type.
+    """
+    import json as _json
+    from pathlib import Path as _Path
+
+    from noui_core.compile import browser_skill as bs
+
+    bundle = _Path(__file__).resolve().parents[1] / "skills/noui/workbench/bundles"
+    found = sorted(bundle.glob("icici-cc-hover-*.json"))
+    if not found:
+        return  # bundle not present in this checkout
+    b = _json.loads(found[0].read_text())
+    nav_ev = [e for e in b["url_events"] if "credit-card" in (e.get("to_url") or "")][0]
+    nav = bs._nav_clicks_for(nav_ev["from_url"], nav_ev, b["click_events"])
+    assert all(n.get("seq") is not None for n in nav), "seq must survive the projection"
+    assert bs.arrival_budget_ms(b["click_events"], nav[-1]["seq"]) > 0

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -271,3 +271,35 @@ def test_operation_zero_resets_to_the_journey_entry_not_the_host_entry(monkeypat
                          "https://retailnetbanking.icici.bank.in": OVERVIEW},
     )
     assert aimed == [OVERVIEW]
+
+
+def test_a_mid_journey_operation_run_alone_is_not_sent_to_the_entry(monkeypatch):
+    """--only made download_statement index 0, and the index-based rule sent it
+    back to /overview from the statement portal it had just reached.
+
+    Beginning the journey is a property of the operation — no starts_from —
+    not of its position in the list.
+    """
+    reset_called: list[str] = []
+    monkeypatch.setattr(
+        session_mod, "_return_to_entry",
+        lambda *a, **k: reset_called.append(a[1]) or None,
+    )
+    page = _Page(CC)
+    monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
+
+    only = [OPS[1], dict(OPS[1], name="second")]  # both carry starts_from=CC
+    run_replay(only, profile_slug="p", token="t", entry_url=OVERVIEW)
+    assert reset_called == [], "a continuing operation must never reset"
+
+
+def test_the_journey_opener_still_resets_wherever_it_sits(monkeypatch):
+    reset_called: list[str] = []
+    monkeypatch.setattr(
+        session_mod, "_return_to_entry",
+        lambda *a, **k: reset_called.append(a[1]) or None,
+    )
+    page = _Page(OVERVIEW, after_first=CC)
+    monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
+    run_replay(OPS, profile_slug="p", token="t", entry_url=OVERVIEW)
+    assert reset_called == [OVERVIEW]

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -1,0 +1,94 @@
+"""A segmented replay runs the recorded journey once, in order.
+
+`steps` repeats the whole chain from the entry page into every operation, so
+replaying operation 2 demanded being back somewhere the recording left once and
+never returned to — and the reset had to invent a route there. Watched failing
+on live ICICI: operations 2-5 reported "could not return to the start of the
+journey" while the browser sat on /credit-card with the next recorded click
+visible on screen.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+
+from noui_core.verify.session import run_replay  # noqa: E402
+
+OVERVIEW = "https://x.test/overview"
+CC = "https://x.test/credit-card"
+
+
+def _op(name, starts_from, seg, full):
+    return {
+        "name": name,
+        "tool": "call_web_browser",
+        "starts_from": starts_from,
+        "segment_steps": seg,
+        "steps": full,
+    }
+
+
+OPS = [
+    _op("read_cc", None,
+        [{"command": "click_by_text", "params": {"text": "Cards"}}],
+        [{"command": "click_by_text", "params": {"text": "Cards"}}]),
+    _op("download", CC,
+        [{"command": "click_element", "params": {"selector": "#DL"}}],
+        [{"command": "click_by_text", "params": {"text": "Cards"}},
+         {"command": "click_element", "params": {"selector": "#DL"}}]),
+]
+
+
+class _Page:
+    def __init__(self, at, after_first=None):
+        self.at = at
+        self.after_first = after_first
+        self.calls: list[str] = []
+
+    def __call__(self, command, params):
+        self.calls.append(command)
+        if command == "get_page_info":
+            return {"data": {"url": self.at}}
+        if command == "click_by_text" and self.after_first:
+            self.at = self.after_first
+        return {"data": {}}
+
+
+def _run(page, **kw):
+    return run_replay(OPS, profile_slug="p", token="t", entry_url=OVERVIEW, **kw)
+
+
+def test_the_second_operation_does_not_re_walk_the_journey(monkeypatch):
+    page = _Page(OVERVIEW, after_first=CC)
+    monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
+    _run(page)
+    # "Cards" is clicked ONCE — by the operation that owns it, not again by the
+    # download that follows it.
+    assert page.calls.count("click_by_text") == 1
+    assert page.calls.count("click_element") == 1
+
+
+def test_a_predecessor_that_did_not_arrive_is_reported_not_replayed(monkeypatch):
+    # The first operation leaves the browser somewhere unexpected, so the second
+    # must refuse rather than act on the wrong page.
+    page = _Page(OVERVIEW, after_first="https://x.test/somewhere-else")
+    monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
+    report = _run(page)
+    dl = [o for o in report["operations"] if o["name"] == "download"][0]
+    assert dl["steps"][0]["status"] == "blocked"
+    assert "did not arrive" in dl["steps"][0]["error"]
+    assert page.calls.count("click_element") == 0, "must not act on the wrong page"
+
+
+def test_a_skill_without_segments_runs_as_it_always_did(monkeypatch):
+    page = _Page(OVERVIEW, after_first=CC)
+    monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
+    legacy = [{k: v for k, v in o.items() if k not in ("segment_steps", "starts_from")}
+              for o in OPS]
+    run_replay(legacy, profile_slug="p", token="t", entry_url=OVERVIEW)
+    # The full chain runs, so "Cards" is clicked by both operations.
+    assert page.calls.count("click_by_text") == 2

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -316,3 +316,23 @@ def test_a_single_operation_run_still_uses_segments(monkeypatch):
     monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
     run_replay([OPS[1]], profile_slug="p", token="t", entry_url=OVERVIEW)
     assert reset_called == [], "one continuing operation must not be reset"
+
+
+def test_a_jsessionid_does_not_make_it_a_different_page():
+    """ICICI's portal carries its session as ;jsessionid=… in the path.
+
+    The guard stripped only `?`, so the page the browser was on and the page the
+    recording named compared as different — blocking the one operation being
+    tested, on the page it had correctly reached.
+    """
+    portal = "https://infinity.icici.bank.in/corp/AuthenticationController"
+    assert session_mod._same_page(portal + ";jsessionid=0000HU:abc", portal)
+    assert session_mod._same_page(portal + ";jsessionid=x?bwayparam=y", portal)
+    assert session_mod._same_page(portal + "/", portal)
+
+
+def test_different_pages_are_still_different():
+    a = "https://retailnetbanking.icici.bank.in/overview"
+    b = "https://retailnetbanking.icici.bank.in/credit-card"
+    assert not session_mod._same_page(a, b)
+    assert not session_mod._same_page(a + ";jsessionid=1", b + ";jsessionid=1")

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -243,3 +243,31 @@ def test_a_long_pause_is_capped():
         {"seq": 2, "timestamp": "2026-08-10T18:05:00.000Z"},
     ]
     assert bs.arrival_budget_ms(events, 1) == bs._ARRIVAL_CAP_MS
+
+
+def test_operation_zero_resets_to_the_journey_entry_not_the_host_entry(monkeypatch):
+    """A replay that ended on the statement portal must still be repeatable.
+
+    Per-origin is right for an operation that starts mid-journey. For the first
+    one it meant "home" resolved to the portal's own entry, the reset did
+    nothing, and the net-banking steps ran against the wrong host — which is why
+    runs alternated pass/fail with no change between them.
+    """
+    PORTAL = "https://infinity.icici.bank.in/corp/AuthenticationController"
+    aimed: list[str] = []
+
+    def fake_reset(execute, entry, known=None, by_origin=None, ops=None, notes=None):
+        aimed.append(entry)
+        assert by_origin is None, "operation 0 must not be redirected per host"
+        return None
+
+    monkeypatch.setattr(session_mod, "_return_to_entry", fake_reset)
+    page = _Page(PORTAL, after_first=CC)
+    monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
+
+    run_replay(
+        OPS, profile_slug="p", token="t", entry_url=OVERVIEW,
+        entry_by_origin={"https://infinity.icici.bank.in": PORTAL,
+                         "https://retailnetbanking.icici.bank.in": OVERVIEW},
+    )
+    assert aimed == [OVERVIEW]

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -409,3 +409,96 @@ def test_the_stabiliser_gives_up_rather_than_hanging(monkeypatch):
 
     session_mod._wait_until_the_page_stops_moving(always_moving)
     assert calls["n"] > 1  # it did try
+
+
+def test_operations_are_emitted_in_the_order_they_were_recorded():
+    """These operations are one journey cut into pieces, so list order IS replay order.
+
+    ICICI's portal sign-in was recorded at 18 and the statement-page read at
+    20-24, but every page operation was emitted before every terminal one — so
+    the sign-in landed after a read that had already navigated past the page the
+    sign-in runs on, and could only ever fail its own starts_from guard.
+    """
+    from noui_core.compile.browser_skill import _recorded_position
+
+    # segment_steps is the operation's OWN work; `steps` prefixes the shared
+    # journey, whose first click is identical for every operation.
+    journey = [{"_seq": 9}]
+    read_cards = {"name": "read_credit_card", "steps": journey,
+                  "segment_steps": [{"_seq": 9}]}
+    read_portal = {"name": "read_corp_auth", "steps": journey + [{"_seq": 11}],
+                   "segment_steps": [{"_seq": 11}, {"_seq": 12}]}
+    read_finacle = {"name": "read_corp_finacle", "steps": journey + [{"_seq": 20}],
+                    "segment_steps": [{"_seq": 20}, {"_seq": 23}]}
+    submit = {"name": "submit_portal_login", "_terminal_seq": 18,
+              "steps": journey, "segment_steps": [{}]}
+    download = {"name": "download_statement", "_terminal_seq": 22,
+                "steps": journey, "segment_steps": [{"_seq": 23}]}
+
+    ops = [read_cards, read_portal, read_finacle, submit, download]
+    ops.sort(key=_recorded_position)
+
+    assert [o["name"] for o in ops] == [
+        "read_credit_card",
+        "read_corp_auth",
+        "submit_portal_login",     # 18 — before the read that navigates past it
+        "read_corp_finacle",       # 20
+        "download_statement",      # 22
+    ]
+
+
+def test_an_operation_the_recording_cannot_place_keeps_its_position():
+    """A stable sort leaves it alone rather than moving it somewhere arbitrary."""
+    from noui_core.compile.browser_skill import _recorded_position
+
+    placed = {"name": "placed", "segment_steps": [{"_seq": 5}]}
+    unplaced = {"name": "unplaced", "segment_steps": [{}]}
+    ops = [placed, unplaced]
+    ops.sort(key=_recorded_position)
+    assert [o["name"] for o in ops] == ["placed", "unplaced"]
+    assert _recorded_position(unplaced) == float("inf")
+
+
+def test_a_terminals_position_is_the_earliest_of_what_it_touches():
+    """Its lead-in steps carry no position; its terminal does."""
+    from noui_core.compile.browser_skill import _recorded_position
+
+    assert _recorded_position(
+        {"_terminal_seq": 22, "segment_steps": [{"_seq": 23}, {"_seq": 24}]}) == 22
+    assert _recorded_position(
+        {"_terminal_seq": 40, "segment_steps": [{"_seq": 23}]}) == 23
+
+
+def test_a_page_that_has_not_finished_loading_is_not_somewhere_to_click(monkeypatch):
+    """Clicking a page mid-load is not a faster click, it is a lost one.
+
+    Watching the URL alone is too weak for a form postback: ICICI's statement
+    portal re-renders in place, so two readings agree immediately and the wait
+    collapsed to nothing. Seen on screen — the replay chose FY2025-26, the portal
+    was still processing the previous click, and the page came back showing
+    FY2024-25 with "we are unable to process your request". The step reported ok.
+    """
+    states = iter([("u", "loading"), ("u", "loading"), ("u", "complete")])
+    seen = []
+
+    def execute(command, params=None):
+        url, ready = next(states)
+        seen.append(ready)
+        return {"data": {"url": url, "ready_state": ready}}
+
+    monkeypatch.setattr(session_mod.time, "sleep", lambda s: None)
+    session_mod._wait_until_the_page_stops_moving(execute)
+
+    # It kept looking while the page said "loading", and stopped once complete.
+    assert seen == ["loading", "loading", "complete"]
+
+
+def test_a_worker_that_reports_no_readiness_behaves_as_before(monkeypatch):
+    """Older workers return {url, title} only; the URL is then all there is."""
+    urls = iter(["a", "b", "b"])
+
+    def execute(command, params=None):
+        return {"data": {"url": next(urls)}}
+
+    monkeypatch.setattr(session_mod.time, "sleep", lambda s: None)
+    session_mod._wait_until_the_page_stops_moving(execute)   # returns, does not hang

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -155,7 +155,12 @@ def test_a_step_with_no_selector_cannot_be_polled_for(monkeypatch):
 
 def test_no_wait_when_the_predecessor_did_not_arrive(monkeypatch):
     # A blocked operation must not also pay the settle.
+    #
+    # Held apart from the live-page stabiliser, which is a different mechanism
+    # with its own test: that one polls after a step that RAN, and a blocked
+    # operation never runs one.
     waited: list[float] = []
+    monkeypatch.setattr(session_mod, "_wait_until_the_page_stops_moving", lambda execute: None)
     monkeypatch.setattr(session_mod.time, "sleep", lambda s: waited.append(s))
     page = _Page(OVERVIEW, after_first="https://x.test/elsewhere")
     monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
@@ -361,3 +366,46 @@ def test_a_step_is_given_time_to_be_processed_before_the_next(monkeypatch):
     slept.clear()
     session_mod._let_the_step_land({"command": "click_element"})
     assert slept == [], "nothing measured, nothing waited"
+
+
+def test_a_step_with_no_recorded_settle_waits_for_the_page_to_stop_moving(monkeypatch):
+    """ICICI's portal reports nothing, so the wait has to be observed.
+
+    Every click on the statement portal records `navigated: false, to_url: null,
+    settled_ms: null` -- the hop is cross-origin and completes after the click
+    returns. So no step there carries a settle, the replay fired the next one
+    into a page mid-load, and the portal treats that as a double click and
+    expires the session. Two readings that agree is the cheapest honest proof
+    that the click has been processed.
+    """
+    urls = iter(["https://p.test/a", "https://p.test/b", "https://p.test/b"])
+    seen: list[str] = []
+
+    def execute(command, params=None):
+        assert command == "get_page_info"
+        url = next(urls)
+        seen.append(url)
+        return {"data": {"url": url}}
+
+    monkeypatch.setattr(session_mod.time, "sleep", lambda s: None)
+    session_mod._wait_until_the_page_stops_moving(execute)
+
+    # Stopped as soon as two readings agreed, and not before.
+    assert seen == ["https://p.test/a", "https://p.test/b", "https://p.test/b"]
+
+
+def test_the_stabiliser_gives_up_rather_than_hanging(monkeypatch):
+    """A page that never settles must not hold the whole replay.
+
+    The step itself waits for its own control and reports what it finds, which
+    is a better error than a timeout with no context.
+    """
+    monkeypatch.setattr(session_mod.time, "sleep", lambda s: None)
+    calls = {"n": 0}
+
+    def always_moving(command, params=None):
+        calls["n"] += 1
+        return {"data": {"url": f"https://p.test/{calls['n']}"}}
+
+    session_mod._wait_until_the_page_stops_moving(always_moving)
+    assert calls["n"] > 1  # it did try

--- a/tests/test_replay_segments.py
+++ b/tests/test_replay_segments.py
@@ -161,3 +161,35 @@ def test_no_wait_when_the_predecessor_did_not_arrive(monkeypatch):
     monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
     run_replay(OPS, profile_slug="p", token="t", entry_url=OVERVIEW)
     assert waited == []
+
+
+def test_the_arrival_budget_comes_from_the_recording(monkeypatch):
+    """The human's own gap, buffered — not a constant pretending to be one.
+
+    On ICICI the gap after the hop to the statement portal was 17.2s; a 3s
+    constant gave up long before the form appeared, and a flat 20s was under the
+    29s the human took elsewhere.
+    """
+    seen: list[float] = []
+    monkeypatch.setattr(
+        session_mod, "_await_first_control",
+        lambda ex, steps, budget: seen.append(budget),
+    )
+    page = _Page(OVERVIEW, after_first=CC)
+    monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
+
+    ops = [dict(OPS[0], causes_arrival_budget_ms=25819), OPS[1]]
+    run_replay(ops, profile_slug="p", token="t", entry_url=OVERVIEW)
+    assert seen == [25.819]
+
+
+def test_a_skill_without_a_recorded_budget_uses_the_constant(monkeypatch):
+    seen: list[float] = []
+    monkeypatch.setattr(
+        session_mod, "_await_first_control",
+        lambda ex, steps, budget: seen.append(budget),
+    )
+    page = _Page(OVERVIEW, after_first=CC)
+    monkeypatch.setattr("noui_core.verify.session._executor", lambda *a, **k: page)
+    run_replay(OPS, profile_slug="p", token="t", entry_url=OVERVIEW)
+    assert seen == [session_mod._ARRIVAL_BUDGET_S]

--- a/tests/test_split_boundary.py
+++ b/tests/test_split_boundary.py
@@ -1,0 +1,45 @@
+def test_an_empty_workflow_half_is_refused_not_returned():
+    """A boundary that places nothing throws the recording away silently.
+
+    `_keep` sends anything it cannot PLACE to the login side, deliberately, so a
+    login request never leaks into the workflow. A boundary carrying a null
+    position places nothing — every event goes left, the workflow half comes out
+    empty, and the compiler is handed a capture of a journey that was never
+    sliced off. It compiled to nothing and said nothing, and the agent reading
+    that concluded the RECORDING was wrong: it asked a member to sign in and
+    drive the whole journey again to route around a bug that had already
+    discarded their capture.
+    """
+    import pytest
+    from noui_core.capture import split as split_mod
+
+    bundle = {
+        "click_events": [
+            {"seq": 1, "url": "https://x.test/login"},
+            {"seq": 4, "url": "https://x.test/app"},
+        ],
+        "url_events": [
+            {"seq": 2, "from_url": "https://x.test/login", "to_url": "https://x.test/app"}
+        ],
+    }
+    # A boundary that can place nothing: every event lands on the login side.
+    monkey = lambda _b: {"seq": None, "timestamp": None}  # noqa: E731
+    original = split_mod._boundary_event
+    split_mod._boundary_event = monkey
+    try:
+        with pytest.raises(split_mod.SplitError) as caught:
+            split_mod.split_bundle(bundle)
+    finally:
+        split_mod._boundary_event = original
+
+    assert "empty workflow half" in str(caught.value)
+    # Says whose fault it is, because the last time this happened the human was
+    # asked to re-record something that was never broken.
+    assert "the recording itself is intact" in str(caught.value).lower()
+
+
+def test_no_login_segment_still_returns_none():
+    """Distinct from the failure above: 'nothing to split' is an ordinary answer."""
+    from noui_core.capture import split as split_mod
+
+    assert split_mod.split_bundle({"click_events": [], "url_events": []}) is None

--- a/tests/test_split_bundle.py
+++ b/tests/test_split_bundle.py
@@ -69,10 +69,28 @@ class TestBoundary:
         # after that is /enterpassword -> /dashboard at T[4].
         assert find_login_boundary(_merged_bundle()) == T[4]
 
-    def test_no_credential_fields_returns_none(self) -> None:
+    def test_a_login_that_typed_nothing_still_has_a_boundary(self) -> None:
+        """ICICI offers a QR sign-in: scan with the bank's app, type nothing.
+
+        Defining "a login happened" as "credentials were typed" made those
+        recordings permanently unsplittable — and SSO redirects, magic links and
+        biometric approval are the same shape. The transition OUT of the sign-in
+        flow is what every one of them leaves behind.
+        """
         b = _merged_bundle()
         for c in b["click_events"]:
             c["field_role"] = None
+        # /enterpassword -> /dashboard is the exit from the sign-in flow.
+        assert find_login_boundary(b) == T[4]
+
+    def test_a_capture_with_no_sign_in_at_all_has_no_boundary(self) -> None:
+        b = _merged_bundle()
+        for c in b["click_events"]:
+            c["field_role"] = None
+        b["url_events"] = [
+            _url(T[0], "about:blank", "https://app.example.com/dashboard"),
+            _url(T[6], "https://app.example.com/dashboard", "https://app.example.com/reports"),
+        ]
         assert find_login_boundary(b) is None
 
     def test_no_nav_after_credentials_falls_back_to_last_credential(self) -> None:
@@ -83,10 +101,26 @@ class TestBoundary:
 
 class TestSplit:
     def test_workflow_only_bundle_returns_none(self) -> None:
+        # Genuinely workflow-only: recorded against an already-authenticated
+        # profile, so the timeline never passes through a sign-in page.
         b = _merged_bundle()
         for c in b["click_events"]:
             c["field_role"] = None
+        b["url_events"] = [
+            _url(T[0], "about:blank", "https://app.example.com/dashboard"),
+            _url(T[6], "https://app.example.com/dashboard", "https://app.example.com/reports"),
+        ]
         assert split_bundle(b) is None
+
+    def test_a_qr_login_splits_on_the_exit_from_the_sign_in_page(self) -> None:
+        b = _merged_bundle()
+        for c in b["click_events"]:
+            c["field_role"] = None
+        parts = split_bundle(b)
+        assert parts is not None
+        login, workflow = parts
+        # The workflow slice starts after the app was reached, not before.
+        assert all("login" not in (u.get("to_url") or "") for u in workflow["url_events"])
 
     def test_login_slice_keeps_credentials_and_login_request(self) -> None:
         login, _ = split_bundle(_merged_bundle())

--- a/tests/test_split_diagnosis.py
+++ b/tests/test_split_diagnosis.py
@@ -1,0 +1,64 @@
+"""The splitter says what it saw, so a wrong answer is diagnosable.
+
+The split turns on ONE thing — whether an interaction was tagged as a credential
+field — and when that tagging fails the bundle is declared login-free however
+plainly its URL timeline shows a sign-in. A member who HAD recorded a login was
+asked to record it again, with nothing anywhere explaining why.
+"""
+
+from noui_core.capture.split import split_diagnosis
+
+BASE = "https://retailnetbanking.icici.bank.in"
+
+
+def test_it_names_the_boundary_when_a_login_is_found():
+    bundle = {
+        "click_events": [
+            {"seq": 1, "field_role": "username", "timestamp": "2026-08-10T10:00:00Z"},
+            {"seq": 2, "field_role": "password", "timestamp": "2026-08-10T10:00:05Z"},
+        ],
+        "url_events": [
+            {"seq": 3, "to_url": f"{BASE}/overview", "timestamp": "2026-08-10T10:00:06Z"}
+        ],
+    }
+    out = split_diagnosis(bundle)
+    assert "login ends at seq=" in out
+    assert "2 credential interaction(s)" in out
+
+
+def test_it_explains_a_sign_in_it_could_not_slice():
+    """The ICICI case: the login is plainly in the timeline and untagged."""
+    bundle = {
+        "click_events": [{"seq": 2, "text": "Login"}, {"seq": 4, "text": "Cards"}],
+        "url_events": [
+            {"seq": 1, "to_url": f"{BASE}/login-page"},
+            {"seq": 3, "to_url": f"{BASE}/overview"},
+        ],
+    }
+    out = split_diagnosis(bundle)
+    assert "NO login segment" in out
+    assert "0 tagged as credential fields" in out
+    # and it points at the evidence that contradicts the conclusion
+    assert "look like a sign-in" in out
+    assert "login-page" in out
+    assert "virtual keyboard" in out
+
+
+def test_it_reports_the_field_roles_it_did_see():
+    bundle = {
+        "click_events": [{"seq": 1, "field_role": "search"}],
+        "url_events": [{"seq": 2, "to_url": f"{BASE}/overview"}],
+    }
+    out = split_diagnosis(bundle)
+    assert "field roles seen: search" in out
+
+
+def test_a_workflow_only_capture_is_reported_plainly():
+    # No sign-in urls either: nothing surprising, nothing to explain away.
+    bundle = {
+        "click_events": [{"seq": 1, "text": "Cards"}],
+        "url_events": [{"seq": 2, "to_url": f"{BASE}/overview"}],
+    }
+    out = split_diagnosis(bundle)
+    assert "NO login segment" in out
+    assert "look like a sign-in" not in out

--- a/tests/test_split_diagnosis.py
+++ b/tests/test_split_diagnosis.py
@@ -62,3 +62,51 @@ def test_a_workflow_only_capture_is_reported_plainly():
     out = split_diagnosis(bundle)
     assert "NO login segment" in out
     assert "look like a sign-in" not in out
+
+
+def test_a_deep_app_route_containing_auth_is_not_the_login_exit():
+    """ICICI's statement portal is infinity.icici.bank.in/corp/AuthenticationController.
+
+    Its path contains "auth", so it read as a sign-in page, and the LAST exit
+    from a sign-in page fell at the end of the workflow — slicing the entire
+    statement journey into the login half and leaving the workflow half empty.
+    A sign-in bounces within its own host; a different host reached by clicking
+    around inside the app is the app.
+    """
+    from noui_core.capture.split import _boundary_event
+
+    bundle = {
+        "click_events": [{"seq": 2, "text": "Credit Cards"}],
+        "url_events": [
+            {"seq": 1, "from_url": "about:blank", "to_url": f"{BASE}/login-page"},
+            {"seq": 3, "from_url": f"{BASE}/login-page", "to_url": f"{BASE}/overview"},
+            {
+                "seq": 9,
+                "from_url": f"{BASE}/credit-card",
+                "to_url": "https://infinity.icici.bank.in/corp/AuthenticationController",
+            },
+            {
+                "seq": 22,
+                "from_url": "https://infinity.icici.bank.in/corp/AuthenticationController",
+                "to_url": "https://infinity.icici.bank.in/corp/Finacle",
+            },
+        ],
+    }
+    assert _boundary_event(bundle)["seq"] == 3
+
+
+def test_an_otp_bounce_on_the_login_host_still_extends_the_login():
+    # The reason the LAST exit is taken: a sign-in commonly returns to an OTP or
+    # consent screen before finally landing.
+    from noui_core.capture.split import _boundary_event
+
+    bundle = {
+        "click_events": [{"seq": 2, "text": "Continue"}],
+        "url_events": [
+            {"seq": 1, "from_url": "about:blank", "to_url": f"{BASE}/login-page"},
+            {"seq": 3, "from_url": f"{BASE}/login-page", "to_url": f"{BASE}/interstitial"},
+            {"seq": 5, "from_url": f"{BASE}/interstitial", "to_url": f"{BASE}/otp"},
+            {"seq": 7, "from_url": f"{BASE}/otp", "to_url": f"{BASE}/overview"},
+        ],
+    }
+    assert _boundary_event(bundle)["seq"] == 7

--- a/tests/test_step_when.py
+++ b/tests/test_step_when.py
@@ -26,12 +26,17 @@ DOWNLOAD_OP = {
     "parameters": [{"name": "timeframe", "default": "monthly"}],
     "steps": [
         {"command": "click_by_text", "params": {"text": "download previous statement"}},
-        {"command": "click_element", "params": {"selector": "#HDisplay23"},
-         "when": {"timeframe": "monthly"}},
-        {"command": "click_by_text", "params": {"text": "Annual"},
-         "when": {"timeframe": "annual"}},
-        {"command": "click_by_text", "params": {"text": "{{financial_year}}"},
-         "when": {"timeframe": "annual"}},
+        {
+            "command": "click_element",
+            "params": {"selector": "#HDisplay23"},
+            "when": {"timeframe": "monthly"},
+        },
+        {"command": "click_by_text", "params": {"text": "Annual"}, "when": {"timeframe": "annual"}},
+        {
+            "command": "click_by_text",
+            "params": {"text": "{{financial_year}}"},
+            "when": {"timeframe": "annual"},
+        },
         {"command": "click_element", "params": {"selector": "#DOWNLOAD_ESTATEMENT_PDF"}},
     ],
 }
@@ -68,7 +73,7 @@ def test_choosing_the_other_variant_swaps_the_divergent_steps():
     assert targets == [
         "download previous statement",
         "Annual",
-        "FY2025-26",          # substitution still applies to the steps that survive
+        "FY2025-26",  # substitution still applies to the steps that survive
         "#DOWNLOAD_ESTATEMENT_PDF",
     ]
     assert "#HDisplay23" not in targets
@@ -77,8 +82,8 @@ def test_choosing_the_other_variant_swaps_the_divergent_steps():
 def test_the_shared_prefix_and_suffix_run_for_every_variant():
     for tf in ("monthly", "annual"):
         cmds = _commands(DOWNLOAD_OP, {"timeframe": tf})
-        assert cmds[0] == "click_by_text"      # reaching the page
-        assert cmds[-1] == "click_element"     # the download itself
+        assert cmds[0] == "click_by_text"  # reaching the page
+        assert cmds[-1] == "click_element"  # the download itself
 
 
 def test_every_named_key_has_to_match():

--- a/tests/test_step_when.py
+++ b/tests/test_step_when.py
@@ -1,0 +1,103 @@
+"""A step can say which variant of an operation it belongs to.
+
+Two operations recorded from one page often differ by WHICH STEPS RUN, not by a
+value. ICICI's monthly and annual statements share four steps to reach the
+download page — hover the nav, Credit Cards, Past, download previous statement —
+and then diverge: annual clicks a radio and picks a financial year, monthly does
+not. Substitution fills placeholders; it cannot add or remove a step. So the
+compiler emitted both as separate operations, each replaying the whole journey
+from the landing page, which is what made every operation need the browser
+returned to the entry page first.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+
+from noui_core.verify.replay import step_applies, substitute_parameters  # noqa: E402
+
+# The real divergence, reduced to the steps that differ.
+DOWNLOAD_OP = {
+    "name": "download_statement",
+    "parameters": [{"name": "timeframe", "default": "monthly"}],
+    "steps": [
+        {"command": "click_by_text", "params": {"text": "download previous statement"}},
+        {"command": "click_element", "params": {"selector": "#HDisplay23"},
+         "when": {"timeframe": "monthly"}},
+        {"command": "click_by_text", "params": {"text": "Annual"},
+         "when": {"timeframe": "annual"}},
+        {"command": "click_by_text", "params": {"text": "{{financial_year}}"},
+         "when": {"timeframe": "annual"}},
+        {"command": "click_element", "params": {"selector": "#DOWNLOAD_ESTATEMENT_PDF"}},
+    ],
+}
+
+
+def _commands(op, values=None):
+    return [s["command"] for s in substitute_parameters(op, values)]
+
+
+def test_a_step_with_no_condition_always_runs():
+    # Everything compiled before `when` existed must behave exactly as it did.
+    assert step_applies({"command": "click_element"}, {}) is True
+    assert step_applies({"command": "click_element", "when": {}}, {}) is True
+    assert step_applies({"command": "click_element", "when": None}, {}) is True
+
+
+def test_the_default_variant_runs_its_own_steps_only():
+    steps = substitute_parameters(DOWNLOAD_OP)
+    targets = [
+        (s.get("params") or {}).get("selector") or (s.get("params") or {}).get("text")
+        for s in steps
+    ]
+    assert targets == ["download previous statement", "#HDisplay23", "#DOWNLOAD_ESTATEMENT_PDF"]
+
+
+def test_choosing_the_other_variant_swaps_the_divergent_steps():
+    steps = substitute_parameters(
+        DOWNLOAD_OP, {"timeframe": "annual", "financial_year": "FY2025-26"}
+    )
+    targets = [
+        (s.get("params") or {}).get("selector") or (s.get("params") or {}).get("text")
+        for s in steps
+    ]
+    assert targets == [
+        "download previous statement",
+        "Annual",
+        "FY2025-26",          # substitution still applies to the steps that survive
+        "#DOWNLOAD_ESTATEMENT_PDF",
+    ]
+    assert "#HDisplay23" not in targets
+
+
+def test_the_shared_prefix_and_suffix_run_for_every_variant():
+    for tf in ("monthly", "annual"):
+        cmds = _commands(DOWNLOAD_OP, {"timeframe": tf})
+        assert cmds[0] == "click_by_text"      # reaching the page
+        assert cmds[-1] == "click_element"     # the download itself
+
+
+def test_every_named_key_has_to_match():
+    # A step can belong to a COMBINATION of choices, not just one.
+    step = {"command": "x", "when": {"timeframe": "annual", "format": "pdf"}}
+    assert step_applies(step, {"timeframe": "annual", "format": "pdf"}) is True
+    assert step_applies(step, {"timeframe": "annual", "format": "csv"}) is False
+
+
+def test_an_unknown_parameter_never_matches_by_accident():
+    # A `when` naming something the operation does not declare is a compiler bug
+    # or a hand edit. Skipping is the safe reading: running a step whose
+    # condition nobody can evaluate is how a download fires on the wrong page.
+    step = {"command": "x", "when": {"nonexistent": "annual"}}
+    assert step_applies(step, {"timeframe": "annual"}) is False
+
+
+def test_values_are_compared_as_text():
+    # Parameters arrive from a CLI and from JSON, so 2 and "2" are the same
+    # choice; a mismatch here would drop a step for a reason nobody could see.
+    assert step_applies({"when": {"page": 2}}, {"page": "2"}) is True
+    assert step_applies({"when": {"page": "2"}}, {"page": 2}) is True

--- a/tests/test_tabby_draft_generate.py
+++ b/tests/test_tabby_draft_generate.py
@@ -489,11 +489,12 @@ class TestAnalyzeHar:
 class TestBuildAppTemplatePayload:
     """The App Template emitter payload derived from the generated drafts."""
 
-    def _drafts(self) -> tuple[dict, dict]:
+    def _drafts(self, **kwargs) -> tuple[dict, dict]:
         result = generate(
             _session(app_name="My App", login_url="https://app.example.com/login"),
             [_click(field_role="username"), _click(field_role="password", input_type="password")],
             [_url_event("https://app.example.com/home")],
+            **kwargs,
         )
         return result["application_draft"], result["service_profile_draft"]
 
@@ -605,8 +606,26 @@ class TestBuildAppTemplatePayload:
         app, prof = self._drafts()
         payload = build_app_template_payload(app, prof)
         # app draft has no browser_policy → safe default, not None.
+        # block_navigate is False here: this is a replay-style app, and refusing
+        # navigate would take away a command it may legitimately need.
         assert payload["browser_policy"] == {
             "clipboard": False,
             "downloads": False,
             "file_chooser": False,
+            "block_navigate": False,
         }
+
+    def test_a_browser_driven_app_refuses_navigate(self) -> None:
+        # A full-page navigation is a reload, and refresh-sensitive portals
+        # destroy the session on one — ICICI lands on /session-expire and the
+        # member is asked to sign in again mid-task. The compiled skill never
+        # emits navigate (it replays the recorded click chain), so nothing
+        # legitimate is lost; what this stops is an agent that gets stuck and
+        # reaches for it anyway.
+        #
+        # Set at compile time because every recording mints a NEW profile:
+        # setting it by hand protects the app you just fixed and none of the
+        # ones you build next.
+        app, prof = self._drafts(keepalive_style="activity")
+        payload = build_app_template_payload(app, prof)
+        assert payload["browser_policy"]["block_navigate"] is True

--- a/tests/test_tabby_sessions.py
+++ b/tests/test_tabby_sessions.py
@@ -80,3 +80,34 @@ def test_create_recording_session_omits_residential_proxy_by_default(monkeypatch
     tabby_client.create_recording_session("login", "https://example.com", "agent-tok")
     # Omitted (not False) so the recording-shell app default applies server-side.
     assert "residential_proxy" not in captured["body"]
+
+
+def test_browser_driven_is_omitted_by_default(monkeypatch):
+    """Full HAR unless the skill kind is known — a workflow recording of an
+    ordinary REST app compiles by replay and needs every request field."""
+    captured: dict = {}
+
+    def fake_http(method, path, body=None, token=None, timeout=None, **kw):
+        captured["body"] = body
+        return {"vnc_url": "https://vnc.test/#token=t", "session_id": "s1"}
+
+    monkeypatch.setattr(tabby_client, "_tabby_http", fake_http)
+    tabby_client.create_recording_session("workflow", "https://app.test", "tok")
+
+    assert "browser_driven" not in captured["body"]
+
+
+def test_browser_driven_is_sent_when_declared(monkeypatch):
+    captured: dict = {}
+
+    def fake_http(method, path, body=None, token=None, timeout=None, **kw):
+        captured["body"] = body
+        return {"vnc_url": "https://vnc.test/#token=t", "session_id": "s1"}
+
+    monkeypatch.setattr(tabby_client, "_tabby_http", fake_http)
+    tabby_client.create_recording_session(
+        "workflow", "https://bank.test", "tok", browser_driven=True
+    )
+
+    assert captured["body"]["browser_driven"] is True
+    assert captured["body"]["recording_mode"] == "workflow"

--- a/tests/test_unreplayable.py
+++ b/tests/test_unreplayable.py
@@ -198,3 +198,72 @@ def test_no_auto_browser_override_forces_replay(tmp_path):
     # detector never ran; the replay path was used
     assert res.get("browser_detection") is None
     assert res["skill"]["runtime"]["operation_style"] != "browser"
+
+
+# --- metadata-reduced HARs (Tabby workflow bundles, schema_version >= 5) -------
+#
+# Tabby strips bodies/headers/query strings from workflow HARs: a browser skill
+# never replays a request, and a bank portal's payloads have no business sitting
+# in a bundle in S3. It keeps the body's SHAPE — top-level field names plus a flag
+# for whether any value was a long string — precisely so the browser-vs-replay
+# decision stays automatic. Without these, every reduced recording would look
+# replayable and ICICI would compile back into 40 operations that all 403.
+
+_APP = "https://retailnetbanking.icici.bank.in"
+
+
+def _reduced_entry(url, method="POST", keys=None, long_values=False):
+    return {
+        "startedDateTime": "2026-08-07T10:00:00Z",
+        "time": 100,
+        "request": {
+            "method": method,
+            "url": url,
+            "headers": [],
+            "queryString": [],
+            "postData": (
+                {"mimeType": "application/json", "keys": keys, "long_values": long_values}
+                if keys is not None
+                else {"mimeType": ""}
+            ),
+        },
+        "response": {"status": 200, "content": {"mimeType": "application/json", "text": ""}},
+    }
+
+
+def _reduced_har(entries):
+    return {"log": {"version": "1.2", "creator": {}, "entries": entries}}
+
+
+def test_detects_unreplayable_from_a_metadata_reduced_har():
+    har = _reduced_har(
+        [_reduced_entry(f"{_APP}/api/getKeys", method="GET")]
+        + [
+            _reduced_entry(f"{_APP}/api/op{i}", keys=["data", "key"], long_values=True)
+            for i in range(4)
+        ]
+    )
+    assert detect_unreplayable(har, app_origin=_APP)["unreplayable"] is True
+
+
+def test_a_reduced_har_of_a_normal_api_stays_replayable():
+    # Domain field names are not an envelope, so replay remains the right compile.
+    har = _reduced_har(
+        [
+            _reduced_entry(f"{_APP}/api/op{i}", keys=["accountId", "fromDate"], long_values=True)
+            for i in range(5)
+        ]
+    )
+    assert detect_unreplayable(har, app_origin=_APP)["unreplayable"] is False
+
+
+def test_envelope_names_without_ciphertext_length_are_not_an_envelope():
+    # Mirrors the text-based guard against a trivially-empty {"data": ""}.
+    har = _reduced_har(
+        [_reduced_entry(f"{_APP}/api/getKeys", method="GET")]
+        + [
+            _reduced_entry(f"{_APP}/api/op{i}", keys=["data", "key"], long_values=False)
+            for i in range(4)
+        ]
+    )
+    assert detect_unreplayable(har, app_origin=_APP)["unreplayable"] is False


### PR DESCRIPTION
The compiler side of the browser-skill recording redesign. Companion to adoptai/tabby#163.

## Why

`_nav_clicks_for` captured a `selector` on every navigation click and `_steps_for_page` **discarded it** — every step compiled to `click_by_text` on visible text alone. With Tabby schema_version >= 4 there is far more to work with.

## Locator choice (new `noui_core.compile.locators`)

Each recorded click now carries several candidates, each with the number of nodes it matched **at record time**. Selection prefers a candidate that matched exactly **one** node over a more durable *kind* that matched several — uniqueness outranks durability, which is the entire reason the count is recorded.

`match_count == 0` is never chosen. It means the candidate did not match even the element it was recorded from — normal for a node inside a shadow root, where the document query cannot see it, and a guaranteed runtime failure if emitted.

## Steps

CSS-expressible winners compile to `click_element` with the recorded selector; semantic ones to `click_by_text` with `exact: true` — the recorder established the text matched **one** control, and a substring match can only widen that back into the ambiguity we just removed.

**Icon controls now compile instead of being dropped.** A click with no visible text was discarded outright, which threw away the hamburger and the chevrons that open a bank nav's accordions — and because the page behind them then had no recoverable nav, the *page* was dropped too.

## Postconditions

Steps carry what the recorder **observed** after the click: the resulting URL, whether a download started, and how long traffic took to settle (doubled for headroom, floored at a second). A linear script cannot tell it has gone wrong and just keeps clicking; an expectation makes that checkable in one step instead of surfacing five clicks later on the wrong page with confidently wrong data.

**Worth reviewing:** nothing enforces `expect` at runtime — the harness executes commands and does not validate it. So SKILL.md is the enforcement: it tells the agent to run steps exactly as given and to stop and report when an expectation fails. With an LLM runtime that is real, but it is persuasion, not a guarantee. A hard check means a harness change.

## Ambiguity is surfaced, not hidden

A locator known to match several elements is named in SKILL.md as a known-weak step. Those are exactly the steps that compile cleanly and then misclick, and the human re-recording is the one who can fix them.

## Keeping browser-vs-replay detection alive

Tabby reduces browser-driven workflow HARs to metadata. `detect_unreplayable` decides whether an app can be a replay skill at all by testing whether its bodies are opaque `{data,key}` encryption envelopes — and it reads `postData.text`, which the reduction empties. That would have silently disabled the decision, sending ICICI back to 40 operations that all 403.

The test only ever reduced to two structural facts: are the top-level field names a subset of the envelope set, and did any value look like ciphertext. Tabby preserves exactly that, so the same verdict is reachable without the bytes.

Also adds a **capture-downgrade warning**: when the classifier says a bundle is a workflow capture but it carries no workflow-shaped capture, the recording pod most likely ran in login mode. Read from content, not the mode stamp — this repo already knows not to trust that label. A warning, never an error.

## Provisioning

`browser_driven` is now declared when provisioning a recording, and **omitted when false** so the default stays a full HAR. It is the skill *kind*, not the authoring phase: a workflow recording of an ordinary REST app compiles by replay and needs every request field. Set it only when the kind is already known; otherwise record full and let `detect_unreplayable` decide.

## Compatibility

Recordings without candidates — everything captured before schema_version 4 — compile exactly as they did before, asserted by test.

**712 tests**, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also here now: the replay that proves the compilation

Compiling was never the hard part. Verifying it was — and every defect below produced
a **green report while doing the wrong thing**, which is the failure this gate exists
to prevent. All were found against a live ICICI session.

### Silent successes

- **A read that mutates.** Page operations collect every click made on their page, and
  the human did two things on ICICI's statement page: downloaded monthly, then
  switched to Annual and downloaded that. So the page read carried `set_checked
  Annual` and performed it for *every* replay — navigating away before the monthly
  download could run. Monthly fetched the wrong document with every step reporting ok.
  A read now stops where the next goal begins.
- **A variant guarded on its destination.** A folded operation's `starts_from` came
  from its terminal's page. ICICI's annual statement is *chosen* on
  `/corp/AuthenticationController` and only *lands* on `/corp/Finacle`, so the annual
  variant refused itself on the page it starts from. Each variant now takes its origin
  from the first step that carries a page.
- **Someone else's file as evidence.** `list_downloads` reports the whole session's
  downloads, so a statement fetched by a previous run counted as this one's proof. Two
  consecutive runs reported success while the download count never moved. The baseline
  is now taken when the run starts.
- **An operation that ran nothing.** `goal_reached` returned true for an empty step
  list, because "no step was blocked" is trivially satisfied by nothing.
- **A mixture of segmented and unsegmented operations.** One operation without a
  segment silently downgraded *every* operation to the legacy reset-before-each model
  — a different execution model, chosen without a word in the report. Now refused by
  name.

### Waiting on what is actually true

Every click on ICICI's statement portal records an EMPTY outcome (`navigated: false,
settled_ms: null`) because the hop is cross-origin and completes after the click
returns. So no step there carries a settle, and the replay fired the next one into a
page mid-load — which that portal treats as a double click and answers by expiring the
session. The replay now waits for the page to be *ready* (document state, not just a
stable URL) when the recording measured nothing.

### Verified end to end

Both statement types, from one recorded session, one compiled skill, one live session:

| variant | file |
|---|---|
| monthly | 814232 bytes — a month range |
| annual | 85189 bytes — `Statement Period 01/04/2025 TO 31/03/2026`, read from the PDF |

1024 tests.
