### PR TITLE
fix(compile): sanitise param names into valid Python identifiers

### DIFF
--- a/skills/noui/noui_core/compile/operation_generator.py
+++ b/skills/noui/noui_core/compile/operation_generator.py
@@ -79,7 +79,12 @@ def _render_body_assignment(body_params: list[dict], var: str = "body") -> str:
     """
     whole = next((p for p in body_params if p.get("whole_body")), None)
     if whole:
-        return f"    {var} = json.loads({whole['name']})"
+        # _pn(), not the wire name. Today a whole_body param is always literally
+        # "body" so the two agree, but if another param's wire name also
+        # sanitises to "body" the collision suffix moves this one to "body_2" --
+        # and referencing the wire name would then silently bind json.loads() to
+        # the OTHER param's value. Caught in review on #145.
+        return f"    {var} = json.loads({_pn(whole)})"
     entries = ", ".join(_body_dict_entry(p) for p in body_params)
     return f"    {var} = {{{entries}}}"
 

--- a/skills/noui/noui_core/compile/operation_generator.py
+++ b/skills/noui/noui_core/compile/operation_generator.py
@@ -16,6 +16,41 @@ payloads: exits 2 (still prints the JSON). On success: exits 0.
 
 from __future__ import annotations
 
+import keyword
+import re
+
+
+def _assign_py_names(params: list[dict]) -> None:
+    """Give every param a valid, UNIQUE Python identifier in ``py_name``.
+
+    A wire parameter name is not necessarily a Python identifier. Form-encoded
+    bodies carry dots and percent-encoded brackets -- TP Catalyst's
+    AnalysisSummary/Export posts
+    ``component.AttachmentTypes%5BReviewSummaryProofs%5D.Selected`` -- and the
+    codegen used the wire name verbatim for BOTH the dict key and the Python
+    symbol, so the emitted module could not be parsed at all (found 2026-08-18).
+    The wire name stays the dict key; only the Python symbol is sanitized, and
+    collisions get a numeric suffix so two wire names can never collapse into
+    one duplicate parameter.
+    """
+    seen: set[str] = set()
+    for p in params:
+        ident = re.sub(r"\W", "_", p.get("name", "")) or "param"
+        if ident[0].isdigit():
+            ident = "p_" + ident
+        if keyword.iskeyword(ident):
+            ident += "_"
+        base, n = ident, 2
+        while ident in seen:
+            ident, n = f"{base}_{n}", n + 1
+        seen.add(ident)
+        p["py_name"] = ident
+
+
+def _pn(p: dict) -> str:
+    """The Python-side symbol for a param (falls back to the wire name)."""
+    return p.get("py_name") or p["name"]
+
 
 def _body_dict_entry(p: dict) -> str:
     """Render one `body = {...}` entry for a skill CLI operation.
@@ -27,10 +62,10 @@ def _body_dict_entry(p: dict) -> str:
     reject. See har_to_tools.py::_body_to_params for how "object"/"array" get
     assigned.
     """
-    name = p["name"]
+    wire, sym = p["name"], _pn(p)
     if p.get("type", "").lower() in ("object", "array"):
-        return f"{name!r}: json.loads({name})"
-    return f"{name!r}: {name}"
+        return f"{wire!r}: json.loads({sym})"
+    return f"{wire!r}: {sym}"
 
 
 def _render_body_assignment(body_params: list[dict], var: str = "body") -> str:
@@ -59,6 +94,7 @@ def render_skill_operation(td: dict, *, auth_plan: dict, execution_mode: str = "
       - "tabby" (default): execute inside Tabby's browser via the /execute/fetch endpoint
       - "http" (legacy): execute via httpx + resolve_auth()
     """
+    _assign_py_names(td.get("params") or [])
     if execution_mode == "tabby":
         return _render_skill_operation_tabby(td, auth_plan=auth_plan)
     return _render_skill_operation_http(td, auth_plan=auth_plan)
@@ -149,7 +185,7 @@ def _render_skill_operation_tabby(td: dict, *, auth_plan: dict) -> str:
     lines.append(f"    url = {url_expr}")
 
     if query_params:
