### PR TITLE
noui: replay-decision-card work — goal model, bundle-provenance fix, design spec

### DIFF
--- a/docs/replay-goal-card-design.md
+++ b/docs/replay-goal-card-design.md
@@ -1,0 +1,172 @@
+# Replay decision card + goal model — design spec
+
+**Status:** design locked, not yet built · **Updated:** 2026-08-14
+
+A reference for building the goal-driven, one-replay-then-decide flow across four
+repos. Every decision below is settled; the "Deferred" section lists what is
+intentionally out of v1.
+
+---
+
+## The problem this fixes
+
+When a replay doesn't fully pass, the agent is currently free to **iterate on its
+own** — amend, `--approve-step`, force-click, re-record, re-run — and each guess
+is often wrong and makes things worse (session drift, bundle desync, session
+expiry). Observed on staging: install loops of 14 and ~50 tool calls.
+
+Separately, the card reports **operations** as if each were a goal ("2 of 3
+operations reached their goal"). The user asked for one thing. The verdict should
+be about that one thing.
+
+Two fixes, one flow: **replay runs once, then a decision card is handed to the
+human**, and the card is **headed by the user's goal(s)**, not the compiler's
+operations.
+
+---
+
+## Goal model (the spine)
+
+A **goal** is a user-stated outcome ("download the annual statement"), not a
+per-operation badge. Operations are the *mechanism* that reaches goals; the
+terminal operation (the download/submit that produces the artifact) *is* the
+goal, and the read/nav operations are its path.
+
+### Precedence for establishing goal(s)
+1. **Clear ask** → one-line **chat confirm** → goal = the ask.
+   *"Recording a skill with 1 goal: download the annual credit-card statement. Add or change goals before we start?"*
+2. **Vague ask** ("onboard ICICI") → **ask the user to state the outcome(s)
+   plainly** — don't guess.
+3. **Vague ask AND nothing stated** (they just recorded) → **infer one goal from
+   the recording's tail**, **one-line chat confirm before compile**, and tag it
+   `inferred` on the card.
+
+Explicit intent always wins; inference is only the floor.
+
+### Multi-goal
+- **Stated asks support N goals** — "download the annual statement **and** last 3
+  months' transactions" = 2 goals → 2 terminal operations. The card shows N goal
+  headlines, each reached/not, with that goal's operations as diagnostics beneath.
+- **Inference collapses to exactly one goal** (a silent recording can't be
+  multi-goal-inferred reliably) — but it's surfaced at the confirm line, so the
+  user can correct it or add a second goal there.
+
+### Inference rule (case 3)
+Pick the goal from the tail, preferring the **last terminal** (download/submit)
+over the **last navigation** — a completed artifact is a far stronger intent
+signal than wherever the cursor stopped.
+- Last terminal near the end → that's the goal ("download annual statement"),
+  even if idle clicks followed it.
+- No terminal, only navigation → the final page reached is the goal.
+- Name it from the terminal control's label (reuse `_op_name`).
+
+### Coverage checks — **warn, never block**
+Compare the goal (stated or inferred) against what the recording actually
+demonstrated:
+- **Goal not demonstrated** (server failed mid-record, no file arrived) → warn,
+  mark the goal "not demonstrated," proceed.
+- **Stated goal ≠ recording tail** (asked annual, ended on monthly) → warn. The
+  stated goal stays the intent; the mismatch is flagged. (This is the
+  "compiled a monthly statement while every check passed" trap, caught early.)
+
+### Success criterion is per goal *type*
+The ask names the goal; the goal type defines "reached":
+- **download** → a **fresh** file arrived (existing `list_downloads` + the
+  download-freshness baseline).
+- **read** → the value was extracted.
+- **submit** → the result page/response came back.
+
+---
+
+## Replay flow
+
+- Replay runs **once**. After it, the harness **mechanically emits the card and
+  pauses the turn** (the way the sign-in card pauses). The agent does **not**
+  loop, amend, or force on its own — its only post-replay move is "the card is
+  shown; wait for the human." Guidance alone won't hold; this must be mechanical.
+- Every re-run afterward is **human-initiated** (one per action), so the loop
+  never reopens.
+
+```
+ask ──clear?──▶ confirm goal (chat line) ─┐
+   └─vague──▶ ask for goal ──stated?──▶  ─┤
+                          └─no──▶ record, then INFER 1 goal from tail,
+                                          confirm before compile ────────┤
+                                                                          ▼
+                                            record to cover goal(s)
+                                                     │
+                                      coverage check (warn, never block)
+                                                     │
+                                       replay ONCE → emit card + PAUSE
+                                                     │
+                          card headed by GOAL(s) reached/not; ops = diagnostics
+```
+
+---
+
+## The card
+
+Headed by the **goal(s)**; operations demote to expandable diagnostics (which
+step, why, and a category cue — blocked vs transient-server vs login).
+
+| Element | Behavior |
+|---|---|
+| Goal headline | the user's words, reached/not; `inferred` tag if it wasn't stated |
+| Optional note | **one field, available for all actions**. The agent reads it on a re-run. If it implies changing what a step targets, that becomes an **amendment** re-surfaced for approval — it can't silently rewrite the skill, and can't bypass the provenance/risk gates. |
+| **Re-run replay** | one human-initiated replay (with the note) |
+| **Install as-is** | installs despite failing steps via `verify_approve --accept-failing` + the member-approval token. **Whole-skill for v1**, with per-goal / per-step flags recorded in provenance and surfaced to the operator at runtime. Styled as a caution (amber), not the primary. |
+| **Request changes** | the **closed set** (use-recorded-path / drop-step / wrong-target) — deterministic, provenance-tracked structural edits. Coexists with the free-text note (structural vs advisory). |
+
+### The note vs Request changes
+Kept as two channels on purpose: **Request changes** is the closed, deterministic
+path for structural edits (becomes part of the skill, provenance-tracked); the
+**note** is the softer "here's what's going on / try this" advisory that only
+becomes a structural change by routing through the amendment-approval loop.
+
+---
+
+## Cross-repo ownership
+
+| Repo | Builds |
+|---|---|
+| **noui** | goal capture + inference from the recording tail; coverage warnings; the replay report keyed to **goals** (not operations) with per-step category/reason |
+| **adoptai-workflows** (harness) | **emit-card-and-pause** after one replay; pass the note to the agent; install gate honors "install as-is / accept-failing" (whole-skill + flags) |
+| **design-system** (genui-components) | the card: goal headline, `inferred` tag, note field, three buttons, per-step reason/category |
+| **adoptwebui** | wire the note + the two new decisions (re-run / install-as-is) through `onSkillReplaySubmit`, same token path as approve |
+
+Leans on machinery that already exists: **terminal detection *is* goal detection**,
+and the **download-freshness check *is* the download-goal's success criterion**.
+
+---
+
+## Build order
+
+1. **Harness: emit-card-and-pause after one replay.** This is what actually kills
+   the 14/50-call flailing — land it first; everything else is refinement.
+2. **Card + note + the two buttons** (design-system + webui).
+3. **Goal model** (noui): chat-confirm for clear asks, inference for silent ones,
+   coverage warnings, report keyed to goals.
+
+---
+
+## Deferred (not in v1)
+
+- **Re-run failing-only** (`verify_replay --only`) — can't prove end-to-end and
+  interacts badly with the cross-origin reset limitation; a naive "failing steps
+  went green → install" would be a false green.
+- **Per-goal install-as-is** — v1 is whole-skill-with-flags; per-goal granularity
+  (ship the passing goals verified, accept only the failing ones) is a later
+  refinement if partial skills are actually needed.
+
+---
+
+## Decisions log
+
+- Replay runs **once**, then card + pause — **mechanical**, not agent guidance.
+- Card actions: **Re-run replay / Install as-is / Request changes** (+ optional note).
+- Note is **optional and available for all actions**; structural effects → amendment → re-approval.
+- Goal = **user ask**, not per-operation; align **before recording**.
+- **Chat-line confirm** for a clear ask; **one-line confirm before compile** when a goal is **inferred**, plus an `inferred` tag on the card.
+- **Warn-not-block** on coverage.
+- **Multi-goal** supported for stated asks; **inference → one goal** from the tail (prefer last terminal over last navigation).
+- **Install as-is = whole-skill-with-flags** for v1.

--- a/skills/noui-harness/SKILL.md
+++ b/skills/noui-harness/SKILL.md
@@ -57,6 +57,23 @@ instructions.** In the harness:
 Ask the user up front for: the **site** (login URL + the workflow to capture) and a short
 **skill/app name**.
 
+## Agree on the goal first — one line, then record
+
+A skill's goal is what the member asked for ("download the annual statement"), NOT one
+badge per operation. Establish it **before** recording:
+
+- **Clear ask** → state it in ONE line together with the recording link and go — no
+  separate wait: *"Recording a skill to **download the annual statement**. In that window,
+  do this…"* Don't over-ask; a clear ask needs a single confirming sentence.
+- **Vague ask** ("onboard ICICI") → ask first, then record: *"What should this skill
+  produce — a downloaded file, a value read off a page?"* Wait for the answer. Don't guess.
+- **Multiple goals are fine** — they can name several ("download the statement **and** the
+  last 3 months' transactions"); record to cover them all.
+
+When you give the recording link, tell the member to **demonstrate reaching each goal** —
+actually download the file, actually submit the form — so the recording carries evidence
+the goal was met.
+
 ## Part A — capture login + workflow in ONE session (the default)
 
 ```bash
@@ -116,6 +133,22 @@ App/ServiceProfile. Tabby auto-provisions a private, per-user App+Profile (strai
 ACTIVE) on each member's first `call_web_api`, so there is no `--promote` step and the
 credential model defaults to `manual:` (the member signs in via VNC; nothing is stored).
 The drained bundle is saved under `workbench/bundles/`.
+
+### Confirm the goal, and heed the coverage warning
+
+`capture_import` prints the recording's **endpoint goal** and, when the recording produced
+no download and no submit, a **coverage warning**. Act on both — all one-liners, never hard
+gates:
+
+- **Member never stated a goal** → confirm the inferred one in ONE line before installing:
+  *"I read your goal from the recording as **download annual statement** — correct?"* Then
+  proceed. An explicit ask always wins; this is only the floor.
+- **Stated goal and the endpoint disagree** — they asked for the annual statement but the
+  recording ended on the monthly one → **say so** and let them decide. The stated goal is
+  the intent; the mismatch is worth a sentence.
+- **Coverage warning** (nothing produced a result — a flaky server, a walkthrough that
+  stopped short) → **relay it, don't block.** The skill still compiles; the member decides
+  whether to re-record or proceed.
 
 ### The sign-in comes next — let it happen
 

--- a/skills/noui-harness/SKILL.md
+++ b/skills/noui-harness/SKILL.md
@@ -238,7 +238,22 @@ with the compiled directory:
 install_skill(skill_dir="/workspace/noui/workbench/skills/<app>")
 ```
 
-It writes the skill to the org catalog (listable on a new turn, ~30s). A skill whose
+**Claim "installed" ONLY when `install_skill` actually returned success — and call it once.**
+
+- If the call came back an **error**, for any reason, the skill is **not** in the catalog.
+  Do **not** write "installed", "fully built and installed", or any success summary; state
+  what the error said and stop. Telling the member a skill is installed when it is not is
+  the worst outcome — they believe they have a tool they do not.
+- **Do not retry `install_skill` in a loop.** The same refusal repeats, and a wall of
+  identical failures buries the one line the member needs. Call it once; if refused,
+  surface the reason and hand back.
+- **"not approved by a member" is not your cue to approve.** That decision is made by the
+  member on the **replay card** and arrives as their own message. **Never run
+  `verify_approve.py` yourself to clear it, and never narrate the approval on their
+  behalf** — that is exactly what the gate refuses. The card is shown mechanically after
+  the replay; wait for the member's approval, then install.
+
+On success, it writes the skill to the org catalog (listable on a new turn, ~30s). A skill whose
 auth is the signed-in user's **session** (the usual login-recording case — e.g. a
 Tabby `profile_slug` was bound) needs **nothing more**: it is runnable as soon as it's
 listed. Do **not** invent a secret-registration step for these.

--- a/skills/noui/noui_core/compile/browser_skill.py
+++ b/skills/noui/noui_core/compile/browser_skill.py
@@ -2000,7 +2000,13 @@ def generate_browser_skill(
 # Downloads are one kind of terminal outcome here, not a special case.
 
 #: Interactions that end a goal, and what to call the operation that reaches them.
-_TERMINAL_KINDS = ("download", "submit")
+#: Split so goal inference can prefer a completed artifact over a bare submit;
+#: this is the SINGLE definition of the terminal-kind set — goals.py imports it
+#: rather than re-declaring, so adding a kind here can never leave goal inference
+#: or the coverage warning working from a stale copy.
+_ARTIFACT_KINDS = ("download",)
+_SUBMIT_KINDS = ("submit",)
+_TERMINAL_KINDS = _ARTIFACT_KINDS + _SUBMIT_KINDS
 
 
 #: A control whose own label or selector says it fetches a file. Mirrors the

--- a/skills/noui/noui_core/compile/goals.py
+++ b/skills/noui/noui_core/compile/goals.py
@@ -55,15 +55,20 @@ def primary_goal_index(operations: list[dict[str, Any]] | None) -> int | None:
     are positional-1:1 with this list, so a caller reads the endpoint's
     reached-status off the RIGHT operation even when two operations share a name —
     matching by name would resolve to whichever came first.
+
+    Only dict operations are considered; a non-dict entry (a placeholder count, a
+    malformed op) can never be an endpoint, and the returned index always points
+    at a dict so ``infer_primary_goal`` can read a descriptor off it.
     """
     ops = list(operations or [])
     for kinds in (_ARTIFACT_KINDS, _SUBMIT_KINDS):
-        matches = [i for i, op in enumerate(ops) if (op.get("kind") or "") in kinds]
+        matches = [
+            i for i, op in enumerate(ops) if isinstance(op, dict) and (op.get("kind") or "") in kinds
+        ]
         if matches:
             return matches[-1]
-    if ops:
-        return len(ops) - 1
-    return None
+    dict_indices = [i for i, op in enumerate(ops) if isinstance(op, dict)]
+    return dict_indices[-1] if dict_indices else None
 
 
 def infer_primary_goal(operations: list[dict[str, Any]] | None) -> dict[str, Any] | None:
@@ -88,7 +93,10 @@ def goal_coverage_warning(operations: list[dict[str, Any]] | None) -> str | None
     "passed" every check. The skill still compiles and the member still decides,
     so this warns rather than refusing.
     """
-    if not any((op.get("kind") or "") in _TERMINAL_KINDS for op in operations or []):
+    if not any(
+        isinstance(op, dict) and (op.get("kind") or "") in _TERMINAL_KINDS
+        for op in operations or []
+    ):
         return (
             "This recording demonstrated no goal: it captured no download and no "
             "submit, so nothing produced a result. It still compiles as read-only, "

--- a/skills/noui/noui_core/compile/goals.py
+++ b/skills/noui/noui_core/compile/goals.py
@@ -40,8 +40,8 @@ def _goal_of(op: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def infer_primary_goal(operations: list[dict[str, Any]] | None) -> dict[str, Any] | None:
-    """The ONE goal a silent recording implies, read off its endpoint.
+def primary_goal_index(operations: list[dict[str, Any]] | None) -> int | None:
+    """Index of the endpoint operation the goal is read from, or None.
 
     Preference, strongest signal first:
 
@@ -51,18 +51,32 @@ def infer_primary_goal(operations: list[dict[str, Any]] | None) -> dict[str, Any
       3. else the LAST operation reached — a navigation-only workflow still has a
          destination ("open the dashboard").
 
-    Returns a ``{name, kind, description}`` descriptor, or None for a recording
-    with no operations at all. An explicit ask ALWAYS overrides this — it is only
-    the floor for a recording the member said nothing about.
+    Returning the INDEX (not the op) is deliberate: the replay report's operations
+    are positional-1:1 with this list, so a caller reads the endpoint's
+    reached-status off the RIGHT operation even when two operations share a name —
+    matching by name would resolve to whichever came first.
     """
     ops = list(operations or [])
     for kinds in (_ARTIFACT_KINDS, _SUBMIT_KINDS):
-        matches = [op for op in ops if (op.get("kind") or "") in kinds]
+        matches = [i for i, op in enumerate(ops) if (op.get("kind") or "") in kinds]
         if matches:
-            return _goal_of(matches[-1])
+            return matches[-1]
     if ops:
-        return _goal_of(ops[-1])
+        return len(ops) - 1
     return None
+
+
+def infer_primary_goal(operations: list[dict[str, Any]] | None) -> dict[str, Any] | None:
+    """The ONE goal a silent recording implies, read off its endpoint.
+
+    A ``{name, kind, description}`` descriptor for the operation
+    ``primary_goal_index`` selects, or None for a recording with no operations at
+    all. An explicit ask ALWAYS overrides this — it is only the floor for a
+    recording the member said nothing about.
+    """
+    ops = list(operations or [])
+    idx = primary_goal_index(ops)
+    return _goal_of(ops[idx]) if idx is not None else None
 
 
 def goal_coverage_warning(operations: list[dict[str, Any]] | None) -> str | None:

--- a/skills/noui/noui_core/compile/goals.py
+++ b/skills/noui/noui_core/compile/goals.py
@@ -1,0 +1,84 @@
+"""What a browser skill is FOR — the goal, distinct from its operations.
+
+A goal is the user's outcome ("download the annual statement"), NOT one badge per
+operation. A statement download is one goal even though the recording navigates,
+selects a period, submits a form and only then downloads — those operations are
+the PATH to the goal, and the download is the goal.
+
+Two things live here, both compile-side:
+
+  - ``infer_primary_goal`` reads ONE goal off the recording's endpoint. It is a
+    FALLBACK: an explicit ask always wins (see the design precedence). When the
+    member stated nothing, the caller surfaces this for a one-line confirm before
+    compiling. Deliberately single: inferring several goals from a silent
+    recording is guesswork; the strongest single signal is the safe floor.
+  - ``goal_coverage_warning`` warns (never blocks) when the recording produced no
+    artifact at all — the "compiled a read-only skill for a task that was meant to
+    fetch a file" trap.
+
+Note what is NOT here: enumerating every terminal as a goal. A workflow that
+submits a period, submits a GO, then downloads has three terminals and ONE goal
+(the download). The terminals are mechanism; only the endpoint is the goal.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Terminal kinds, strongest goal-signal first. A completed download is a file the
+#: user asked for; a submit is a form driven to a result; a read is only a step.
+_ARTIFACT_KINDS = ("download",)
+_SUBMIT_KINDS = ("submit",)
+_TERMINAL_KINDS = _ARTIFACT_KINDS + _SUBMIT_KINDS
+
+
+def _goal_of(op: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": op.get("name") or "",
+        "kind": op.get("kind") or "read",
+        "description": op.get("description") or "",
+    }
+
+
+def infer_primary_goal(operations: list[dict[str, Any]] | None) -> dict[str, Any] | None:
+    """The ONE goal a silent recording implies, read off its endpoint.
+
+    Preference, strongest signal first:
+
+      1. the LAST download — a completed file is the clearest statement of intent,
+         even if idle clicks or an intermediate submit followed it;
+      2. else the LAST submit — a form the human drove to a result;
+      3. else the LAST operation reached — a navigation-only workflow still has a
+         destination ("open the dashboard").
+
+    Returns a ``{name, kind, description}`` descriptor, or None for a recording
+    with no operations at all. An explicit ask ALWAYS overrides this — it is only
+    the floor for a recording the member said nothing about.
+    """
+    ops = list(operations or [])
+    for kinds in (_ARTIFACT_KINDS, _SUBMIT_KINDS):
+        matches = [op for op in ops if (op.get("kind") or "") in kinds]
+        if matches:
+            return _goal_of(matches[-1])
+    if ops:
+        return _goal_of(ops[-1])
+    return None
+
+
+def goal_coverage_warning(operations: list[dict[str, Any]] | None) -> str | None:
+    """Warn (never block) when the recording demonstrated no artifact-bearing goal.
+
+    No download and no submit means nothing produced a result — a bank server that
+    failed mid-record, or a walkthrough that stopped short. That is exactly the
+    trap where a task meant to fetch a file compiled to a read-only skill and
+    "passed" every check. The skill still compiles and the member still decides,
+    so this warns rather than refusing.
+    """
+    if not any((op.get("kind") or "") in _TERMINAL_KINDS for op in operations or []):
+        return (
+            "This recording demonstrated no goal: it captured no download and no "
+            "submit, so nothing produced a result. It still compiles as read-only, "
+            "but confirm with the member what the skill should achieve — and that "
+            "the recording actually reached it — before installing."
+        )
+    return None

--- a/skills/noui/noui_core/compile/goals.py
+++ b/skills/noui/noui_core/compile/goals.py
@@ -25,11 +25,16 @@ from __future__ import annotations
 
 from typing import Any
 
-#: Terminal kinds, strongest goal-signal first. A completed download is a file the
-#: user asked for; a submit is a form driven to a result; a read is only a step.
-_ARTIFACT_KINDS = ("download",)
-_SUBMIT_KINDS = ("submit",)
-_TERMINAL_KINDS = _ARTIFACT_KINDS + _SUBMIT_KINDS
+# Terminal kinds, strongest goal-signal first (a completed download is a file the
+# user asked for; a submit is a form driven to a result; a read is only a step).
+# Imported from the compiler's terminal detection, NOT re-declared here, so the two
+# can never drift: a new terminal kind added there is picked up by goal inference
+# and the coverage warning automatically.
+from noui_core.compile.browser_skill import (
+    _ARTIFACT_KINDS,
+    _SUBMIT_KINDS,
+    _TERMINAL_KINDS,
+)
 
 
 def _goal_of(op: dict[str, Any]) -> dict[str, Any]:

--- a/skills/noui/noui_core/compile/goals.py
+++ b/skills/noui/noui_core/compile/goals.py
@@ -63,7 +63,9 @@ def primary_goal_index(operations: list[dict[str, Any]] | None) -> int | None:
     ops = list(operations or [])
     for kinds in (_ARTIFACT_KINDS, _SUBMIT_KINDS):
         matches = [
-            i for i, op in enumerate(ops) if isinstance(op, dict) and (op.get("kind") or "") in kinds
+            i
+            for i, op in enumerate(ops)
+            if isinstance(op, dict) and (op.get("kind") or "") in kinds
         ]
         if matches:
             return matches[-1]

--- a/skills/noui/noui_core/compile/provenance.py
+++ b/skills/noui/noui_core/compile/provenance.py
@@ -46,6 +46,25 @@ def bundle_digest(bundle: dict[str, Any]) -> str:
     return hashlib.sha256(blob.encode("utf-8")).hexdigest()
 
 
+def bundle_matches_manifest(bundle: dict[str, Any], manifest: dict[str, Any]) -> bool:
+    """Is the recording bundle in the dir the one these operations were sealed from?
+
+    The manifest stamps ``bundle_sha256`` at compile time. If the dir's bundle
+    hashes to something else, ``operations.json`` and ``recording_bundle.json``
+    came from DIFFERENT compile/import runs -- a skill-directory consistency
+    problem, not a bad recording and not hand-editing. Checking this BEFORE
+    ``unobserved_locators`` matters: that check reads the dir's bundle, so a
+    swapped bundle makes it report the operations' real locators as "controls the
+    recording never saw" -- pointing the blame at the recording (and at a pointless
+    re-record) when the true fault is that the wrong bundle is sitting in the dir.
+
+    Returns True when they agree, or when the manifest carries no stamp to check
+    against (an older skill) -- absence of a stamp is not evidence of a mismatch.
+    """
+    stamped = str((manifest.get("provenance") or {}).get("bundle_sha256") or "")
+    return not stamped or bundle_digest(bundle) == stamped
+
+
 def observed_selectors(bundle: dict[str, Any]) -> set[str]:
     """Every locator value the recorder actually saw, in any form.
 

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -37,6 +37,8 @@ import re
 import time
 from typing import Any
 
+from noui_core.compile.goals import infer_primary_goal
+
 
 class SessionNotReadyError(RuntimeError):
     """Tabby has no healthy session for this profile — the human must sign in.
@@ -731,8 +733,28 @@ def build_report(
                 "needs_approval_count": sum(1 for s in steps if s.get("status") == NEEDS_APPROVAL),
             }
         )
+    # The GOAL is the endpoint the member asked for, not one badge per operation.
+    # Its replayed outcome is the verdict that matters — and it differs from
+    # all_goals_reached, which also trips on an intermediate submit that blocked a
+    # step even when the download arrived. One goal for now (the endpoint the
+    # recording built toward); explicit multi-goal asks are threaded through later.
+    goals: list[dict] = []
+    primary = infer_primary_goal(operations)
+    if primary and primary.get("name"):
+        endpoint = next((o for o in ops_out if o.get("name") == primary["name"]), None)
+        goals.append(
+            {
+                "name": primary["name"],
+                "kind": primary["kind"],
+                "description": primary.get("description") or "",
+                "reached": bool(endpoint and endpoint.get("goal_reached")),
+            }
+        )
+
     return {
         "operations": ops_out,
+        # The verdict the card headlines, keyed to what the member asked for.
+        "goals": goals,
         "all_goals_reached": bool(ops_out) and all(o["goal_reached"] for o in ops_out),
         "needs_approval": any(o["needs_approval_count"] for o in ops_out),
         # Ties the approval to the exact plan that was replayed.

--- a/skills/noui/noui_core/verify/replay.py
+++ b/skills/noui/noui_core/verify/replay.py
@@ -37,7 +37,7 @@ import re
 import time
 from typing import Any
 
-from noui_core.compile.goals import infer_primary_goal
+from noui_core.compile.goals import primary_goal_index
 
 
 class SessionNotReadyError(RuntimeError):
@@ -739,17 +739,21 @@ def build_report(
     # step even when the download arrived. One goal for now (the endpoint the
     # recording built toward); explicit multi-goal asks are threaded through later.
     goals: list[dict] = []
-    primary = infer_primary_goal(operations)
-    if primary and primary.get("name"):
-        endpoint = next((o for o in ops_out if o.get("name") == primary["name"]), None)
-        goals.append(
-            {
-                "name": primary["name"],
-                "kind": primary["kind"],
-                "description": primary.get("description") or "",
-                "reached": bool(endpoint and endpoint.get("goal_reached")),
-            }
-        )
+    # ops_out is positional-1:1 with operations, so index the endpoint directly
+    # rather than matching by name -- two operations sharing a name would resolve
+    # the reached-status to the wrong one.
+    idx = primary_goal_index(operations)
+    if idx is not None and idx < len(ops_out):
+        endpoint = ops_out[idx]
+        if endpoint.get("name"):
+            goals.append(
+                {
+                    "name": endpoint["name"],
+                    "kind": endpoint.get("kind") or "read",
+                    "description": endpoint.get("description") or "",
+                    "reached": bool(endpoint.get("goal_reached")),
+                }
+            )
 
     return {
         "operations": ops_out,

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -150,17 +150,19 @@ def _report_workflow(result: dict, args: argparse.Namespace) -> int:
         # The GOAL is what the member asked for, not one badge per operation. An
         # explicit ask wins; when they stated nothing, this is the endpoint to
         # confirm before installing. And warn (never block) if the recording
-        # produced no result at all.
+        # produced no result at all. Both go to stdout, the SAME stream as the
+        # `Skill:` line above -- SKILL.md tells the agent to relay them, so they
+        # must land where the agent reads the rest of this report, not split onto
+        # stderr where a stdout-only reader would drop them.
         goal = infer_primary_goal(ops)
         if goal and goal.get("name"):
             print(
                 "Goal (the recording's endpoint — confirm with the member if they "
-                f"did not state one): {goal['name']} [{goal['kind']}]",
-                file=sys.stderr,
+                f"did not state one): {goal['name']} [{goal['kind']}]"
             )
         coverage = goal_coverage_warning(ops)
         if coverage:
-            print(coverage, file=sys.stderr)
+            print(coverage)
     # Tell the operator when the app was auto-routed to browser mode, and why —
     # this is the recommendation surfaced to a user authoring a skill in the
     # harness, so browser mode is never picked silently.

--- a/skills/noui/scripts/capture_import.py
+++ b/skills/noui/scripts/capture_import.py
@@ -28,6 +28,7 @@ from noui_core.capture import ledger, recording
 from noui_core.capture.bundle import save_bundle
 from noui_core.capture.classify import COMBINED, LOGIN, WORKFLOW
 from noui_core.capture.split import SplitError, split_bundle, split_diagnosis
+from noui_core.compile.goals import goal_coverage_warning, infer_primary_goal
 from noui_core.compile.login import compile_login_bundle
 from noui_core.compile.workflow import compile_workflow_bundle
 
@@ -144,7 +145,22 @@ def _report_workflow(result: dict, args: argparse.Namespace) -> int:
     if mcp:
         print(f"MCP server: {mcp.get('server_id', '?')} ({len(mcp.get('tools', []))} tool(s))")
     if skill:
-        print(f"Skill: {skill.get('skill_id', '?')} ({len(skill.get('operations', []))} op(s))")
+        ops = skill.get("operations") or []
+        print(f"Skill: {skill.get('skill_id', '?')} ({len(ops)} op(s))")
+        # The GOAL is what the member asked for, not one badge per operation. An
+        # explicit ask wins; when they stated nothing, this is the endpoint to
+        # confirm before installing. And warn (never block) if the recording
+        # produced no result at all.
+        goal = infer_primary_goal(ops)
+        if goal and goal.get("name"):
+            print(
+                "Goal (the recording's endpoint — confirm with the member if they "
+                f"did not state one): {goal['name']} [{goal['kind']}]",
+                file=sys.stderr,
+            )
+        coverage = goal_coverage_warning(ops)
+        if coverage:
+            print(coverage, file=sys.stderr)
     # Tell the operator when the app was auto-routed to browser mode, and why —
     # this is the recommendation surfaced to a user authoring a skill in the
     # harness, so browser mode is never picked silently.

--- a/skills/noui/scripts/verify_replay.py
+++ b/skills/noui/scripts/verify_replay.py
@@ -166,6 +166,34 @@ def main() -> int:
             print(f"Cannot read {bundle_path}: {exc}", file=sys.stderr)
             return 1
 
+        # The dir's bundle MUST be the one these operations were sealed from.
+        # A re-import, or a recompile against a different capture, can leave
+        # operations.json and recording_bundle.json in the dir out of sync -- and
+        # then unobserved_locators below reads the WRONG bundle and reports the
+        # operations' real locators as "controls the recording never saw", which
+        # reads as a bad recording and sends the build off to re-record. Catch the
+        # mismatch here, first, and name it for what it is.
+        if not provenance.bundle_matches_manifest(bundle, manifest):
+            stamped = str((manifest.get("provenance") or {}).get("bundle_sha256") or "")
+            print(
+                "SKILL DIRECTORY IS INCONSISTENT -- a COMPILE/IMPORT problem, NOT a "
+                "recording problem and NOT hand-editing.\n"
+                "\n"
+                "The recording_bundle.json in this skill dir is not the one these "
+                "operations were compiled from: its checksum does not match the "
+                f"manifest's bundle_sha256 ({stamped[:12]}...). operations.json and "
+                "recording_bundle.json came from different compile/import runs.\n"
+                "\n"
+                "DO NOT re-record -- the recording is fine; the wrong bundle is in the "
+                "dir. Restore the recording_bundle.json whose checksum matches the "
+                "manifest, or re-import ONCE so operations.json + recording_bundle.json "
+                "+ manifest.json all come from a single compile. (The 'controls the "
+                "recording never saw' error you would hit next is a symptom of this, "
+                "not a real fabrication.)",
+                file=sys.stderr,
+            )
+            return 1
+
         unbacked = provenance.unbacked_control_steps(operations)
         if unbacked:
             shown = ", ".join(repr(u) for u in unbacked[:5])
@@ -188,10 +216,12 @@ def main() -> int:
             print(
                 f"These steps target controls the recording never saw: {shown}{more}.\n"
                 "\n"
-                "The operations no longer match what was compiled from the recording, "
-                "which almost always means they were edited by hand after compiling. "
-                "Replaying now would drive a live session through steps nobody has "
-                "seen work, and when they miss, the run improvises and wanders.\n"
+                "The bundle checksum already matched the manifest, so this is NOT a "
+                "swapped bundle -- these operations genuinely diverge from THIS "
+                "recording. That almost always means they were edited by hand after "
+                "compiling. Replaying now would drive a live session through steps "
+                "nobody has seen work, and when they miss, the run improvises and "
+                "wanders.\n"
                 "\n"
                 "You may rename an operation, reword its description, or add a "
                 "parameter. You may NOT change what a step targets, reorder steps, "

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -13,11 +13,28 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_ROOT / "skills" / "noui"))
 
-from noui_core.compile.goals import goal_coverage_warning, infer_primary_goal  # noqa: E402
+from noui_core.compile.goals import (  # noqa: E402
+    goal_coverage_warning,
+    infer_primary_goal,
+    primary_goal_index,
+)
 
 
 def op(name: str, kind: str | None = None) -> dict:
     return {"name": name, "kind": kind, "description": f"{name} desc"}
+
+
+def test_primary_goal_index_points_at_the_same_op_infer_selects():
+    # The index and the descriptor must agree: the report indexes ops_out by this
+    # to read reached-status off the right op even when two share a name.
+    ops = [op("submit_period", "submit"), op("download_annual", "download")]
+    assert primary_goal_index(ops) == 1
+    assert infer_primary_goal(ops)["name"] == ops[primary_goal_index(ops)]["name"]
+    # Duplicate names -> the LAST terminal's index, not the first match.
+    dup = [op("download_x", "download"), op("download_x", "download")]
+    assert primary_goal_index(dup) == 1
+    assert primary_goal_index([]) is None
+    assert primary_goal_index(None) is None
 
 
 def test_the_endpoint_download_is_the_goal_not_the_intermediate_submits():

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -37,6 +37,18 @@ def test_primary_goal_index_points_at_the_same_op_infer_selects():
     assert primary_goal_index(None) is None
 
 
+def test_the_goal_helpers_tolerate_non_dict_operations():
+    # capture_import can hand these a placeholder/malformed operations list (e.g. a
+    # count-only stand-in). They must not AttributeError on a non-dict entry.
+    assert primary_goal_index([1, 2]) is None
+    assert infer_primary_goal([1, 2]) is None
+    assert goal_coverage_warning([1, 2]) is not None  # no dict terminal -> warns
+    # A real dict alongside a non-dict still resolves to the dict.
+    mixed = [1, op("download_x", "download")]
+    assert primary_goal_index(mixed) == 1
+    assert infer_primary_goal(mixed)["name"] == "download_x"
+
+
 def test_the_endpoint_download_is_the_goal_not_the_intermediate_submits():
     # ICICI's shape: select period (submit), GO (submit), then download. The goal
     # is the download, and the submits are the path to it.

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -1,0 +1,74 @@
+"""A skill's goal is the user's outcome, not one badge per operation.
+
+The muddle this closes: a statement download navigates, selects a period, submits
+a GO, then downloads -- three terminals, ONE goal. Asked "what did you build?",
+the answer is "download the annual statement", not "3 of 3 operations".
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+
+from noui_core.compile.goals import goal_coverage_warning, infer_primary_goal  # noqa: E402
+
+
+def op(name: str, kind: str | None = None) -> dict:
+    return {"name": name, "kind": kind, "description": f"{name} desc"}
+
+
+def test_the_endpoint_download_is_the_goal_not_the_intermediate_submits():
+    # ICICI's shape: select period (submit), GO (submit), then download. The goal
+    # is the download, and the submits are the path to it.
+    ops = [
+        op("read_credit_card"),
+        op("submit_period", "submit"),
+        op("submit_go", "submit"),
+        op("download_annual_statement", "download"),
+    ]
+    goal = infer_primary_goal(ops)
+    assert goal["name"] == "download_annual_statement"
+    assert goal["kind"] == "download"
+
+
+def test_a_download_wins_even_when_a_submit_came_after_it():
+    # A completed file is the strongest signal, so it wins over a later submit.
+    ops = [op("download_report", "download"), op("submit_feedback", "submit")]
+    assert infer_primary_goal(ops)["name"] == "download_report"
+
+
+def test_the_last_download_wins_when_there_are_several():
+    ops = [op("download_jan", "download"), op("download_annual", "download")]
+    assert infer_primary_goal(ops)["name"] == "download_annual"
+
+
+def test_a_submit_is_the_goal_when_nothing_downloaded():
+    ops = [op("read_page"), op("submit_search", "submit")]
+    assert infer_primary_goal(ops)["name"] == "submit_search"
+
+
+def test_a_navigation_only_recording_falls_back_to_its_last_page():
+    # No artifact produced -- the destination reached is the goal ("open X").
+    ops = [op("read_overview"), op("read_dashboard")]
+    goal = infer_primary_goal(ops)
+    assert goal["name"] == "read_dashboard"
+    assert goal["kind"] == "read"
+
+
+def test_no_operations_infers_no_goal():
+    assert infer_primary_goal([]) is None
+    assert infer_primary_goal(None) is None
+
+
+def test_coverage_warns_when_the_recording_produced_no_result():
+    # Read-only: the "meant to fetch a file but captured nothing" trap.
+    warn = goal_coverage_warning([op("read_overview"), op("read_dashboard")])
+    assert warn and "demonstrated no goal" in warn
+
+
+def test_coverage_is_silent_when_a_terminal_was_captured():
+    assert goal_coverage_warning([op("read_x"), op("download_y", "download")]) is None
+    assert goal_coverage_warning([op("submit_z", "submit")]) is None

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -205,3 +205,32 @@ def test_a_role_addressed_control_the_recording_never_saw_is_still_caught():
     ]
     bundle = {"click_events": [{"candidates": [{"kind": "role_name", "value": "radio|Annual"}]}]}
     assert unobserved_locators(ops, bundle) == ["Ghost"]
+
+
+def test_bundle_matches_manifest_catches_a_swapped_bundle():
+    """The desync verify_replay must catch BEFORE blaming the recording.
+
+    A re-import/recompile can leave a recording_bundle.json in the dir that is
+    not the one operations.json was sealed from. unobserved_locators then reads
+    the wrong bundle and reports real locators as unseen -- pointing at a bad
+    recording. bundle_matches_manifest names it for what it is: a dir mismatch.
+    """
+    from noui_core.compile.provenance import bundle_digest, bundle_matches_manifest
+
+    sealed = {"click_events": [{"candidates": [{"kind": "id", "value": "#dl"}]}]}
+    manifest = {"provenance": {"bundle_sha256": bundle_digest(sealed)}}
+
+    # The bundle that actually sealed the operations -> matches.
+    assert bundle_matches_manifest(sealed, manifest) is True
+    # A different capture left in the dir by a second import -> mismatch.
+    other = {"click_events": [{"candidates": [{"kind": "id", "value": "#other"}]}]}
+    assert bundle_matches_manifest(other, manifest) is False
+
+
+def test_bundle_matches_manifest_is_lenient_without_a_stamp():
+    # An older skill whose manifest carries no bundle_sha256 cannot be checked;
+    # absence of a stamp is not evidence of a mismatch.
+    from noui_core.compile.provenance import bundle_matches_manifest
+
+    assert bundle_matches_manifest({"click_events": []}, {}) is True
+    assert bundle_matches_manifest({"click_events": []}, {"provenance": {}}) is True

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -268,6 +268,48 @@ def test_the_report_names_the_goal_that_failed_not_just_a_step_count():
     assert op["name"] == "download_statement"
 
 
+def test_the_report_headlines_the_goal_the_recording_built_toward():
+    # The card is headed by the GOAL, not per-operation. A statement workflow's
+    # goal is its download endpoint.
+    steps = [
+        [
+            {"status": OK, "command": "click_element"},
+            {"status": OK, "command": "list_downloads", "data": {"downloads": [{"id": "dl-9"}]}},
+        ]
+    ]
+    report = build_report([DOWNLOAD_OP], steps)
+    assert len(report["goals"]) == 1
+    goal = report["goals"][0]
+    assert goal["name"] == "download_statement"
+    assert goal["kind"] == "download"
+    assert goal["reached"] is True
+
+
+def test_the_goal_verdict_is_the_endpoints_not_all_goals_reached():
+    # THE distinction the goal model buys: two submits then a download is ONE goal
+    # (the download). Its verdict is the download's — reached even when an
+    # intermediate submit op is judged not-reached, which all_goals_reached is not.
+    submit_op = {"name": "submit_period", "kind": "submit", "steps": []}
+    report = build_report(
+        [submit_op, DOWNLOAD_OP],
+        [
+            [{"status": BLOCKED, "command": "click_element"}],
+            [
+                {"status": OK, "command": "click_element"},
+                {
+                    "status": OK,
+                    "command": "list_downloads",
+                    "data": {"downloads": [{"id": "dl-1"}]},
+                },
+            ],
+        ],
+    )
+    assert len(report["goals"]) == 1
+    assert report["goals"][0]["name"] == "download_statement"
+    assert report["goals"][0]["reached"] is True
+    assert report["all_goals_reached"] is False
+
+
 # --- scope --------------------------------------------------------------------
 
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -310,6 +310,30 @@ def test_the_goal_verdict_is_the_endpoints_not_all_goals_reached():
     assert report["all_goals_reached"] is False
 
 
+def test_two_operations_sharing_a_name_read_the_goal_off_the_endpoint():
+    # The endpoint is the LAST download. When an earlier operation shares its
+    # name, the goal's reached-status must come from that last op (indexed
+    # positionally), not the first name match. Here the first download produced a
+    # file (reached) and the last produced nothing fresh (not reached); the goal
+    # is the last, so it is NOT reached. Matching by name would wrongly report the
+    # first op's success.
+    first = {"name": "download_statement", "kind": "download", "steps": []}
+    last = {"name": "download_statement", "kind": "download", "steps": []}
+    report = build_report(
+        [first, last],
+        [
+            [{"status": OK, "command": "list_downloads", "data": {"downloads": [{"id": "old"}]}}],
+            [{"status": OK, "command": "list_downloads", "data": {"downloads": [{"id": "old"}]}}],
+        ],
+    )
+    assert len(report["goals"]) == 1
+    # The first op saw "old" as fresh; the last saw it already banked, so nothing
+    # new arrived — the endpoint did not reach its goal.
+    assert report["operations"][0]["goal_reached"] is True
+    assert report["operations"][1]["goal_reached"] is False
+    assert report["goals"][0]["reached"] is False
+
+
 # --- scope --------------------------------------------------------------------
 
 

--- a/tests/test_verify_replay_gate.py
+++ b/tests/test_verify_replay_gate.py
@@ -1,0 +1,84 @@
+"""verify_replay's provenance gate tells a build WHICH kind of problem it hit.
+
+The failure that motivated this: a re-import left a recording_bundle.json in the
+skill dir that was not the one operations.json was sealed from. unobserved_locators
+then read the wrong bundle and reported real locators as "controls the recording
+never saw" -- so the build concluded the RECORDING was bad and re-recorded, twice,
+burning ~50 tool calls. The bundle-consistency check catches the mismatch first and
+names it a compile/import problem, not a recording one.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import io
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_ROOT / "skills" / "noui"))
+sys.path.insert(0, str(_ROOT / "skills" / "noui" / "scripts"))
+
+from noui_core.compile import provenance  # noqa: E402
+
+_vr = importlib.import_module("verify_replay")
+
+_OPS = {
+    "operations": [
+        {
+            "name": "read_x",
+            "tool": "call_web_browser",
+            "steps": [{"command": "click_element", "params": {"selector": "#dl"}}],
+        }
+    ]
+}
+_SEALED = {"click_events": [{"candidates": [{"kind": "id", "value": "#dl"}]}]}
+_SWAPPED = {"click_events": [{"candidates": [{"kind": "id", "value": "#other"}]}]}
+
+
+def _run(skill_dir: Path) -> tuple[int, str]:
+    sys.argv = ["verify_replay.py", str(skill_dir), "--profile-slug", "x"]
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err):
+        try:
+            rc = _vr.main()
+        except SystemExit as exc:  # argparse/exit paths
+            rc = exc.code
+    return rc, err.getvalue()
+
+
+def _write(p: Path, bundle: dict) -> None:
+    manifest = {
+        "provenance": {
+            "steps_sha256": provenance.steps_digest(_OPS["operations"]),
+            "bundle_sha256": provenance.bundle_digest(_SEALED),
+        }
+    }
+    (p / "operations.json").write_text(json.dumps(_OPS))
+    (p / "manifest.json").write_text(json.dumps(manifest))
+    (p / provenance.BUNDLE_FILE).write_text(json.dumps(bundle))
+
+
+def test_a_swapped_bundle_is_named_a_compile_problem_not_a_recording_one():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        _write(p, _SWAPPED)  # dir bundle != the one operations were sealed from
+        rc, msg = _run(p)
+    assert rc == 1
+    assert "COMPILE/IMPORT problem" in msg
+    assert "DO NOT re-record" in msg
+    # It stops at the desync gate, not the misleading unobserved-locators verdict
+    # (whose message alone carries this line about the bundle checksum matching).
+    assert "The bundle checksum already matched" not in msg
+
+
+def test_the_matching_bundle_passes_the_consistency_gate():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        _write(p, _SEALED)  # the bundle these operations were sealed from
+        _, msg = _run(p)
+    # Gate not triggered; the run proceeds past it (and later reports no session).
+    assert "SKILL DIRECTORY IS INCONSISTENT" not in msg


### PR DESCRIPTION
The single noui branch for the replay-decision-card / goal-model work (consolidated from the earlier #141/#142, now closed — one branch per repo). Three commits:

### 1. `fix(verify)` — bundle-operations desync named for what it is
A re-import/recompile could leave a `recording_bundle.json` in the skill dir that wasn't the one `operations.json` was sealed from, so `unobserved_locators` read the wrong bundle and blamed the recording ("controls the recording never saw") — a staging build re-recorded twice and burned ~50 tool calls chasing it. New `provenance.bundle_matches_manifest`, gated before the locator checks, names it a **compile/import** problem, not a recording one ("do NOT re-record"). Makes the failure layers legible (steps digest = edited ops; bundle digest = wrong bundle; unobserved = genuine gap).

### 2. `docs(design)` — replay decision card + goal model spec
`docs/replay-goal-card-design.md`: the locked design (emit-card-and-pause, the card + note + buttons, the goal model, warn-not-block coverage, cross-repo ownership, build order).

### 3. `feat(compile)` — infer the ONE goal from a recording's endpoint + coverage warning
`compile/goals.py`: `infer_primary_goal` reads **one** goal off the endpoint (last download → submit → page); `goal_coverage_warning` warns (never blocks) when nothing produced a result. Surfaced in `capture_import`. On the real ICICI capture it infers `download_corp_finacle` — one goal, not the three terminals.

## Verified
24 tests across the three areas + the broader compile/verify suites; ruff, format, mypy clean.

## Remaining goal-model slices (same branch)
- report keyed to goals → the card's goal headline
- agent chat-confirm / confirm-before-compile (harness SKILL.md)
- stated-goal-vs-tail coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)