### PR TITLE
fix(verify): catch a bundle-operations desync and stop mislabeling it a recording problem

### DIFF
--- a/skills/noui/noui_core/compile/provenance.py
+++ b/skills/noui/noui_core/compile/provenance.py
@@ -46,6 +46,25 @@ def bundle_digest(bundle: dict[str, Any]) -> str:
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()
 
 
+def bundle_matches_manifest(bundle: dict[str, Any], manifest: dict[str, Any]) -> bool:
+    """Is the recording bundle in the dir the one these operations were sealed from?
+
+    The manifest stamps ``bundle_sha256`` at compile time. If the dir's bundle
+    hashes to something else, ``operations.json`` and ``recording_bundle.json``
+    came from DIFFERENT compile/import runs -- a skill-directory consistency
+    problem, not a bad recording and not hand-editing. Checking this BEFORE
+    ``unobserved_locators`` matters: that check reads the dir's bundle, so a
+    swapped bundle makes it report the operations' real locators as "controls the
+    recording never saw" -- pointing the blame at the recording (and at a pointless
+    re-record) when the true fault is that the wrong bundle is sitting in the dir.
+
+    Returns True when they agree, or when the manifest carries no stamp to check
+    against (an older skill) -- absence of a stamp is not evidence of a mismatch.
+    """
+    stamped = str((manifest.get("provenance") or {}).get("bundle_sha256") or "")
+    return not stamped or bundle_digest(bundle) == stamped
+
+
 def observed_selectors(bundle: dict[str, Any]) -> set[str]:
     """Every locator value the recorder actually saw, in any form.
 

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -166,6 +166,34 @@ def main() -> int:
             print(f"Cannot read {bundle_path}: {exc}", file=sys.stderr)
             return 1
 
+        # The dir's bundle MUST be the one these operations were sealed from.
+        # A re-import, or a recompile against a different capture, can leave
+        # operations.json and recording_bundle.json in the dir out of sync -- and
+        # then unobserved_locators below reads the WRONG bundle and reports the
+        # operations' real locators as "controls the recording never saw", which
+        # reads as a bad recording and sends the build off to re-record. Catch the
+        # mismatch here, first, and name it for what it is.
+        if not provenance.bundle_matches_manifest(bundle, manifest):
+            stamped = str((manifest.get("provenance") or {}).get("bundle_sha256") or "")
+            print(
+                "SKILL DIRECTORY IS INCONSISTENT -- a COMPILE/IMPORT problem, NOT a "
+                "recording problem and NOT hand-editing.\n"
+                "\n"
+                "The recording_bundle.json in this skill dir is not the one these "
+                "operations were compiled from: its checksum does not match the "
+                f"manifest's bundle_sha256 ({stamped[:12]}...). operations.json and "
+                "recording_bundle.json came from different compile/import runs.\n"
+                "\n"
+                "DO NOT re-record -- the recording is fine; the wrong bundle is in the "
+                "dir. Restore the recording_bundle.json whose checksum matches the "
+                "manifest, or re-import ONCE so operations.json + recording_bundle.json "
+                "+ manifest.json all come from a single compile. (The 'controls the "
+                "recording never saw' error you would hit next is a symptom of this, "
+                "not a real fabrication.)",
+                file=sys.stderr,
+            )
+            return 1
+
         unbacked = provenance.unbacked_control_steps(operations)
         if unbacked:
             shown = ", ".join(repr(u) for u in unbacked[:5])
@@ -188,10 +216,12 @@ def main() -> int:
             print(
                 f"These steps target controls the recording never saw: {shown}{more}.\n"
                 "\n"
-                "The operations no longer match what was compiled from the recording, "
-                "which almost always means they were edited by hand after compiling. "
-                "Replaying now would drive a live session through steps nobody has "
-                "seen work, and when they miss, the run improvises and wanders.\n"
+                "The bundle checksum already matched the manifest, so this is NOT a "
+                "swapped bundle -- these operations genuinely diverge from THIS "
+                "recording. That almost always means they were edited by hand after "
+                "compiling. Replaying now would drive a live session through steps "
+                "nobody has seen work, and when they miss, the run improvises and "
+                "wanders.\n"
                 "\n"
                 "You may rename an operation, reword its description, or add a "
                 "parameter. You may NOT change what a step targets, reorder steps, "

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -205,3 +205,32 @@ def test_a_role_addressed_control_the_recording_never_saw_is_still_caught():
     ]
     bundle = {"click_events": [{"candidates": [{"kind": "role_name", "value": "radio|Annual"}]}]}
     assert unobserved_locators(ops, bundle) == ["Ghost"]
+
+
+def test_bundle_matches_manifest_catches_a_swapped_bundle():
+    """The desync verify_replay must catch BEFORE blaming the recording.
+
+    A re-import/recompile can leave a recording_bundle.json in the dir that is
+    not the one operations.json was sealed from. unobserved_locators then reads
+    the wrong bundle and reports real locators as unseen -- pointing at a bad
+    recording. bundle_matches_manifest names it for what it is: a dir mismatch.
+    """
+    from noui_core.compile.provenance import bundle_digest, bundle_matches_manifest
+
+    sealed = {"click_events": [{"candidates": [{"kind": "id", "value": "#dl"}]}]}
+    manifest = {"provenance": {"bundle_sha256": bundle_digest(sealed)}}
+
+    # The bundle that actually sealed the operations -> matches.
+    assert bundle_matches_manifest(sealed, manifest) is True
+    # A different capture left in the dir by a second import -> mismatch.
+    other = {"click_events": [{"candidates": [{"kind": "id", "value": "#other"}]}]}
+    assert bundle_matches_manifest(other, manifest) is False
+
+
+def test_bundle_matches_manifest_is_lenient_without_a_stamp():
+    # An older skill whose manifest carries no bundle_sha256 cannot be checked;
+    # absence of a stamp is not evidence of a mismatch.
+    from noui_core.compile.provenance import bundle_matches_manifest
+
+    assert bundle_matches_manifest({"click_events": []}, {}) is True
+    assert bundle_matches_manifest({"click_events": []}, {"provenance": {}}) is True

--- a/tests/test_verify_replay_gate.py
+++ b/tests/test_verify_replay_gate.py
@@ -1,0 +1,84 @@
+"""verify_replay's provenance gate tells a build WHICH kind of problem it hit.
+
+The failure that motivated this: a re-import left a recording_bundle.json in the
+skill dir that was not the one operations.json was sealed from. unobserved_locators
+then read the wrong bundle and reported real locators as "controls the recording
+never saw" -- so the build concluded the RECORDING was bad and re-recorded, twice,
+burning ~50 tool calls. The bundle-consistency check catches the mismatch first and
+names it a compile/import problem, not a recording one.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import io
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+sys.path.insert(0, str(_ROOT / "skills" / "noui" / "scripts"))
+
+from noui_core.compile import provenance  # noqa: E402
+
+_vr = importlib.import_module("verify_replay")
+
+_OPS = {
+    "operations": [
+        {
+            "name": "read_x",
+            "tool": "call_web_browser",
+            "steps": [{"command": "click_element", "params": {"selector": "#dl"}}],
+        }
+    ]
+}
+_SEALED = {"click_events": [{"candidates": [{"kind": "id", "value": "#dl"}]}]}
+_SWAPPED = {"click_events": [{"candidates": [{"kind": "id", "value": "#other"}]}]}
+
+
+def _run(skill_dir: Path) -> tuple[int, str]:
+    sys.argv = ["verify_replay.py", str(skill_dir), "--profile-slug", "x"]
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        try:
+            rc = _vr.main()
+        except SystemExit as exc:  # argparse/exit paths
+            rc = exc.code
+    return rc, err.getvalue()
+
+
+def _write(p: Path, bundle: dict) -> None:
+    manifest = {
+        "provenance": {
+            "steps_sha256": provenance.steps_digest(_OPS["operations"]),
+            "bundle_sha256": provenance.bundle_digest(_SEALED),
+        }
+    }
+    (p / "operations.json").write_text(json.dumps(_OPS))
+    (p / "manifest.json").write_text(json.dumps(manifest))
+    (p / provenance.BUNDLE_FILE).write_text(json.dumps(bundle))
+
+
+def test_a_swapped_bundle_is_named_a_compile_problem_not_a_recording_one():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        _write(p, _SWAPPED)  # dir bundle != the one operations were sealed from
+        rc, msg = _run(p)
+    assert rc == 1
+    assert "COMPILE/IMPORT problem" in msg
+    assert "DO NOT re-record" in msg
+    # It stops at the desync gate, not the misleading unobserved-locators verdict
+    # (whose message alone carries this line about the bundle checksum matching).
+    assert "The bundle checksum already matched" not in msg
+
+
+def test_the_matching_bundle_passes_the_consistency_gate():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        _write(p, _SEALED)  # the bundle these operations were sealed from
+        _, msg = _run(p)
+    # Gate not triggered; the run proceeds past it (and later reports no session).
+    assert "SKILL DIRECTORY IS INCONSISTENT" not in msg


