### PR TITLE
fix(capture): accept platform_jwt credentials for recording sessions

### DIFF
--- a/skills/noui/noui_core/capture/recording.py
+++ b/skills/noui/noui_core/capture/recording.py
@@ -20,8 +20,20 @@ from noui_core.capture.classify import classify_bundle
 from noui_core.config import settings
 
 _MISSING_CREDS = (
-    "TABBY_CLIENT_ID and TABBY_CLIENT_SECRET must be set (or present in the env / .env) "
-    "to authenticate against Tabby. Run your Tabby setup first."
+    "No Tabby credentials found. Set either ADOPT_API_URL + ADOPT_CLIENT_ID + "
+    "ADOPT_CLIENT_SECRET (platform_jwt — a platform PAT, exchanged for a Tabby bearer "
+    "carrying your real role) or TABBY_CLIENT_ID + TABBY_CLIENT_SECRET (agent_token). "
+    "Either may live in the env or a .env file."
+)
+
+_MISSING_PLATFORM_CREDS = (
+    "NOUI_TABBY_AUTH_MODE=platform_jwt but ADOPT_API_URL / ADOPT_CLIENT_ID / "
+    "ADOPT_CLIENT_SECRET are not all set — platform_jwt exchanges those for a Tabby bearer."
+)
+
+_MISSING_AGENT_CREDS = (
+    "NOUI_TABBY_AUTH_MODE=agent_token but TABBY_CLIENT_ID / TABBY_CLIENT_SECRET are not "
+    "both set. Run your Tabby setup first, or use platform_jwt with ADOPT_* credentials."
 )
 
 _MISSING_BROKER_TOKEN = (
@@ -30,19 +42,67 @@ _MISSING_BROKER_TOKEN = (
 )
 
 
+def _platform_creds() -> tuple[str, str, str]:
+    return (
+        os.environ.get("ADOPT_API_URL", "").rstrip("/"),
+        os.environ.get("ADOPT_CLIENT_ID", ""),
+        os.environ.get("ADOPT_CLIENT_SECRET", ""),
+    )
+
+
+def _agent_creds() -> tuple[str, str]:
+    return os.environ.get("TABBY_CLIENT_ID", ""), os.environ.get("TABBY_CLIENT_SECRET", "")
+
+
 def resolve_agent_token() -> str:
     """Resolve the bearer NoUI sends to ``settings.tabby_api_host``.
 
-    In ``broker`` mode this is the opaque per-conversation capability token (the
-    broker swaps it for the real per-user Tabby bearer); no Tabby client creds are
-    needed or present in the sandbox. Otherwise it is a minted Tabby agent token.
+    Same preference order as ``activate.register.resolve_admin_token`` — recording
+    previously accepted only broker and agent_token, so a runtime holding the
+    platform credentials NoUI already uses everywhere else could list app templates
+    but could not provision the recording session it needs to create one:
+
+      1. ``broker`` — the opaque per-conversation capability the harness injects;
+         the broker swaps it for the user's federated bearer, so no Tabby
+         credential is present in the sandbox at all.
+      2. ``platform_jwt`` (ADOPT_API_URL + ADOPT_CLIENT_ID + ADOPT_CLIENT_SECRET) —
+         exchanged for a Tabby JWT carrying the caller's real IdP-resolved role.
+         Preferred over agent_token when the mode is not pinned, because it reuses
+         the credentials NoUI already needs rather than a second, separately
+         managed pair.
+      3. ``agent_token`` (TABBY_CLIENT_ID + TABBY_CLIENT_SECRET) — a minted Tabby
+         agent token, for local/self-host setups with no platform integration.
+
+    An explicitly set ``NOUI_TABBY_AUTH_MODE`` is honoured and fails loudly when
+    its own credentials are missing, rather than silently falling through to a
+    different identity.
     """
     if settings.broker_mode():
         if not settings.broker_token:
             raise RuntimeError(_MISSING_BROKER_TOKEN)
         return settings.broker_token
-    client_id = os.environ.get("TABBY_CLIENT_ID", "")
-    client_secret = os.environ.get("TABBY_CLIENT_SECRET", "")
+
+    mode = settings.tabby_auth_mode
+    adopt_api_url, adopt_client_id, adopt_client_secret = _platform_creds()
+    client_id, client_secret = _agent_creds()
+
+    if mode == "platform_jwt":
+        if not (adopt_api_url and adopt_client_id and adopt_client_secret):
+            raise RuntimeError(_MISSING_PLATFORM_CREDS)
+        return tabby_client.get_platform_tabby_token(
+            adopt_api_url, adopt_client_id, adopt_client_secret
+        )
+
+    if mode == "agent_token":
+        if not (client_id and client_secret):
+            raise RuntimeError(_MISSING_AGENT_CREDS)
+        return tabby_client.get_agent_token(client_id, client_secret)
+
+    # Mode unpinned: prefer the platform credentials, matching resolve_admin_token.
+    if adopt_api_url and adopt_client_id and adopt_client_secret:
+        return tabby_client.get_platform_tabby_token(
+            adopt_api_url, adopt_client_id, adopt_client_secret
+        )
     if not (client_id and client_secret):
         raise RuntimeError(_MISSING_CREDS)
     return tabby_client.get_agent_token(client_id, client_secret)

--- a/skills/noui/noui_core/capture/recording.py
+++ b/skills/noui/noui_core/capture/recording.py
@@ -20,10 +20,17 @@ from noui_core.capture.classify import classify_bundle
 from noui_core.config import settings
 
 _MISSING_CREDS = (
-    "No Tabby credentials found. Set either ADOPT_API_URL + ADOPT_CLIENT_ID + "
-    "ADOPT_CLIENT_SECRET (platform_jwt — a platform PAT, exchanged for a Tabby bearer "
-    "carrying your real role) or TABBY_CLIENT_ID + TABBY_CLIENT_SECRET (agent_token). "
-    "Either may live in the env or a .env file."
+    "No complete set of Tabby credentials found — a partially-set pair does not count. "
+    "Set either ADOPT_API_URL + ADOPT_CLIENT_ID + ADOPT_CLIENT_SECRET (platform_jwt — a "
+    "platform PAT, exchanged for a Tabby bearer carrying your real role) or both "
+    "TABBY_CLIENT_ID and TABBY_CLIENT_SECRET (agent_token). Either may live in the env "
+    "or a .env file."
+)
+
+_UNKNOWN_MODE = (
+    "Unknown NOUI_TABBY_AUTH_MODE {mode!r} — expected 'broker', 'platform_jwt', or "
+    "'agent_token'. Refusing to guess: a misspelled mode must not silently resolve a "
+    "different identity."
 )
 
 _MISSING_PLATFORM_CREDS = (
@@ -74,8 +81,8 @@ def resolve_agent_token() -> str:
          agent token, for local/self-host setups with no platform integration.
 
     An explicitly set ``NOUI_TABBY_AUTH_MODE`` is honoured and fails loudly when
-    its own credentials are missing, rather than silently falling through to a
-    different identity.
+    its own credentials are missing — and an unrecognised mode is rejected outright
+    — rather than silently falling through to a different identity.
     """
     if settings.broker_mode():
         if not settings.broker_token:
@@ -83,6 +90,12 @@ def resolve_agent_token() -> str:
         return settings.broker_token
 
     mode = settings.tabby_auth_mode
+    if mode and mode not in ("platform_jwt", "agent_token"):
+        # ``broker`` never reaches here (handled above). Anything else is a typo or a
+        # mode this resolver does not implement — raising beats falling through to a
+        # different identity, and matches activate.execute_adapter's behaviour.
+        raise RuntimeError(_UNKNOWN_MODE.format(mode=mode))
+
     adopt_api_url, adopt_client_id, adopt_client_secret = _platform_creds()
     client_id, client_secret = _agent_creds()
 

--- a/skills/noui/references/auth-modes.md
+++ b/skills/noui/references/auth-modes.md
@@ -32,7 +32,11 @@ tokens are cached per mode.
   `POST /admin/app-templates` (register) when broker mode is active.
 
 ## Where it applies
-- **Recording + register**: `agent_token` (recording) / `TABBY_ADMIN_TOKEN` (register).
+- **Recording + register**: both resolve in the same preference order —
+  `broker` → `platform_jwt` (`ADOPT_*`) → `agent_token` (recording:
+  `TABBY_CLIENT_ID/SECRET`) or `TABBY_ADMIN_TOKEN` (register). A pinned
+  `NOUI_TABBY_AUTH_MODE` is honoured and errors when its own credentials are
+  missing rather than resolving a different identity.
 - **Execution**: the vendored `noui_runtime/auth.py` in each generated asset
   mirrors these two modes for `POST /execute/fetch`.
 

--- a/tests/test_recording_platform_jwt_auth.py
+++ b/tests/test_recording_platform_jwt_auth.py
@@ -1,0 +1,102 @@
+"""Recording sessions must accept ``platform_jwt`` credentials.
+
+``capture.recording.resolve_agent_token`` used to accept only broker mode and
+agent_token, while ``activate.register.resolve_admin_token`` already preferred
+platform_jwt. A runtime configured the platform way could therefore list app
+templates but not provision the recording session needed to create one. These
+tests pin the shared preference order:
+
+    broker  >  platform_jwt (ADOPT_*)  >  agent_token (TABBY_CLIENT_*)
+
+with an explicitly pinned NOUI_TABBY_AUTH_MODE failing loudly rather than
+silently resolving a different identity.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from noui_core import tabby_client
+from noui_core.capture import recording
+from noui_core.config import settings
+
+PLATFORM_ENV = {
+    "ADOPT_API_URL": "https://api.adopt.ai",
+    "ADOPT_CLIENT_ID": "pat-cid",
+    "ADOPT_CLIENT_SECRET": "pat-secret",
+}
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    for var in ("TABBY_CLIENT_ID", "TABBY_CLIENT_SECRET", "ADOPT_API_URL",
+                "ADOPT_CLIENT_ID", "ADOPT_CLIENT_SECRET"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(settings, "tabby_auth_mode", "")
+    monkeypatch.setattr(settings, "broker_token", "")
+
+
+def _set(monkeypatch, env: dict) -> None:
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+
+
+class TestPlatformJwtAccepted:
+    def test_explicit_platform_jwt_mode_exchanges_platform_creds(self, clean_env, monkeypatch):
+        monkeypatch.setattr(settings, "tabby_auth_mode", "platform_jwt")
+        _set(monkeypatch, PLATFORM_ENV)
+        with patch.object(tabby_client, "get_platform_tabby_token", return_value="tabby-jwt") as ex:
+            assert recording.resolve_agent_token() == "tabby-jwt"
+        ex.assert_called_once_with("https://api.adopt.ai", "pat-cid", "pat-secret")
+
+    def test_platform_creds_preferred_when_mode_unpinned(self, clean_env, monkeypatch):
+        """Matches resolve_admin_token: platform creds win over agent creds."""
+        _set(monkeypatch, {**PLATFORM_ENV, "TABBY_CLIENT_ID": "cid", "TABBY_CLIENT_SECRET": "csec"})
+        with patch.object(tabby_client, "get_platform_tabby_token", return_value="tabby-jwt"), \
+             patch.object(tabby_client, "get_agent_token") as mint:
+            assert recording.resolve_agent_token() == "tabby-jwt"
+            mint.assert_not_called()
+
+    def test_trailing_slash_stripped_from_api_url(self, clean_env, monkeypatch):
+        _set(monkeypatch, {**PLATFORM_ENV, "ADOPT_API_URL": "https://api.adopt.ai/"})
+        with patch.object(tabby_client, "get_platform_tabby_token", return_value="t") as ex:
+            recording.resolve_agent_token()
+        assert ex.call_args[0][0] == "https://api.adopt.ai"
+
+    def test_explicit_platform_jwt_without_creds_raises(self, clean_env, monkeypatch):
+        monkeypatch.setattr(settings, "tabby_auth_mode", "platform_jwt")
+        with pytest.raises(RuntimeError, match="ADOPT_API_URL"):
+            recording.resolve_agent_token()
+
+
+class TestAgentTokenUnaffected:
+    def test_agent_creds_used_when_no_platform_creds(self, clean_env, monkeypatch):
+        _set(monkeypatch, {"TABBY_CLIENT_ID": "cid", "TABBY_CLIENT_SECRET": "csec"})
+        with patch.object(tabby_client, "get_agent_token", return_value="minted") as mint:
+            assert recording.resolve_agent_token() == "minted"
+        mint.assert_called_once_with("cid", "csec")
+
+    def test_pinned_agent_token_never_falls_through_to_platform(self, clean_env, monkeypatch):
+        """A pinned mode must fail loudly, not silently resolve another identity."""
+        monkeypatch.setattr(settings, "tabby_auth_mode", "agent_token")
+        _set(monkeypatch, PLATFORM_ENV)
+        with patch.object(tabby_client, "get_platform_tabby_token") as ex:
+            with pytest.raises(RuntimeError, match="TABBY_CLIENT_ID"):
+                recording.resolve_agent_token()
+            ex.assert_not_called()
+
+    def test_no_credentials_at_all_names_both_paths(self, clean_env):
+        with pytest.raises(RuntimeError) as exc:
+            recording.resolve_agent_token()
+        assert "ADOPT_CLIENT_ID" in str(exc.value) and "TABBY_CLIENT_ID" in str(exc.value)
+
+
+class TestBrokerStillWins:
+    def test_broker_mode_ignores_platform_creds(self, clean_env, monkeypatch):
+        monkeypatch.setattr(settings, "tabby_auth_mode", "broker")
+        monkeypatch.setattr(settings, "broker_token", "cap-tok")
+        _set(monkeypatch, PLATFORM_ENV)
+        with patch.object(tabby_client, "get_platform_tabby_token") as ex:
+            assert recording.resolve_agent_token() == "cap-tok"
+            ex.assert_not_called()

--- a/tests/test_recording_platform_jwt_auth.py
+++ b/tests/test_recording_platform_jwt_auth.py
@@ -30,8 +30,13 @@ PLATFORM_ENV = {
 
 @pytest.fixture
 def clean_env(monkeypatch):
-    for var in ("TABBY_CLIENT_ID", "TABBY_CLIENT_SECRET", "ADOPT_API_URL",
-                "ADOPT_CLIENT_ID", "ADOPT_CLIENT_SECRET"):
+    for var in (
+        "TABBY_CLIENT_ID",
+        "TABBY_CLIENT_SECRET",
+        "ADOPT_API_URL",
+        "ADOPT_CLIENT_ID",
+        "ADOPT_CLIENT_SECRET",
+    ):
         monkeypatch.delenv(var, raising=False)
     monkeypatch.setattr(settings, "tabby_auth_mode", "")
     monkeypatch.setattr(settings, "broker_token", "")
@@ -53,8 +58,10 @@ class TestPlatformJwtAccepted:
     def test_platform_creds_preferred_when_mode_unpinned(self, clean_env, monkeypatch):
         """Matches resolve_admin_token: platform creds win over agent creds."""
         _set(monkeypatch, {**PLATFORM_ENV, "TABBY_CLIENT_ID": "cid", "TABBY_CLIENT_SECRET": "csec"})
-        with patch.object(tabby_client, "get_platform_tabby_token", return_value="tabby-jwt"), \
-             patch.object(tabby_client, "get_agent_token") as mint:
+        with (
+            patch.object(tabby_client, "get_platform_tabby_token", return_value="tabby-jwt"),
+            patch.object(tabby_client, "get_agent_token") as mint,
+        ):
             assert recording.resolve_agent_token() == "tabby-jwt"
             mint.assert_not_called()
 

--- a/tests/test_recording_platform_jwt_auth.py
+++ b/tests/test_recording_platform_jwt_auth.py
@@ -98,6 +98,28 @@ class TestAgentTokenUnaffected:
             recording.resolve_agent_token()
         assert "ADOPT_CLIENT_ID" in str(exc.value) and "TABBY_CLIENT_ID" in str(exc.value)
 
+    def test_half_a_pair_is_not_credentials(self, clean_env, monkeypatch):
+        """Only one of the pair set — the error must not claim nothing was found."""
+        _set(monkeypatch, {"TABBY_CLIENT_ID": "cid"})
+        with pytest.raises(RuntimeError, match="partially-set pair"):
+            recording.resolve_agent_token()
+
+
+class TestUnknownModeRejected:
+    @pytest.mark.parametrize("bad", ["platfrom_jwt", "agenttoken", "jwt", "none"])
+    def test_unrecognised_mode_raises_instead_of_falling_through(self, clean_env, monkeypatch, bad):
+        """A typo'd mode must never silently resolve a different identity."""
+        monkeypatch.setattr(settings, "tabby_auth_mode", bad)
+        _set(monkeypatch, PLATFORM_ENV)
+        with (
+            patch.object(tabby_client, "get_platform_tabby_token") as ex,
+            patch.object(tabby_client, "get_agent_token") as mint,
+        ):
+            with pytest.raises(RuntimeError, match="Unknown NOUI_TABBY_AUTH_MODE"):
+                recording.resolve_agent_token()
+            ex.assert_not_called()
+            mint.assert_not_called()
+
 
 class TestBrokerStillWins:
     def test_broker_mode_ignores_platform_creds(self, clean_env, monkeypatch):


### PR DESCRIPTION
## Problem

`capture.recording.resolve_agent_token()` accepted only **broker** mode and **agent_token**, while `activate.register.resolve_admin_token()` already preferred **platform_jwt** — and its docstring calls that path *"preferred, because it reuses the same credentials NoUI already needs rather than a second, separately-managed pair."*

Recording never got that middle tier. A runtime holding the `ADOPT_*` platform credentials NoUI uses everywhere else can therefore **list app templates but cannot provision the recording session needed to create one**:

```
$ python scripts/capture_record.py --mode login --url https://<app>
Provisioning failed: TABBY_CLIENT_ID and TABBY_CLIENT_SECRET must be set
(or present in the env / .env) to authenticate against Tabby.
```

…even though perfectly usable credentials were present. Hit for real on an automated capture runtime configured with `NOUI_TABBY_AUTH_MODE=platform_jwt`; the only workarounds were provisioning a second credential pair or running inside a harness sandbox for the broker token (which is minted per-conversation with a 1h TTL and cannot be configured on a standalone runtime).

## Fix

Align recording with register's preference order:

    broker  >  platform_jwt (ADOPT_*)  >  agent_token (TABBY_CLIENT_*)

An explicitly pinned `NOUI_TABBY_AUTH_MODE` is now honoured and **fails loudly** when its own credentials are missing, rather than silently falling through to a different identity — a pinned `agent_token` will not quietly resolve as the platform user.

**Existing agent_token setups are unaffected**: they have no `ADOPT_*` vars, so resolution reaches the same branch as before. Broker mode still short-circuits first.

The "no credentials at all" error now names both paths instead of only the Tabby pair.

## Tests

New `tests/test_recording_platform_jwt_auth.py` (10 cases): explicit platform_jwt exchange, platform-preferred-when-unpinned, trailing-slash normalization, pinned-mode-fails-loudly in both directions, agent_token unaffected, broker still wins, and the both-paths error message.

```
tests/test_recording_platform_jwt_auth.py + broker/provision/tabby_auth/capture_record  49 passed
full suite                                                                             692 passed
```

## Docs

`references/auth-modes.md` "Where it applies" said *"Recording: agent_token"* — updated to the shared preference order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)