-        q_dict = ", ".join(f"{p['name']!r}: {p['name']}" for p in query_params)
+        q_dict = ", ".join(f"{p['name']!r}: {_pn(p)}" for p in query_params)
         lines.append(f"    _query = {{{q_dict}}}")
         lines.append("    url = url + ('?' + urllib.parse.urlencode(_query) if _query else '')")
 
@@ -186,6 +222,7 @@ def _render_skill_operation_tabby(td: dict, *, auth_plan: dict) -> str:
 
 def _render_skill_operation_http(td: dict, *, auth_plan: dict) -> str:
     """Render a skill op using httpx + resolve_auth (legacy mode)."""
+    _assign_py_names(td.get("params") or [])
     name = td["name"]
     method = td["method"].lower()
     path_template = td["path"]
@@ -267,7 +304,7 @@ def _render_skill_operation_http(td: dict, *, auth_plan: dict) -> str:
         lines.append(_render_body_assignment(body_params, var))
 
     if query_params:
-        q_dict = ", ".join(f"{p['name']!r}: {p['name']}" for p in query_params)
+        q_dict = ", ".join(f"{p['name']!r}: {_pn(p)}" for p in query_params)
         lines.append(f"    params = {{{q_dict}}}")
 
     if needs_auth:
@@ -323,7 +360,7 @@ def _render_cli_wrapper(name: str, description: str, params: list[dict]) -> list
     optional = [p for p in params if not p.get("required", True)]
 
     for p in [*required, *optional]:
-        pname = p["name"]
+        pname = _pn(p)
         flag = f"--{pname.replace('_', '-')}"
         ptype = p.get("type", "string").lower()
         help_text = (p.get("description") or "").replace('"', "'") or pname
@@ -364,7 +401,7 @@ def _render_cli_wrapper(name: str, description: str, params: list[dict]) -> list
     ]
 
     if params:
-        kwargs = ", ".join(f"{p['name']}=args.{p['name']}" for p in params)
+        kwargs = ", ".join(f"{_pn(p)}=args.{_pn(p)}" for p in params)
         lines.append(f"        result = asyncio.run(execute({kwargs}))")
     else:
         lines.append("        result = asyncio.run(execute())")
@@ -398,10 +435,10 @@ def _py_signature(params: list[dict]) -> list[str]:
     required = [p for p in params if p.get("required", True)]
     optional = [p for p in params if not p.get("required", True)]
     for p in required:
-        parts.append(f"{p['name']}: {_py_type(p.get('type', 'string'))}")
+        parts.append(f"{_pn(p)}: {_py_type(p.get('type', 'string'))}")
     for p in optional:
         ptype = p.get("type", "string")
-        parts.append(f"{p['name']}: {_py_type(ptype)} = {_py_default(ptype)}")
+        parts.append(f"{_pn(p)}: {_py_type(ptype)} = {_py_default(ptype)}")
     return parts
 
 

--- a/skills/noui/noui_core/compile/server_generator.py
+++ b/skills/noui/noui_core/compile/server_generator.py
@@ -28,6 +28,8 @@ from noui_core.compile.api_doc_generator import generate_api_markdown
 from noui_core.compile.auth_plan import generate_auth_plan
 from noui_core.compile.har_to_tools import har_to_tool_defs
 
+from .operation_generator import _assign_py_names, _pn
+
 _VALID_EXECUTION_MODES = ("tabby", "http")
 
 # ---------------------------------------------------------------------------
@@ -322,8 +324,9 @@ def _render_server(*, app_name: str, tool_defs: list[dict]) -> str:
     for td in tool_defs:
         n = td["name"]
         params = td.get("params", [])
+        _assign_py_names(params)
         sig_parts = _py_signature(params)
-        call_parts = ", ".join(f"{p['name']}={p['name']}" for p in params)
+        call_parts = ", ".join(f"{_pn(p)}={_pn(p)}" for p in params)
         desc = td.get("description", "").replace('"""', "'''")
 
         lines.append("")