### PR DESCRIPTION
## Why

On staging, an ICICI browser-skill build hit `verify_replay` with *"controls the recording never saw"*, concluded the **recording** was bad, and re-recorded twice — burning ~50 tool calls. The recording was fine (the recorder captured the labels in candidates). The real fault: a prune → recompile-from-bundle → re-import churn left a `recording_bundle.json` in the skill dir that was **not** the one `operations.json` was sealed from.

`verify_replay` checked `steps_sha256` (operations unchanged since compile) but **never checked `bundle_sha256`** (the dir's bundle is the one it was sealed with). So `unobserved_locators` read the **swapped** bundle and reported the operations' real locators as unseen — indistinguishable, to the agent, from a bad recording.

## What

- **`provenance.bundle_matches_manifest(bundle, manifest)`** — compares the dir's bundle digest to the manifest's stamped `bundle_sha256` (lenient when no stamp).
- **`verify_replay` gates on it first**, before `unbacked`/`unobserved`. On mismatch it says plainly: *"SKILL DIRECTORY IS INCONSISTENT — a COMPILE/IMPORT problem, NOT a recording problem and NOT hand-editing … DO NOT re-record."*
- Reframed the `unobserved_locators` message: now that the bundle is confirmed to match, it says so — so *that* verdict genuinely means the operations diverge from **this** recording (where restoring/re-recording is legitimate), distinct from a swapped bundle.

This makes the failure **layers legible** so a build (and a human) can tell recording vs compile vs other:
| Check | Meaning | Fix |
|---|---|---|
| `steps_sha256` mismatch | operations edited after compile | restore operations.json |
| **`bundle_sha256` mismatch (new)** | **wrong bundle in the dir** | **restore the matching bundle / re-import once — not re-record** |
| `unbacked_control_steps` | keyless steps the compiler never emits | restore operations.json |
| `unobserved_locators` (bundle confirmed) | operations genuinely diverge from this recording | fix the step / re-record |

## Tests
- `test_provenance.py`: `bundle_matches_manifest` matches / mismatches / lenient-without-stamp.
- `test_verify_replay_gate.py`: end-to-end — a swapped bundle returns 1 with the compile/import message (not the recording verdict); a matching bundle passes the gate.
- 103 passing across provenance/replay/entry-point suites; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)