@@ -367,6 +370,7 @@ def _render_operation(td: dict, *, auth_plan: dict, execution_mode: str = "tabby
         Recorded non-auth headers (Accept, Content-Type, etc.) are merged with
         live auth headers so they are not dropped.
     """
+    _assign_py_names(td.get("params") or [])
     if execution_mode == "tabby":
         return _render_operation_tabby(td, auth_plan=auth_plan)
     return _render_operation_http(td, auth_plan=auth_plan)
@@ -451,7 +455,7 @@ def _render_operation_tabby(td: dict, *, auth_plan: dict) -> str:
     lines.append(f"    url = {url_expr}")
 
     if query_params:
-        q_dict = ", ".join(f"{p['name']!r}: {p['name']}" for p in query_params)
+        q_dict = ", ".join(f"{p['name']!r}: {_pn(p)}" for p in query_params)
         lines.append(f"    _query = {{{q_dict}}}")
         lines.append("    url = url + ('?' + urllib.parse.urlencode(_query) if _query else '')")
 
@@ -562,7 +566,7 @@ def _render_operation_http(td: dict, *, auth_plan: dict) -> str:
         lines.append(_render_body_assignment(body_params, var))
 
     if query_params:
-        q_dict = ", ".join(f"{repr(p['name'])}: {p['name']}" for p in query_params)
+        q_dict = ", ".join(f"{repr(p['name'])}: {_pn(p)}" for p in query_params)
         lines.append(f"    params = {{{q_dict}}}")
 
     # Header construction
@@ -618,7 +622,7 @@ def _render_body_assignment(body_params: list[dict], var: str = "body") -> str:
     """
     whole = next((p for p in body_params if p.get("whole_body")), None)
     if whole:
-        n = whole["name"]
+        n = _pn(whole)
         return f"    {var} = json.loads({n}) if isinstance({n}, str) else {n}"
     entries = ", ".join(_body_dict_entry(p) for p in body_params)
     return f"    {var} = {{{entries}}}"
@@ -633,10 +637,10 @@ def _body_dict_entry(p: dict) -> str:
     client integrations — json.loads() it defensively so a GraphQL-style
     `variables` field can't get double-encoded on the wire.
     """
-    name = p["name"]
+    wire, sym = p["name"], _pn(p)
     if p.get("type", "").lower() in ("object", "array"):
-        return f"{name!r}: json.loads({name}) if isinstance({name}, str) else {name}"
-    return f"{name!r}: {name}"
+        return f"{wire!r}: json.loads({sym}) if isinstance({sym}, str) else {sym}"
+    return f"{wire!r}: {sym}"
 
 
 def _py_signature(params: list[dict]) -> list[str]:
@@ -646,11 +650,11 @@ def _py_signature(params: list[dict]) -> list[str]:
     optional = [p for p in params if not p.get("required", True)]
     for p in required:
         ptype = _py_type(p.get("type", "string"))
-        parts.append(f"{p['name']}: {ptype}")
+        parts.append(f"{_pn(p)}: {ptype}")
     for p in optional:
         ptype = _py_type(p.get("type", "string"))
         default = _py_default(p.get("type", "string"))
-        parts.append(f"{p['name']}: {ptype} = {default}")
+        parts.append(f"{_pn(p)}: {ptype} = {default}")
     return parts
 
 

--- a/tests/test_operation_generator.py
+++ b/tests/test_operation_generator.py
@@ -187,3 +187,33 @@ class TestWireNameIsNotAPythonIdentifier:
         src = render_skill_operation(td, auth_plan={})
         assert "query: str" in src
         assert "p_query" not in src
+
+
+class TestWholeBodyUsesTheSanitisedSymbol:
+    """The whole-body branch must reference `_pn()`, not the wire name.
+
+    Today a whole_body param is always literally named "body", so the two
+    agree and the bug is invisible. But `_assign_py_names` suffixes collisions:
+    if another param's wire name also sanitises to "body", the whole_body one
+    becomes "body_2" while the wire name stays "body". Referencing the wire name
+    would then bind json.loads() to the OTHER param's value. Raised in review.
+    """
+
+    def test_collision_moves_the_whole_body_symbol_and_the_render_follows(self) -> None:
+        td = _whole_body_tool_def(
+            params=[
+                # listed first, so this one takes the plain "body" symbol
+                {"name": "body", "type": "string", "required": False, "source": "query"},
+                {
+                    "name": "body",
+                    "type": "array",
+                    "required": True,
+                    "source": "body",
+                    "whole_body": True,
+                },
+            ]
+        )
+        src = render_skill_operation(td, auth_plan={})
+        compile(src, "<generated>", "exec")
+        # The whole-body param was suffixed, so the assignment must use it.
+        assert "body = json.loads(body_2)" in src

--- a/tests/test_operation_generator.py
+++ b/tests/test_operation_generator.py
@@ -107,3 +107,83 @@ class TestWholeBodyArrayCodegen:
         # The ordinary path must be untouched by the whole_body branch.
         src = render_skill_operation(_tool_def(), auth_plan={})
         assert "body = {" in src
+
+
+def _wire_name_tool_def(**overrides) -> dict:
+    """A form-encoded body whose field names are not Python identifiers."""
+    base = {
+        "name": "create_export",
+        "method": "POST",
+        "path": "/companies/AnalysisSummary/Export",
+        "base_url": "https://tpcatalyst-r1.bvdinfo.com",
+        "description": "Post Export",
+        "request_content_type": "application/x-www-form-urlencoded",
+        "request_headers": [],
+        "params": [
+            {"name": "component.FileName", "type": "string", "required": True, "source": "body"},
+            {
+                "name": "component.AttachmentTypes%5BReviewSummaryProofs%5D.Selected",
+                "type": "string",
+                "required": True,
+                "source": "body",
+            },
+            {"name": "2ndTry", "type": "string", "required": False, "source": "query"},
+            {"name": "class", "type": "string", "required": False, "source": "query"},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestWireNameIsNotAPythonIdentifier:
+    """Wire parameter names are not necessarily Python identifiers.
+
+    TP Catalyst's AnalysisSummary/Export posts form fields carrying dots and
+    percent-encoded brackets. The codegen used the wire name for BOTH the dict
+    key and the Python symbol, so the emitted module did not parse at all —
+    the operation could never run. Found 2026-08-18.
+    """
+
+    def test_generated_source_parses(self) -> None:
+        # The regression itself: the file used to be a SyntaxError.
+        src = render_skill_operation(_wire_name_tool_def(), auth_plan={})
+        compile(src, "<generated>", "exec")
+
+    def test_wire_name_is_kept_as_the_dict_key(self) -> None:
+        # Sanitising the key too would send the server a field it does not know.
+        src = render_skill_operation(_wire_name_tool_def(), auth_plan={})
+        assert "'component.AttachmentTypes%5BReviewSummaryProofs%5D.Selected':" in src
+
+    def test_python_symbol_is_sanitised(self) -> None:
+        src = render_skill_operation(_wire_name_tool_def(), auth_plan={})
+        assert "component_FileName" in src
+        assert "component.FileName:" not in src  # never as a parameter
+
+    def test_leading_digit_and_keyword_are_handled(self) -> None:
+        src = render_skill_operation(_wire_name_tool_def(), auth_plan={})
+        compile(src, "<generated>", "exec")
+        assert "p_2ndTry" in src  # identifiers may not start with a digit
+        assert "class_" in src  # nor be a reserved word
+
+    def test_colliding_wire_names_do_not_produce_duplicate_parameters(self) -> None:
+        # "a.b" and "a-b" both sanitise to "a_b"; without a suffix that is a
+        # duplicate-argument SyntaxError, which is worse than the original bug.
+        td = _wire_name_tool_def(
+            params=[
+                {"name": "a.b", "type": "string", "required": True, "source": "body"},
+                {"name": "a-b", "type": "string", "required": True, "source": "body"},
+            ]
+        )
+        src = render_skill_operation(td, auth_plan={})
+        compile(src, "<generated>", "exec")
+        assert "a_b_2" in src
+
+    def test_ordinary_names_are_untouched(self) -> None:
+        td = _wire_name_tool_def(
+            params=[
+                {"name": "query", "type": "string", "required": True, "source": "body"},
+            ]
+        )
+        src = render_skill_operation(td, auth_plan={})
+        assert "query: str" in src
+        assert "p_query" not in src

--- a/tests/test_server_generator_identifiers.py
+++ b/tests/test_server_generator_identifiers.py
@@ -1,0 +1,74 @@
+"""The MCP compiler must sanitise wire names into Python identifiers too.
+
+`server_generator.py` kept its own copy of `_body_dict_entry` / `_py_signature`,
+"duplicated from operation_generator.py ... small enough to keep in sync by
+hand". Both copies used the wire name as the dict key AND the Python symbol, so
+the MCP path emitted modules that did not parse — including `server.py` itself.
+
+Compiling the TP Catalyst bundle with `--as mcp` produced 3 SyntaxErrors before
+this fix and 0 after. Raised in review on #145 by @rahulbh1510.
+"""
+
+from __future__ import annotations
+
+from noui_core.compile.server_generator import (
+    _assign_py_names,
+    _body_dict_entry,
+    _py_signature,
+    _render_operation,
+)
+
+HOSTILE = "component.AttachmentTypes%5BReviewSummaryProofs%5D.Selected"
+
+
+def _params() -> list[dict]:
+    p = [
+        {"name": HOSTILE, "type": "string", "required": True, "source": "body"},
+        {"name": "2ndTry", "type": "string", "required": False, "source": "query"},
+        {"name": "class", "type": "string", "required": False, "source": "query"},
+    ]
+    _assign_py_names(p)
+    return p
+
+
+def _tool_def() -> dict:
+    return {
+        "name": "create_export",
+        "method": "POST",
+        "path": "/companies/AnalysisSummary/Export",
+        "base_url": "https://tpcatalyst-r1.bvdinfo.com",
+        "description": "Post Export",
+        "request_content_type": "application/x-www-form-urlencoded",
+        "request_headers": [],
+        "params": [
+            {"name": HOSTILE, "type": "string", "required": True, "source": "body"},
+            {"name": "class", "type": "string", "required": False, "source": "query"},
+        ],
+    }
+
+
+class TestMcpWireNameSanitisation:
+    def test_generated_operation_parses(self) -> None:
+        # The regression: this module used to be a SyntaxError.
+        src = _render_operation(_tool_def(), auth_plan={})
+        compile(src, "<generated>", "exec")
+
+    def test_wire_name_stays_the_dict_key(self) -> None:
+        # Sanitising the key too would send the server a field it does not know.
+        entry = _body_dict_entry(_params()[0])
+        assert entry.startswith(f"{HOSTILE!r}:")
+
+    def test_python_symbol_is_sanitised_in_the_dict_value(self) -> None:
+        entry = _body_dict_entry(_params()[0])
+        assert "component_AttachmentTypes_5BReviewSummaryProofs_5D_Selected" in entry
+
+    def test_signature_uses_the_sanitised_symbol(self) -> None:
+        sig = " ".join(_py_signature(_params()))
+        assert HOSTILE not in sig
+        assert "p_2ndTry" in sig  # may not start with a digit
+        assert "class_" in sig  # nor be a reserved word
+
+    def test_ordinary_names_are_untouched(self) -> None:
+        p = [{"name": "query", "type": "string", "required": True, "source": "body"}]
+        _assign_py_names(p)
+        assert _body_dict_entry(p[0]) == "'query': query"


### PR DESCRIPTION
> **Stacked on #144.** Both touch `operation_generator.py` and were developed together. Review that one first.

## What

A wire parameter name is not necessarily a Python identifier, but the codegen used it verbatim for **both** the dict key and the Python symbol. The emitted module was a `SyntaxError` — the operation could never run.

Found compiling TP Catalyst's `AnalysisSummary/Export`, which posts:

```
component.AttachmentTypes%5BReviewSummaryProofs%5D.Selected
```

which the generator rendered straight into a function signature:

```python
async def execute(
    component.AttachmentTypes%5BReviewSummaryProofs%5D.Selected: str,   # does not parse
```

## How

`_assign_py_names()` gives each param a valid, unique identifier in `py_name`. The **wire name stays the dict key**, so the request is byte-identical on the wire; only the Python symbol changes.

Collisions take a numeric suffix — two wire names sanitising to the same symbol would be a duplicate-argument `SyntaxError`, which is worse than the original bug. Leading digits (`2ndTry` → `p_2ndTry`) and reserved words (`class` → `class_`) are handled too.

## Verification

- 6 tests added, including the collision case and the "wire name is preserved as the key" guarantee
- **Verified by re-injecting the defect**: 4 of the 6 fire; the two that do not are guarding the unchanged paths, deliberately
- Full suite: 1096 passed. `ruff`, `ruff format`, `mypy` clean

> The one failure (`test_bound_profile_compiles_normally`) is pre-existing and environment-dependent — see the note on the stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
